### PR TITLE
Add self-reading methods to GenerateDiagram

### DIFF
--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -10,6 +10,23 @@ public class GenerateDiagram {
         Files.writeString(output, content);
     }
 
+    /**
+     * Reads the source code of this class.
+     *
+     * @return the contents of GenerateDiagram.java
+     */
+    public static String readSelf() throws IOException {
+        Path self = Path.of("src/magma/GenerateDiagram.java");
+        return Files.readString(self);
+    }
+
+    /**
+     * Determines if the source code contains its own class declaration.
+     */
+    public static boolean hasClassDeclaration() throws IOException {
+        return readSelf().contains("class GenerateDiagram");
+    }
+
     public static void main(String[] args) throws IOException {
         GenerateDiagram.writeDiagram(Path.of("diagram.puml"));
     }

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -19,4 +19,13 @@ public class GenerateDiagramTest {
         String expected = "@startuml\nBob -> Alice : hello\n@enduml\n";
         assertEquals(expected, content);
     }
+
+    @Test
+    public void testReadSelfContainsClassName() throws Exception {
+        String source = GenerateDiagram.readSelf();
+        assertTrue(source.contains("class GenerateDiagram"),
+                "Source should contain its own class declaration");
+        assertTrue(GenerateDiagram.hasClassDeclaration(),
+                "hasClassDeclaration should return true");
+    }
 }


### PR DESCRIPTION
## Summary
- add methods to read GenerateDiagram's source
- test that GenerateDiagram can read its own source and detect the class declaration

## Testing
- `javac -d . -cp junit-platform-console-standalone.jar:. src/magma/GenerateDiagram.java test/magma/GenerateDiagramTest.java`
- `java -jar junit-platform-console-standalone.jar --class-path junit-platform-console-standalone.jar:. --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_684046784a448321983b1d67056711b5