### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,48 @@
-# Magmac Compiler
+# Magma Tools
 
-This project contains an experimental compiler written in Java. The compiler parses a Java inspired language and can produce different targets such as TypeScript sources or PlantUML class diagrams.
-
-The compiler is designed to be bootstrapped. Initially the Java implementation
-generates TypeScript so that the compiler can run in a JavaScript environment.
-Once stable, the Java front end will be replaced with a parser for the Magma
-language itself. After the compiler is self-hosting in Magma, additional back
-ends will be added starting with C output via Clang and eventually LLVM.
+This repository contains a small set of tools written in Java. The code scans
+Java source files and extracts the class hierarchy and simple dependencies. From
+that information it generates a PlantUML diagram and matching TypeScript stubs.
+The project is an early experiment for a future Magma compiler pipeline.
 
 ## Getting Started
 
-The sources are located in `packages/compiler-java/src/main/java`. A modern JDK (17 or newer) is required to build the project. A simple way to compile everything into the `packages/compiler-java/out` directory is:
+The sources are located in `src/java`. A modern JDK (21 or newer) is required to
+build the project. A simple way to compile everything into the `out` directory is:
 
 ```bash
-javac -d packages/compiler-java/out $(find packages/compiler-java/src/main/java -name '*.java')
+javac -d out $(find src/java -name '*.java')
 ```
 
-The entry point of the compiler is `magmac.Main`. After compiling you can run:
+The entry point of the program is `magma.GenerateDiagram`. After compiling you
+can run:
 
 ```bash
-java -cp packages/compiler-java/out magmac.Main
+java --enable-preview -cp out magma.GenerateDiagram
 ```
 
 For convenience there are helper scripts at the repository root:
 
 ```bash
 ./build.sh   # compile the Java sources
-./run.sh     # run magmac.Main (builds automatically if needed)
+./run.sh     # run the program (builds automatically if needed)
 ./test.sh    # execute the JUnit test suite
 ```
 
-This will scan the sources, run the compiler pipeline and write the generated outputs to the directories configured by each `TargetPlatform` (for example `diagrams` for PlantUML files and `src/web` for TypeScript files).
-
-Primitive Java types are translated to their TypeScript equivalents. Numeric primitives
-(`byte`, `short`, `int`, `long`, `float`, `double`) become `number`, `boolean` stays
-`boolean` and `char` or `String` are emitted as `string`.
+Running the program creates a `diagram.puml` file in the repository root and
+generates `.ts` stubs under `src/node`. Primitive Java types are translated to
+their TypeScript equivalents. Numeric primitives (`byte`, `short`, `int`, `long`,
+`float`, `double`) become `number`, `boolean` stays `boolean` and `char` or
+`String` are emitted as `string`.
 
 ## Repository Layout
 
-- `packages/compiler-java/src/main/java` – Java source code for the compiler implementation
-- `packages/compiler-ts` – TypeScript tooling and build configuration
-- `diagrams/` – PlantUML files produced by the compiler
-- `docs/` – Documentation and architecture diagrams
+- `src/java` – Java source code
+- `test/java` – JUnit tests
+- `docs/` – Documentation
 
-See [`docs/architecture.md`](docs/architecture.md) for an overview of how the compiler is structured.
-For details on how the PlantUML class diagram is generated see [`docs/diagram-generation.md`](docs/diagram-generation.md).
-The inspection report produced by IntelliJ is summarised in [`docs/inspection/tasks.md`](docs/inspection/tasks.md).
-For a high level roadmap and a list of missing Java→TypeScript features see [`docs/roadmap.md`](docs/roadmap.md).
-Suggestions for profiling the compiler's performance can be found in [`docs/performance-profiling.md`](docs/performance-profiling.md).
-Guidance on translating the current Java features to C is available in [`docs/java-to-c.md`](docs/java-to-c.md).
+Additional notes on regex usage, coding style and CI can be found in the `docs/`
+directory.
 
 Instance fields in the Java sources are always accessed using `this`. Java does
 not require it, but TypeScript does, and using the same convention avoids an

--- a/docs/build.md
+++ b/docs/build.md
@@ -7,5 +7,6 @@ compiles all `*.java` files under the `src` directory:
 ./build.sh
 ```
 
-Running `build.sh` also generates matching TypeScript stubs under `src/node`
-and writes a fresh `diagram.puml` by invoking `GenerateDiagram`.
+The script simply compiles the Java sources into the `out` directory. After
+building you can manually run `GenerateDiagram` to create the TypeScript stubs
+and update `diagram.puml`.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -8,5 +8,5 @@ executes the tests:
 ./test.sh
 ```
 
-The test script compiles the Java sources and invokes `GenerateDiagram` to
-update the TypeScript stubs and diagram before running JUnit.
+The test script compiles the Java sources and then runs the JUnit test suite.
+`GenerateDiagram` is not executed automatically during the tests.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,8 +6,9 @@ Run the program using the provided helper script:
 ./run.sh
 ```
 
-This script keeps the TypeScript stubs in `src/node` up to date and rewrites
-`diagram.puml` on every run.
+`./run.sh` compiles the project if necessary and then executes
+`magma.GenerateDiagram`.
 
-Executing the program creates a file named `diagram.puml` in the same directory.
-The file contains a PlantUML diagram describing the `GenerateDiagram` class.
+Executing the program creates a file named `diagram.puml` in the repository
+root. The file contains a PlantUML diagram describing the discovered classes and
+their relationships.


### PR DESCRIPTION
## Summary
- fix README info about project purpose and file locations
- correct doc references for build, testing, and usage

## Testing
- `./test.sh` *(fails: `find: 'packages/compiler-java/src/main/java': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68408cc9b848832182f483dc7ef1c6a4