### PR TITLE
Enforce style rules and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Following these principles helps keep the codebase easy to understand and
 maintain. We also keep methods focused on a single task in line with the
 Single Responsibility Principle (SRP).
 
+### Additional style rules
+
+The code also follows several structural guidelines:
+
+1. Functions contain at most **one** loop.
+2. Nesting is limited to two levels of braces.
+3. Guard clauses are preferred to reduce indentation.
+4. Production code never uses `null`; optional values are expressed with `Optional<T>`.
+5. Exceptions are represented with `Result<T, X>` instead of `throws` clauses.
+
 ## Continuous Integration
 
 The GitHub Actions workflow builds the project using `build.sh`. Earlier

--- a/src/magma/Err.java
+++ b/src/magma/Err.java
@@ -36,7 +36,7 @@ public final class Err<T, X extends Exception> implements Result<T, X> {
     }
 
     @Override
-    public T unwrap() throws X {
-        throw error;
+    public T unwrap() {
+        throw new RuntimeException(error);
     }
 }

--- a/src/magma/GenerateDiagram.java
+++ b/src/magma/GenerateDiagram.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import magma.Relation;
+import magma.Unit;
 
 public class GenerateDiagram {
     // Helper methods split to comply with SRP (Single Responsibility Principle)
@@ -21,7 +22,7 @@ public class GenerateDiagram {
      * throwing an exception, any I/O error is returned wrapped in an
      * {@code Optional}.
      */
-    public static Result<Void, IOException> writeDiagram(Path output) {
+    public static Result<Unit, IOException> writeDiagram(Path output) {
         Path src = Path.of("src/magma");
         Result<List<String>, IOException> sources = readSources(src);
         if (sources.isErr()) {
@@ -37,7 +38,7 @@ public class GenerateDiagram {
         content.append("@enduml\n");
         try {
             Files.writeString(output, content.toString());
-            return new Ok<>(null);
+            return new Ok<>(Unit.INSTANCE);
         } catch (IOException e) {
             return new Err<>(e);
         }
@@ -178,14 +179,24 @@ public class GenerateDiagram {
         return map;
     }
 
-    private static boolean omitDependency(String source,
+    private static java.util.Set<String> toInheritedSet(List<Relation> inheritance) {
+        java.util.Set<String> set = new java.util.LinkedHashSet<>();
+        for (Relation rel : inheritance) {
+            set.add(rel.from() + "->" + rel.to());
+        }
+        return set;
+    }
+
+    private static boolean omitDependency(java.util.Optional<String> source,
                                           String dependency,
                                           java.util.Map<String, java.util.List<String>> implementations) {
-        if (source == null) {
+        if (source.isEmpty()) {
             return false;
         }
-        var interfaces = implementations.get(dependency);
-        return interfaces != null && containsInterfaceReference(source, interfaces);
+        java.util.List<String> interfaces =
+                implementations.getOrDefault(dependency, java.util.Collections.emptyList());
+        return !interfaces.isEmpty() &&
+                containsInterfaceReference(source.get(), interfaces);
     }
 
     private static boolean containsInterfaceReference(String source, java.util.List<String> interfaces) {
@@ -206,10 +217,7 @@ public class GenerateDiagram {
 
         java.util.Map<String, String> sourceMap = mapSourcesByClass(sources);
 
-        Set<String> inherited = new LinkedHashSet<>();
-        for (Relation rel : inheritance) {
-            inherited.add(rel.from() + "->" + rel.to());
-        }
+        Set<String> inherited = toInheritedSet(inheritance);
 
         List<Relation> relations = new ArrayList<>();
         for (String src : sources) {
@@ -236,12 +244,17 @@ public class GenerateDiagram {
                 continue;
             }
             Pattern word = Pattern.compile("\\b" + Pattern.quote(other) + "\\b");
-            if (word.matcher(src).find() && !inherited.contains(name + "->" + other)) {
-                if (omitDependency(sourceMap.get(name), other, implementations)) {
-                    continue;
-                }
-                relations.add(new Relation(name, "-->", other));
+            if (!word.matcher(src).find()) {
+                continue;
             }
+            if (inherited.contains(name + "->" + other)) {
+                continue;
+            }
+            if (omitDependency(java.util.Optional.ofNullable(sourceMap.get(name)),
+                              other, implementations)) {
+                continue;
+            }
+            relations.add(new Relation(name, "-->", other));
         }
     }
 

--- a/src/magma/Result.java
+++ b/src/magma/Result.java
@@ -3,8 +3,8 @@ package magma;
 /**
  * A simple result type representing either a successful value or an error.
  * It is meant for situations where a returned value is meaningful. If the
- * success case carries no value (for example {@code Result<Void, X>}), prefer
- * using {@link java.util.Optional Optional}&lt;X&gt; instead.
+ * success case carries no value use {@link magma.Unit Unit} as the
+ * successful type.
  *
  * @param <T> the successful value type
  * @param <X> the exception type, which must extend {@link Exception}
@@ -34,10 +34,10 @@ public interface Result<T, X extends Exception> {
     <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper);
 
     /**
-     * Gets the successful value or throws the stored exception if this result
+     * Gets the successful value or throws a runtime exception if this result
      * represents an error. Most code should avoid calling this method and
      * handle both cases explicitly.
      */
-    T unwrap() throws X;
+    T unwrap();
 }
 

--- a/src/magma/Unit.java
+++ b/src/magma/Unit.java
@@ -1,0 +1,6 @@
+package magma;
+
+/** Marker type representing an empty value. */
+public enum Unit {
+    INSTANCE
+}

--- a/test/magma/GenerateDiagramTest.java
+++ b/test/magma/GenerateDiagramTest.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import magma.Unit;
+import magma.Err;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GenerateDiagramTest {
@@ -18,7 +21,7 @@ public class GenerateDiagramTest {
         }
     }
 
-    private Result<Void, IOException> writeDiagram(Path output) {
+    private Result<Unit, IOException> writeDiagram(Path output) {
         return GenerateDiagram.writeDiagram(output);
     }
 
@@ -32,11 +35,9 @@ public class GenerateDiagramTest {
 
     private Path createDiagram() {
         Path output = createOutput();
-        Result<Void, IOException> result = writeDiagram(output);
-        try {
-            result.unwrap();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        Result<Unit, IOException> result = writeDiagram(output);
+        if (result.isErr()) {
+            throw new RuntimeException(((Err<Unit, IOException>) result).error());
         }
         return output;
     }
@@ -48,14 +49,9 @@ public class GenerateDiagramTest {
     @Test
     public void diagramWriteSucceeds() {
         Path output = createOutput();
-        Result<Void, IOException> result = writeDiagram(output);
-        String message;
-        try {
-            result.unwrap();
-            message = "";
-        } catch (IOException e) {
-            message = e.getMessage();
-        }
+        Result<Unit, IOException> result = writeDiagram(output);
+        String message = result.isOk() ? ""
+                : ((Err<Unit, IOException>) result).error().getMessage();
         assertTrue(result.isOk(), "writeDiagram failed: " + message);
     }
 


### PR DESCRIPTION
## Summary
- introduce `Unit` to avoid using `null`
- return `Result<Unit, IOException>` from `writeDiagram`
- remove checked exceptions from `Result.unwrap`
- refactor dependency discovery to use guard clauses and Optional
- document style rules in README

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840677e57c8832187843b8c8d73e98f