### PR TITLE
Adjust GenerateDiagram dependencies

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -2,15 +2,12 @@ package magma;
 
 import magma.result.Err;
 import magma.result.Ok;
-import magma.result.Result;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 public class GenerateDiagram {
     // Helper methods split to comply with SRP (Single Responsibility Principle)
@@ -22,7 +19,7 @@ public class GenerateDiagram {
      */
     public static Optional<IOException> writeDiagram(Path output) {
         Path src = Path.of("src/java/magma");
-        Result<List<String>, IOException> sources = readSources(src);
+        var sources = Sources.read(src);
         if (sources.isErr()) {
             return Optional.of(((Err<List<String>, IOException>) sources).error());
         }
@@ -67,27 +64,6 @@ public class GenerateDiagram {
             }
         }
         return "class";
-    }
-
-    private static Result<List<String>, IOException> readSources(Path directory) {
-        List<Path> files;
-        try (Stream<Path> stream = Files.walk(directory)) {
-            files = stream.filter(Files::isRegularFile)
-                    .filter(p -> p.toString().endsWith(".java"))
-                    .toList();
-        } catch (IOException e) {
-            return new Err<>(e);
-        }
-
-        List<String> sources = new ArrayList<>();
-        for (Path file : files) {
-            try {
-                sources.add(Files.readString(file));
-            } catch (IOException e) {
-                return new Err<>(e);
-            }
-        }
-        return new Ok<>(sources);
     }
 
     public static void main(String[] args) {

--- a/src/java/magma/Sources.java
+++ b/src/java/magma/Sources.java
@@ -1,5 +1,12 @@
 package magma;
 
+import magma.result.Err;
+import magma.result.Ok;
+import magma.result.Result;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -8,12 +15,34 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Utility record wrapping a list of source files. Methods operate on the
  * provided sources instead of requiring them as parameters.
  */
 public record Sources(List<String> list) {
+
+    public static Result<List<String>, IOException> read(Path directory) {
+        List<Path> files;
+        try (Stream<Path> stream = Files.walk(directory)) {
+            files = stream.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .toList();
+        } catch (IOException e) {
+            return new Err<>(e);
+        }
+
+        List<String> sources = new ArrayList<>();
+        for (Path file : files) {
+            try {
+                sources.add(Files.readString(file));
+            } catch (IOException e) {
+                return new Err<>(e);
+            }
+        }
+        return new Ok<>(sources);
+    }
     public List<String> findClasses() {
         Pattern pattern = Pattern.compile(
                 "^\\s*(?:public\\s+|protected\\s+|private\\s+)?" +

--- a/test/java/magma/GenerateDiagramTest.java
+++ b/test/java/magma/GenerateDiagramTest.java
@@ -120,21 +120,21 @@ public class GenerateDiagramTest {
     }
 
     @Test
-    public void diagramContainsGenerateDiagramResultDependency() {
+    public void diagramOmitsGenerateDiagramResultDependency() {
         String content = diagramContent();
-        assertTrue(content.contains("GenerateDiagram --> Result\n"), "Diagram missing dependency GenerateDiagram --> Result");
+        assertTrue(!content.contains("GenerateDiagram --> Result\n"), "Diagram should omit dependency GenerateDiagram --> Result");
     }
 
     @Test
-    public void diagramOmitsGenerateDiagramOkDependency() {
+    public void diagramContainsGenerateDiagramOkDependency() {
         String content = diagramContent();
-        assertTrue(!content.contains("GenerateDiagram --> Ok\n"), "Diagram should omit dependency GenerateDiagram --> Ok");
+        assertTrue(content.contains("GenerateDiagram --> Ok\n"), "Diagram missing dependency GenerateDiagram --> Ok");
     }
 
     @Test
-    public void diagramOmitsGenerateDiagramErrDependency() {
+    public void diagramContainsGenerateDiagramErrDependency() {
         String content = diagramContent();
-        assertTrue(!content.contains("GenerateDiagram --> Err\n"), "Diagram should omit dependency GenerateDiagram --> Err");
+        assertTrue(content.contains("GenerateDiagram --> Err\n"), "Diagram missing dependency GenerateDiagram --> Err");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- move `readSources` logic to `Sources.read`
- stop referencing `Result` directly in `GenerateDiagram`
- update tests for new dependency expectations

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840782abf4c8321b5d6e78d5eba0b30