### PR TITLE
Map Java char/String return types

### DIFF
--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -159,7 +159,7 @@ public class GenerateDiagram {
                 String mName = mMatcher.group(3);
                 if (!mName.equals(name)) {
                     String prefix = staticKw == null ? "" : "static ";
-                    list.add("\t" + prefix + mName + "(): " + returnType + " {");
+                    list.add("\t" + prefix + mName + "(): " + tsType(returnType) + " {");
                     list.add("\t}");
                 }
             }
@@ -221,6 +221,13 @@ public class GenerateDiagram {
             builder.append("}").append(System.lineSeparator());
         }
         return builder.toString();
+    }
+
+    private static String tsType(String javaType) {
+        return switch (javaType) {
+            case "char", "String" -> "string";
+            default -> javaType;
+        };
     }
 
     private static String importLine(Path from, Path root, String name) {

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -140,7 +140,7 @@ public class GenerateDiagramStubsTest {
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
         assertTrue(a.contains("foo(): void {"), "A.ts missing foo method");
         assertTrue(a.contains("static bar(): int {"), "A.ts missing static bar method");
-        assertTrue(a.contains("baz(): String {"), "A.ts missing baz method");
+        assertTrue(a.contains("baz(): string {"), "A.ts missing baz method");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- map `char` and `String` return types to TypeScript `string`
- update stub generation test

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684094939a708321af627ff5d822c6a3