### PR TITLE
Add convenience build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,7 @@ jobs:
         run: echo "Skipping TypeScript build"
 
       - name: Build Java
-        run: |
-          mkdir -p out
-          javac --release 21 --enable-preview -d out $(find packages/compiler-java/src/main/java -name '*.java')
+        run: ./build.sh
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -75,7 +73,4 @@ jobs:
           path: out
 
       - name: Run Java tests
-        run: |
-          curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar
-          javac --release 21 --enable-preview -cp junit-platform-console-standalone.jar:out -d out $(find packages/compiler-java/src/test/java -name '*.java')
-          java --enable-preview -jar junit-platform-console-standalone.jar --class-path out --scan-class-path
+        run: ./test.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The entry point of the compiler is `magmac.Main`. After compiling you can run:
 java -cp packages/compiler-java/out magmac.Main
 ```
 
+For convenience there are helper scripts at the repository root:
+
+```bash
+./build.sh   # compile the Java sources
+./run.sh     # run magmac.Main (builds automatically if needed)
+./test.sh    # execute the JUnit test suite
+```
+
 This will scan the sources, run the compiler pipeline and write the generated outputs to the directories configured by each `TargetPlatform` (for example `diagrams` for PlantUML files and `src/web` for TypeScript files).
 
 Primitive Java types are translated to their TypeScript equivalents. Numeric primitives
@@ -50,5 +58,7 @@ extra lookup step when translating the compiler.
 
 The repository is built on every pull request using a GitHub Actions workflow.
 It compiles the Java sources with JDK&nbsp;21 and preview features enabled.
+The workflow calls `build.sh` and `test.sh` to keep the CI steps in sync with
+the local helper scripts.
 Compilation of the generated TypeScript is currently **skipped** because the
 compiler's TypeScript pipeline is still under development.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR="out"
+
+mkdir -p "$OUT_DIR"
+javac --release 21 --enable-preview -d "$OUT_DIR" $(find packages/compiler-java/src/main/java -name '*.java')
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/out"
+
+if [ ! -d "$OUT_DIR" ]; then
+  "$SCRIPT_DIR/build.sh"
+fi
+
+java --enable-preview -cp "$OUT_DIR" magmac.Main "$@"
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure main classes are built
+"$SCRIPT_DIR/build.sh"
+
+JUNIT_VERSION="1.10.1"
+JUNIT_JAR="junit-platform-console-standalone.jar"
+
+if [ ! -f "$JUNIT_JAR" ]; then
+  curl -L -o "$JUNIT_JAR" "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/${JUNIT_VERSION}/junit-platform-console-standalone-${JUNIT_VERSION}.jar"
+fi
+
+javac --release 21 --enable-preview -cp "$JUNIT_JAR:$SCRIPT_DIR/out" -d "$SCRIPT_DIR/out" $(find packages/compiler-java/src/test/java -name '*.java')
+java --enable-preview -jar "$JUNIT_JAR" --class-path "$SCRIPT_DIR/out" --scan-class-path
+


### PR DESCRIPTION
## Summary
- provide `build.sh`, `run.sh` and `test.sh` helpers
- call these scripts from the GitHub Actions workflow
- document the new scripts in README

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684049625a0c8321a9d0558b0f5a3b29