### PR TITLE
Refactor omitDependency and document parameter style

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The code also follows several structural guidelines:
 10. When several static methods share the same parameter type, wrap that
     parameter in a record and convert the methods to instance methods of the
     new record.
+11. Avoid boolean parameters. Split the behavior into separate methods so the
+    caller's intent is clear. For the same reason, do not accept `Optional` or
+    `Result` parameters—these types should represent return values instead.
 
 ## Continuous Integration
 

--- a/src/java/magma/Sources.java
+++ b/src/java/magma/Sources.java
@@ -189,14 +189,13 @@ public record Sources(List<String> list) {
         return set;
     }
 
-    private static boolean omitDependency(java.util.Optional<String> source,
-                                          String dependency,
-                                          Map<String, List<String>> implementations) {
-        if (source.isEmpty()) {
-            return false;
-        }
-        List<String> interfaces = implementations.getOrDefault(dependency, Collections.emptyList());
-        return !interfaces.isEmpty() && containsInterfaceReference(source.get(), interfaces);
+    private static List<String> interfacesFor(String dependency,
+                                              Map<String, List<String>> implementations) {
+        return implementations.getOrDefault(dependency, Collections.emptyList());
+    }
+
+    private static boolean omitDependency(String source, List<String> interfaces) {
+        return !interfaces.isEmpty() && containsInterfaceReference(source, interfaces);
     }
 
     private static boolean containsInterfaceReference(String source, List<String> interfaces) {
@@ -233,7 +232,9 @@ public record Sources(List<String> list) {
             if (inherited.contains(name + "->" + other)) {
                 continue;
             }
-            if (omitDependency(java.util.Optional.ofNullable(sourceMap.get(name)), other, implementations)) {
+            List<String> interfaces = interfacesFor(other, implementations);
+            String selfSource = sourceMap.get(name);
+            if (selfSource != null && omitDependency(selfSource, interfaces)) {
                 continue;
             }
             relations.add(new Relation(name, "-->", other));


### PR DESCRIPTION
## Summary
- split `Sources.omitDependency` so it no longer accepts `Optional`
- avoid use of `omitDependency` when the source is missing
- clarify style guide to avoid boolean, Optional and Result parameters

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840857a7f108321a115d35a3aa08735