### PR TITLE
Preserve generic parameters in TypeScript stubs

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -115,7 +115,7 @@ public class GenerateDiagram {
     private static java.util.List<String> readDeclarations(Path file) throws IOException {
         String source = Files.readString(file);
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
-                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+)",
+                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+(?:<[^>]+>)?)",
                 java.util.regex.Pattern.MULTILINE);
         java.util.regex.Matcher matcher = pattern.matcher(source);
         java.util.List<String> declarations = new java.util.ArrayList<>();

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -44,9 +44,9 @@ public class GenerateDiagramStubsTest {
         Path javaRoot = Files.createTempDirectory("java");
         Path tsRoot = Files.createTempDirectory("ts");
 
-        createTempJavaSource(javaRoot, "test/A.java", "package test;\npublic class A {}\n");
-        createTempJavaSource(javaRoot, "test/I.java", "package test;\npublic interface I {}\n");
-        createTempJavaSource(javaRoot, "test/R.java", "package test;\npublic record R(int x) {}\n");
+        createTempJavaSource(javaRoot, "test/A.java", "package test;\npublic class A<T> {}\n");
+        createTempJavaSource(javaRoot, "test/I.java", "package test;\npublic interface I<T> {}\n");
+        createTempJavaSource(javaRoot, "test/R.java", "package test;\npublic record R<T>(T x) {}\n");
 
         Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
         if (result.isPresent()) {
@@ -57,8 +57,8 @@ public class GenerateDiagramStubsTest {
         String i = Files.readString(tsRoot.resolve("test/I.ts"));
         String r = Files.readString(tsRoot.resolve("test/R.ts"));
 
-        assertTrue(a.contains("export class A {}"), "A.ts missing class A");
-        assertTrue(i.contains("export interface I {}"), "I.ts missing interface I");
-        assertTrue(r.contains("export class R {}"), "R.ts missing record R");
+        assertTrue(a.contains("export class A<T> {}"), "A.ts missing class A<T>");
+        assertTrue(i.contains("export interface I<T> {}"), "I.ts missing interface I<T>");
+        assertTrue(r.contains("export class R<T> {}"), "R.ts missing record R<T>");
     }
 }


### PR DESCRIPTION
## Summary
- keep type parameters when parsing Java declarations
- ensure stub generation includes generic parameters
- update tests accordingly

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684084e98b508321a3db8026e4b25630