### PR TITLE
Replace Result<Void,T> with Optional

### DIFF
--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -4,18 +4,20 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import java.util.Optional;
+
 import static magma.Result.err;
 import static magma.Result.ok;
 
 public class GenerateDiagram {
-    public static Result<Void, IOException> writeDiagram(Path output) {
+    public static Optional<IOException> writeDiagram(Path output) {
         try {
             String className = GenerateDiagram.class.getSimpleName();
             String content = "@startuml\nclass " + className + "\n@enduml\n";
             Files.writeString(output, content);
-            return ok(null);
+            return Optional.empty();
         } catch (IOException e) {
-            return err(e);
+            return Optional.of(e);
         }
     }
 

--- a/src/magma/Result.java
+++ b/src/magma/Result.java
@@ -2,6 +2,9 @@ package magma;
 
 /**
  * A simple result type representing either a successful value or an error.
+ * It is meant for situations where a returned value is meaningful. If the
+ * success case carries no value (for example {@code Result<Void, X>}), prefer
+ * using {@link java.util.Optional Optional}&lt;X&gt; instead.
  *
  * @param <T> the successful value type
  * @param <X> the exception type, which must extend {@link Exception}

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import magma.Result;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,11 +21,9 @@ public class GenerateDiagramTest {
             throw new RuntimeException(e);
         }
         Path output = tempDir.resolve("diagram.puml");
-        Result<Void, IOException> result = GenerateDiagram.writeDiagram(output);
-        assertTrue(result.isOk(),
-                "writeDiagram failed: " + (result.isErr()
-                        ? ((Result.Err<Void, IOException>) result).error()
-                        : ""));
+        Optional<IOException> result = GenerateDiagram.writeDiagram(output);
+        assertTrue(result.isEmpty(),
+                "writeDiagram failed: " + result.orElse(null));
         boolean exists;
         String content;
         try {


### PR DESCRIPTION
## Summary
- prefer `Optional<T>` over `Result<Void, T>`
- update `Result` javadoc with guidance on when not to use `Result`
- adjust `GenerateDiagram` and tests to use `Optional<IOException>`

## Testing
- `bash test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68404edab0fc8321945f1e398b4c25c3