### PR TITLE
Refactor tests for single assertions

### DIFF
--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -7,76 +7,106 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import static magma.TestUtil.writeSource;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GenerateDiagramStubsTest {
-    private Path createTempJavaSource(Path root, String relPath, String content) throws IOException {
-        Path file = root.resolve(relPath);
-        Files.createDirectories(file.getParent());
-        Files.writeString(file, content);
-        return file;
-    }
 
-    @Test
-    public void stubGenerationCreatesFiles() throws IOException {
+    private Path generateStubs() throws IOException {
         Path javaRoot = Files.createTempDirectory("java");
         Path tsRoot = Files.createTempDirectory("ts");
 
-        createTempJavaSource(javaRoot, "test/A.java", "package test;\npublic class A {}\n");
-        createTempJavaSource(javaRoot, "test/B.java", "package test;\nimport test.A;\npublic class B {}\n");
+        writeSource(javaRoot, "test/A.java", "package test;\npublic class A {}\n");
+        writeSource(javaRoot, "test/B.java", "package test;\nimport test.A;\npublic class B {}\n");
 
         Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
         if (result.isPresent()) {
             throw result.get();
         }
-
-        Path aTs = tsRoot.resolve("test/A.ts");
-        Path bTs = tsRoot.resolve("test/B.ts");
-        assertTrue(Files.exists(aTs), "A.ts not created");
-        assertTrue(Files.exists(bTs), "B.ts not created");
-
-        String bContent = Files.readString(bTs);
-        assertTrue(bContent.contains("import { A } from \"./A\";"), "B.ts missing import of A");
+        return tsRoot;
     }
 
     @Test
-    public void stubCopiesClasses() throws IOException {
+    public void createsAStub() throws IOException {
+        Path tsRoot = generateStubs();
+        assertTrue(Files.exists(tsRoot.resolve("test/A.ts")));
+    }
+
+    @Test
+    public void createsBStub() throws IOException {
+        Path tsRoot = generateStubs();
+        assertTrue(Files.exists(tsRoot.resolve("test/B.ts")));
+    }
+
+    @Test
+    public void addsImportForDependency() throws IOException {
+        Path tsRoot = generateStubs();
+        String content = Files.readString(tsRoot.resolve("test/B.ts"));
+        assertTrue(content.contains("import { A } from \"./A\";"));
+    }
+
+    private Path generateGenericStubs() throws IOException {
         Path javaRoot = Files.createTempDirectory("java");
         Path tsRoot = Files.createTempDirectory("ts");
 
-        createTempJavaSource(javaRoot, "test/A.java", "package test;\npublic class A<T> {}\n");
-        createTempJavaSource(javaRoot, "test/I.java", "package test;\npublic interface I<T> {}\n");
-        createTempJavaSource(javaRoot, "test/R.java", "package test;\npublic record R<T>(T x) {}\n");
+        writeSource(javaRoot, "test/A.java", "package test;\npublic class A<T> {}\n");
+        writeSource(javaRoot, "test/I.java", "package test;\npublic interface I<T> {}\n");
+        writeSource(javaRoot, "test/R.java", "package test;\npublic record R<T>(T x) {}\n");
 
         Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
         if (result.isPresent()) {
             throw result.get();
         }
+        return tsRoot;
+    }
 
+    @Test
+    public void copiesClassDeclaration() throws IOException {
+        Path tsRoot = generateGenericStubs();
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
-        String i = Files.readString(tsRoot.resolve("test/I.ts"));
-        String r = Files.readString(tsRoot.resolve("test/R.ts"));
-
-        assertTrue(a.contains("export class A<T> {}"), "A.ts missing class A<T>");
-        assertTrue(i.contains("export interface I<T> {}"), "I.ts missing interface I<T>");
-        assertTrue(r.contains("export class R<T> {}"), "R.ts missing record R<T>");
+        assertTrue(a.contains("export class A<T> {}"));
     }
 
     @Test
-    public void stubCopiesMethods() throws IOException {
+    public void copiesInterfaceDeclaration() throws IOException {
+        Path tsRoot = generateGenericStubs();
+        String i = Files.readString(tsRoot.resolve("test/I.ts"));
+        assertTrue(i.contains("export interface I<T> {}"));
+    }
+
+    @Test
+    public void copiesRecordDeclaration() throws IOException {
+        Path tsRoot = generateGenericStubs();
+        String r = Files.readString(tsRoot.resolve("test/R.ts"));
+        assertTrue(r.contains("export class R<T> {}"));
+    }
+
+    private Path generateMethodStubs() throws IOException {
         Path javaRoot = Files.createTempDirectory("java");
         Path tsRoot = Files.createTempDirectory("ts");
 
-        createTempJavaSource(javaRoot, "test/A.java",
+        writeSource(javaRoot, "test/A.java",
                 "package test;\npublic class A { public void foo(){} public static void bar(){} }\n");
 
         Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
         if (result.isPresent()) {
             throw result.get();
         }
+        return tsRoot;
+    }
 
+    @Test
+    public void copiesInstanceMethod() throws IOException {
+        Path tsRoot = generateMethodStubs();
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
-        assertTrue(a.contains("void foo() {"), "A.ts missing foo method");
-        assertTrue(a.contains("void bar() {"), "A.ts missing bar method");
+        assertTrue(a.contains("void foo() {"));
+    }
+
+    @Test
+    public void copiesStaticMethod() throws IOException {
+        Path tsRoot = generateMethodStubs();
+        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        assertTrue(a.contains("void bar() {"));
     }
 }

--- a/test/java/magma/SourcesClassParsingTest.java
+++ b/test/java/magma/SourcesClassParsingTest.java
@@ -5,16 +5,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import static magma.TestUtil.sampleSources;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SourcesClassParsingTest {
-    private static Sources sampleSources() {
-        String result = "public interface Result {}";
-        String ok = "public class Ok implements Result {}";
-        String err = "public class Err implements Result {}";
-        String gen = "public class GenerateDiagram { Ok ok; Err err; }";
-        return new Sources(List.of(result, ok, err, gen));
-    }
 
     @Test
     public void findsAllClasses() {
@@ -27,7 +22,9 @@ public class SourcesClassParsingTest {
     public void findsImplementations() {
         Sources sources = sampleSources();
         Map<String, List<String>> impl = sources.findImplementations();
-        assertEquals(List.of("Result"), impl.get("Ok"));
-        assertEquals(List.of("Result"), impl.get("Err"));
+        assertEquals(Map.of(
+                "Ok", List.of("Result"),
+                "Err", List.of("Result")
+        ), impl);
     }
 }

--- a/test/java/magma/SourcesRelationsTest.java
+++ b/test/java/magma/SourcesRelationsTest.java
@@ -7,16 +7,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static magma.TestUtil.sampleSources;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SourcesRelationsTest {
-    private static Sources sampleSources() {
-        String result = "public interface Result {}";
-        String ok = "public class Ok implements Result {}";
-        String err = "public class Err implements Result {}";
-        String gen = "public class GenerateDiagram { Ok ok; Err err; }";
-        return new Sources(List.of(result, ok, err, gen));
-    }
 
     @Test
     public void findsRelations() {

--- a/test/java/magma/TestUtil.java
+++ b/test/java/magma/TestUtil.java
@@ -1,0 +1,25 @@
+package magma;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+final class TestUtil {
+    private TestUtil() {}
+
+    static Path writeSource(Path root, String relPath, String content) throws IOException {
+        Path file = root.resolve(relPath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+        return file;
+    }
+
+    static Sources sampleSources() {
+        String result = "public interface Result {}";
+        String ok = "public class Ok implements Result {}";
+        String err = "public class Err implements Result {}";
+        String gen = "public class GenerateDiagram { Ok ok; Err err; }";
+        return new Sources(List.of(result, ok, err, gen));
+    }
+}


### PR DESCRIPTION
## Summary
- add `TestUtil` to share common helpers
- refactor `GenerateDiagramStubsTest` into one-assert tests
- remove duplicate source setup in parsing tests
- adjust `SourcesClassParsingTest` and `SourcesRelationsTest` to use the helper

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68408800891c8321be61869f7b4dab75