### PR TITLE
Fix TypeScript stub format

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -150,13 +150,14 @@ public class GenerateDiagram {
             }
             String body = source.substring(start, i - 1);
             java.util.regex.Pattern methodPat = java.util.regex.Pattern.compile(
-                    "(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?[\\w<>\\[\\]]+\\s+(\\w+)\\s*\\([^)]*\\)\\s*\\{");
+                    "(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?([\\w<>\\[\\]]+)\\s+(\\w+)\\s*\\([^)]*\\)\\s*\\{");
             java.util.regex.Matcher mMatcher = methodPat.matcher(body);
             java.util.List<String> list = new java.util.ArrayList<>();
             while (mMatcher.find()) {
-                String mName = mMatcher.group(1);
+                String returnType = mMatcher.group(1);
+                String mName = mMatcher.group(2);
                 if (!mName.equals(name)) {
-                    list.add("\tvoid " + mName + "() {");
+                    list.add("\t" + mName + "(): " + returnType + " {");
                     list.add("\t}");
                 }
             }

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -68,7 +68,7 @@ public class GenerateDiagramStubsTest {
         Path tsRoot = Files.createTempDirectory("ts");
 
         createTempJavaSource(javaRoot, "test/A.java",
-                "package test;\npublic class A { public void foo(){} public static void bar(){} }\n");
+                "package test;\npublic class A { public void foo(){} public static int bar(){return 0;} public String baz(){return \"\";} }\n");
 
         Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
         if (result.isPresent()) {
@@ -76,7 +76,8 @@ public class GenerateDiagramStubsTest {
         }
 
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
-        assertTrue(a.contains("void foo() {"), "A.ts missing foo method");
-        assertTrue(a.contains("void bar() {"), "A.ts missing bar method");
+        assertTrue(a.contains("foo(): void {"), "A.ts missing foo method");
+        assertTrue(a.contains("bar(): int {"), "A.ts missing bar method");
+        assertTrue(a.contains("baz(): String {"), "A.ts missing baz method");
     }
 }


### PR DESCRIPTION
## Summary
- include Java return type when generating TypeScript stubs
- update tests for typed method stubs

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840884e997883218a6682b7433a4002