### PR TITLE
Improve build scripts to compile all sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains a simple Java program that generates a PlantUML file.
 
 ## Building
 
-Compile the sources using the provided helper script:
+Compile the sources using the provided helper script. The script automatically
+compiles all `*.java` files under the `src` directory:
 
 ```bash
 ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,5 @@ set -e
 
 # Build the project by compiling Java sources into the out/ directory
 mkdir -p out
-javac -d out src/magma/Result.java src/magma/GenerateDiagram.java
+# Compile all Java source files under the src/ directory
+javac -d out $(find src -name '*.java')

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@ set -e
 
 # Compile sources
 mkdir -p out
-javac -d out src/magma/Result.java src/magma/GenerateDiagram.java
+# Compile all source files under src/
+javac -d out $(find src -name '*.java')
 
 # Run the program
 java -cp out magma.GenerateDiagram

--- a/test.sh
+++ b/test.sh
@@ -7,5 +7,6 @@ if [ ! -f "$JUNIT_JAR" ]; then
 fi
 
 mkdir -p out
-javac -d out -cp "$JUNIT_JAR" src/magma/Result.java src/magma/GenerateDiagram.java test/magma/GenerateDiagramTest.java
+# Compile all Java files from src/ and test/ directories
+javac -d out -cp "$JUNIT_JAR" $(find src test -name '*.java')
 java -jar "$JUNIT_JAR" --class-path out:"$JUNIT_JAR" --scan-class-path


### PR DESCRIPTION
## Summary
- ensure `build.sh`, `run.sh`, and `test.sh` compile every Java file in the repo
- clarify in README that build script compiles all sources

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68404fea057c8321a7e66ea903850e48