### PR TITLE
Refactor Result to avoid factory dependency

### DIFF
--- a/src/magma/Err.java
+++ b/src/magma/Err.java
@@ -11,4 +11,29 @@ public final class Err<T, X extends Exception> implements Result<T, X> {
     public X error() {
         return error;
     }
+
+    @Override
+    public boolean isOk() {
+        return false;
+    }
+
+    @Override
+    public boolean isErr() {
+        return true;
+    }
+
+    @Override
+    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+        return new Err<>(error);
+    }
+
+    @Override
+    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+        return new Err<>(error);
+    }
+
+    @Override
+    public T unwrap() throws X {
+        throw error;
+    }
 }

--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -14,9 +14,6 @@ import java.util.stream.Stream;
 
 import magma.Relation;
 
-import static magma.Result.err;
-import static magma.Result.ok;
-
 public class GenerateDiagram {
     // Helper methods split to comply with SRP (Single Responsibility Principle)
     /**
@@ -28,7 +25,7 @@ public class GenerateDiagram {
         Path src = Path.of("src/magma");
         Result<List<String>, IOException> sources = readSources(src);
         if (sources.isErr()) {
-            return err(((Err<List<String>, IOException>) sources).error());
+            return new Err<>(((Err<List<String>, IOException>) sources).error());
         }
         List<String> allSources = ((Ok<List<String>, IOException>) sources).value();
         List<String> classes = findClasses(allSources);
@@ -39,9 +36,9 @@ public class GenerateDiagram {
         content.append("@enduml\n");
         try {
             Files.writeString(output, content.toString());
-            return ok(null);
+            return new Ok<>(null);
         } catch (IOException e) {
-            return err(e);
+            return new Err<>(e);
         }
     }
 
@@ -146,7 +143,7 @@ public class GenerateDiagram {
                     .filter(p -> p.toString().endsWith(".java"))
                     .toList();
         } catch (IOException e) {
-            return err(e);
+            return new Err<>(e);
         }
 
         List<String> sources = new ArrayList<>();
@@ -154,10 +151,10 @@ public class GenerateDiagram {
             try {
                 sources.add(Files.readString(file));
             } catch (IOException e) {
-                return err(e);
+                return new Err<>(e);
             }
         }
-        return ok(sources);
+        return new Ok<>(sources);
     }
 
     public static void main(String[] args) {

--- a/src/magma/Ok.java
+++ b/src/magma/Ok.java
@@ -11,4 +11,29 @@ public final class Ok<T, X extends Exception> implements Result<T, X> {
     public T value() {
         return value;
     }
+
+    @Override
+    public boolean isOk() {
+        return true;
+    }
+
+    @Override
+    public boolean isErr() {
+        return false;
+    }
+
+    @Override
+    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+        return new Ok<>(mapper.apply(value));
+    }
+
+    @Override
+    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+        return mapper.apply(value);
+    }
+
+    @Override
+    public T unwrap() {
+        return value;
+    }
 }

--- a/src/magma/Result.java
+++ b/src/magma/Result.java
@@ -13,59 +13,31 @@ public sealed interface Result<T, X extends Exception>
         permits Ok, Err {
 
 
-    /** Factory method for creating a successful result. */
-    static <T, X extends Exception> Result<T, X> ok(T value) {
-        return new Ok<>(value);
-    }
-
-    /** Factory method for creating an error result. */
-    static <T, X extends Exception> Result<T, X> err(X error) {
-        return new Err<>(error);
-    }
 
     /** Convenience method to check if this result is successful. */
-    default boolean isOk() {
-        return this instanceof Ok;
-    }
+    boolean isOk();
 
     /** Convenience method to check if this result is an error. */
-    default boolean isErr() {
-        return this instanceof Err;
-    }
+    boolean isErr();
 
     /**
      * Transforms the successful value using {@code mapper}. If this result is
      * an error, the same error is returned unchanged.
      */
-    default <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
-        if (this instanceof Ok<T, X> ok) {
-            return Result.ok(mapper.apply(ok.value()));
-        }
-        return Result.err(((Err<T, X>) this).error());
-    }
+    <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper);
 
     /**
      * Transforms the successful value using a function that itself returns a
      * {@code Result}. This allows for chaining operations without explicit
      * casts.
      */
-    default <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
-        if (this instanceof Ok<T, X> ok) {
-            return mapper.apply(ok.value());
-        }
-        return Result.err(((Err<T, X>) this).error());
-    }
+    <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper);
 
     /**
      * Gets the successful value or throws the stored exception if this result
      * represents an error. Most code should avoid calling this method and
      * handle both cases explicitly.
      */
-    default T unwrap() throws X {
-        if (this instanceof Ok<T, X> ok) {
-            return ok.value();
-        }
-        throw ((Err<T, X>) this).error();
-    }
+    T unwrap() throws X;
 }
 


### PR DESCRIPTION
## Summary
- remove `Result.ok` and `Result.err`
- inline factory usages inside `Ok`, `Err` and `GenerateDiagram`

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68405d7c619483219ad334ca2e3963d7