### PR TITLE
Fix static method generation

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -150,14 +150,16 @@ public class GenerateDiagram {
             }
             String body = source.substring(start, i - 1);
             java.util.regex.Pattern methodPat = java.util.regex.Pattern.compile(
-                    "(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?([\\w<>\\[\\]]+)\\s+(\\w+)\\s*\\([^)]*\\)\\s*\\{");
+                    "(?:public\\s+|protected\\s+|private\\s+)?(static\\s+)?(?:final\\s+)?([\\w<>\\[\\]]+)\\s+(\\w+)\\s*\\([^)]*\\)\\s*\\{");
             java.util.regex.Matcher mMatcher = methodPat.matcher(body);
             java.util.List<String> list = new java.util.ArrayList<>();
             while (mMatcher.find()) {
-                String returnType = mMatcher.group(1);
-                String mName = mMatcher.group(2);
+                String staticKw = mMatcher.group(1);
+                String returnType = mMatcher.group(2);
+                String mName = mMatcher.group(3);
                 if (!mName.equals(name)) {
-                    list.add("\t" + mName + "(): " + returnType + " {");
+                    String prefix = staticKw == null ? "" : "static ";
+                    list.add("\t" + prefix + mName + "(): " + returnType + " {");
                     list.add("\t}");
                 }
             }

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -139,7 +139,7 @@ public class GenerateDiagramStubsTest {
         Path tsRoot = generateMethodStubs();
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
         assertTrue(a.contains("foo(): void {"), "A.ts missing foo method");
-        assertTrue(a.contains("bar(): int {"), "A.ts missing bar method");
+        assertTrue(a.contains("static bar(): int {"), "A.ts missing static bar method");
         assertTrue(a.contains("baz(): String {"), "A.ts missing baz method");
     }
 


### PR DESCRIPTION
## Summary
- preserve the `static` keyword when generating TypeScript stubs
- check for static methods in GenerateDiagramStubsTest

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684092e6940c8321922170d1cf65e685