### PR TITLE
Copy Java class names to TypeScript stubs

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -88,7 +88,8 @@ public class GenerateDiagram {
             try {
                 Files.createDirectories(tsFile.getParent());
                 var imports = readImports(file);
-                String content = stubContent(relative, tsFile.getParent(), tsRoot, imports);
+                var declarations = readDeclarations(file);
+                String content = stubContent(relative, tsFile.getParent(), tsRoot, imports, declarations);
                 Files.writeString(tsFile, content);
             } catch (IOException e) {
                 return Optional.of(e);
@@ -111,7 +112,27 @@ public class GenerateDiagram {
         return imports;
     }
 
-    private static String stubContent(Path relative, Path from, Path root, java.util.List<String> imports) {
+    private static java.util.List<String> readDeclarations(Path file) throws IOException {
+        String source = Files.readString(file);
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+)",
+                java.util.regex.Pattern.MULTILINE);
+        java.util.regex.Matcher matcher = pattern.matcher(source);
+        java.util.List<String> declarations = new java.util.ArrayList<>();
+        while (matcher.find()) {
+            String kind = matcher.group(1);
+            String name = matcher.group(2);
+            if ("record".equals(kind)) {
+                kind = "class";
+            }
+            declarations.add("export " + kind + " " + name + " {}");
+        }
+        return declarations;
+    }
+
+    private static String stubContent(Path relative, Path from, Path root,
+                                      java.util.List<String> imports,
+                                      java.util.List<String> declarations) {
         StringBuilder builder = new StringBuilder();
         builder.append("// Auto-generated from ").append(relative).append(System.lineSeparator());
 
@@ -135,7 +156,14 @@ public class GenerateDiagram {
             builder.append(";").append(System.lineSeparator());
         }
 
-        builder.append("export {};").append(System.lineSeparator());
+        if (declarations.isEmpty()) {
+            builder.append("export {};").append(System.lineSeparator());
+            return builder.toString();
+        }
+
+        for (String decl : declarations) {
+            builder.append(decl).append(System.lineSeparator());
+        }
         return builder.toString();
     }
 

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -38,4 +38,27 @@ public class GenerateDiagramStubsTest {
         String bContent = Files.readString(bTs);
         assertTrue(bContent.contains("import { A } from \"./A\";"), "B.ts missing import of A");
     }
+
+    @Test
+    public void stubCopiesClasses() throws IOException {
+        Path javaRoot = Files.createTempDirectory("java");
+        Path tsRoot = Files.createTempDirectory("ts");
+
+        createTempJavaSource(javaRoot, "test/A.java", "package test;\npublic class A {}\n");
+        createTempJavaSource(javaRoot, "test/I.java", "package test;\npublic interface I {}\n");
+        createTempJavaSource(javaRoot, "test/R.java", "package test;\npublic record R(int x) {}\n");
+
+        Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
+        if (result.isPresent()) {
+            throw result.get();
+        }
+
+        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String i = Files.readString(tsRoot.resolve("test/I.ts"));
+        String r = Files.readString(tsRoot.resolve("test/R.ts"));
+
+        assertTrue(a.contains("export class A {}"), "A.ts missing class A");
+        assertTrue(i.contains("export interface I {}"), "I.ts missing interface I");
+        assertTrue(r.contains("export class R {}"), "R.ts missing record R");
+    }
 }


### PR DESCRIPTION
## Summary
- parse Java sources for class/interface/record declarations
- generate matching declarations in TypeScript stubs
- test that class names are copied correctly

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840839b193c83219981c8704fb03638