### PR TITLE
Generate diagram for class itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Run the program using the provided helper script:
 ```
 
 Executing the program creates a file named `diagram.puml` in the same directory.
-The file contains a minimal example of a PlantUML diagram.
+The file contains a PlantUML diagram describing the `GenerateDiagram` class.
 
 ## Running tests
 

--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -6,7 +6,8 @@ import java.nio.file.Path;
 
 public class GenerateDiagram {
     public static void writeDiagram(Path output) throws IOException {
-        String content = "@startuml\nBob -> Alice : hello\n@enduml\n";
+        String className = GenerateDiagram.class.getSimpleName();
+        String content = "@startuml\nclass " + className + "\n@enduml\n";
         Files.writeString(output, content);
     }
 

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -16,7 +16,8 @@ public class GenerateDiagramTest {
         GenerateDiagram.writeDiagram(output);
         assertTrue(Files.exists(output), "diagram.puml was not created");
         String content = Files.readString(output);
-        String expected = "@startuml\nBob -> Alice : hello\n@enduml\n";
+        String expected = "@startuml\nclass " +
+                GenerateDiagram.class.getSimpleName() + "\n@enduml\n";
         assertEquals(expected, content);
     }
 


### PR DESCRIPTION
## Summary
- update `GenerateDiagram.writeDiagram` so that the PlantUML output lists the `GenerateDiagram` class
- adjust the README to explain the new diagram output
- update tests for the changed diagram content

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68404ba1a4bc8321943a40a2743ee9c1