### PR TITLE
Refactor Result usage with monadic transforms

### DIFF
--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -22,28 +22,26 @@ public class GenerateDiagram {
      * {@code Optional}.
      */
     public static Result<Void, IOException> writeDiagram(Path output) {
-        Result<List<String>, IOException> result = findClasses(Path.of("src/magma"));
-        if (result.isErr()) {
-            return err(((Err<List<String>, IOException>) result).error());
-        }
-        List<String> classes = ((Ok<List<String>, IOException>) result).value();
-        StringBuilder content = new StringBuilder("@startuml\n");
-        for (String name : classes) {
-            content.append("class ").append(name).append("\n");
-        }
-        try {
-            Path src = Path.of("src/magma");
-            List<String[]> relations = findRelations(src);
-            for (String[] rel : relations) {
-                content.append(rel[0]).append(" --|> ")
-                        .append(rel[1]).append("\n");
-            }
-            content.append("@enduml\n");
-            Files.writeString(output, content.toString());
-            return ok(null);
-        } catch (IOException e) {
-            return err(e);
-        }
+        return findClasses(Path.of("src/magma"))
+                .flatMapValue(classes -> {
+                    StringBuilder content = new StringBuilder("@startuml\n");
+                    for (String name : classes) {
+                        content.append("class ").append(name).append("\n");
+                    }
+                    try {
+                        Path src = Path.of("src/magma");
+                        List<String[]> relations = findRelations(src);
+                        for (String[] rel : relations) {
+                            content.append(rel[0]).append(" --|> ")
+                                    .append(rel[1]).append("\n");
+                        }
+                        content.append("@enduml\n");
+                        Files.writeString(output, content.toString());
+                        return ok(null);
+                    } catch (IOException e) {
+                        return err(e);
+                    }
+                });
     }
 
     private static Result<List<String>, IOException> findClasses(Path directory) {
@@ -136,13 +134,8 @@ public class GenerateDiagram {
      * Determines if the source code contains its own class declaration.
      */
     public static Result<Boolean, IOException> hasClassDeclaration() {
-        Result<String, IOException> source = readSelf();
-        if (source.isErr()) {
-            return err(((Err<String, IOException>) source).error());
-        }
         String declaration = "class " + GenerateDiagram.class.getSimpleName();
-        String src = ((Ok<String, IOException>) source).value();
-        return ok(src.contains(declaration));
+        return readSelf().mapValue(src -> src.contains(declaration));
     }
 
     public static void main(String[] args) {

--- a/src/magma/Result.java
+++ b/src/magma/Result.java
@@ -34,6 +34,29 @@ public sealed interface Result<T, X extends Exception>
     }
 
     /**
+     * Transforms the successful value using {@code mapper}. If this result is
+     * an error, the same error is returned unchanged.
+     */
+    default <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+        if (this instanceof Ok<T, X> ok) {
+            return Result.ok(mapper.apply(ok.value()));
+        }
+        return Result.err(((Err<T, X>) this).error());
+    }
+
+    /**
+     * Transforms the successful value using a function that itself returns a
+     * {@code Result}. This allows for chaining operations without explicit
+     * casts.
+     */
+    default <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+        if (this instanceof Ok<T, X> ok) {
+            return mapper.apply(ok.value());
+        }
+        return Result.err(((Err<T, X>) this).error());
+    }
+
+    /**
      * Gets the successful value or throws the stored exception if this result
      * represents an error. Most code should avoid calling this method and
      * handle both cases explicitly.

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -21,7 +21,13 @@ public class GenerateDiagramTest {
         }
         Path output = tempDir.resolve("diagram.puml");
         Result<Void, IOException> result = GenerateDiagram.writeDiagram(output);
-        String message = result.isErr() ? ((Err<Void, IOException>) result).error().getMessage() : "";
+        String message;
+        try {
+            result.unwrap();
+            message = "";
+        } catch (IOException e) {
+            message = e.getMessage();
+        }
         assertTrue(result.isOk(), "writeDiagram failed: " + message);
         boolean exists;
         String content;


### PR DESCRIPTION
## Summary
- add `mapValue` and `flatMapValue` helpers in `Result`
- refactor `GenerateDiagram` to use the new methods
- adjust unit test to avoid casts

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684054c655f883219b340d93ef96a850