### PR TITLE
Generate diagram for all classes

### DIFF
--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -4,7 +4,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static magma.Result.err;
 import static magma.Result.ok;
@@ -12,13 +21,38 @@ import static magma.Result.ok;
 public class GenerateDiagram {
     public static Optional<IOException> writeDiagram(Path output) {
         try {
-            String className = GenerateDiagram.class.getSimpleName();
-            String content = "@startuml\nclass " + className + "\n@enduml\n";
-            Files.writeString(output, content);
+        List<String> classes = findClasses(Path.of("src/magma"));
+            StringBuilder content = new StringBuilder("@startuml\n");
+            for (String name : classes) {
+                content.append("class ").append(name).append("\n");
+            }
+            content.append("@enduml\n");
+            Files.writeString(output, content.toString());
             return Optional.empty();
         } catch (IOException e) {
             return Optional.of(e);
         }
+    }
+
+    private static List<String> findClasses(Path directory) throws IOException {
+        Pattern pattern = Pattern.compile("^\\s*(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(?:class|interface)\\s+(\\w+)", Pattern.MULTILINE);
+        List<Path> files;
+        try (Stream<Path> stream = Files.walk(directory)) {
+            files = stream.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .collect(Collectors.toList());
+        }
+        Set<String> unique = new LinkedHashSet<>();
+        for (Path file : files) {
+            String src = Files.readString(file);
+            Matcher matcher = pattern.matcher(src);
+            while (matcher.find()) {
+                unique.add(matcher.group(1));
+            }
+        }
+        List<String> names = new ArrayList<>(unique);
+        Collections.sort(names);
+        return names;
     }
 
     /**

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Path;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GenerateDiagramTest {
@@ -33,9 +32,13 @@ public class GenerateDiagramTest {
             throw new RuntimeException(e);
         }
         assertTrue(exists, "diagram.puml was not created");
-        String expected = "@startuml\nclass " +
-                GenerateDiagram.class.getSimpleName() + "\n@enduml\n";
-        assertEquals(expected, content);
+        assertTrue(content.startsWith("@startuml\n"), "diagram should start correctly");
+        assertTrue(content.endsWith("@enduml\n"), "diagram should end correctly");
+        String[] expectedClasses = {"GenerateDiagram", "Result", "Ok", "Err"};
+        for (String cls : expectedClasses) {
+            assertTrue(content.contains("class " + cls + "\n"),
+                    "Diagram missing class " + cls);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update `GenerateDiagram` to scan all source files for class and interface declarations
- include all discovered classes in the generated PlantUML diagram
- make test verify that `Result`, `Ok`, `Err`, and `GenerateDiagram` are all present

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840502c96e883218b4de20bb5d55c04