### PR TITLE
Add TypeScript checking utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ It compiles the Java sources with the JDK available on the runner
 (currently 21) and preview features enabled.
 The workflow calls `build.sh` and `test.sh` to keep the CI steps in sync with
 the local helper scripts.
-Compilation of the generated TypeScript is currently **skipped** because the
-compiler's TypeScript pipeline is still under development.
+Compilation of the generated TypeScript is not part of the pipeline. You can
+manually verify the stubs by running `./check-ts.sh` after generating them.

--- a/check-ts.sh
+++ b/check-ts.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Generate TypeScript stubs if they do not exist
+if [ ! -d "$SCRIPT_DIR/src/node" ]; then
+  "$SCRIPT_DIR/run.sh" >/dev/null
+fi
+
+# Type check the generated TypeScript
+exec tsc --noEmit -p "$SCRIPT_DIR/tsconfig.json"

--- a/docs/build.md
+++ b/docs/build.md
@@ -9,4 +9,11 @@ compiles all `*.java` files under the `src` directory:
 
 The script simply compiles the Java sources into the `out` directory. After
 building you can manually run `GenerateDiagram` to create the TypeScript stubs
-and update `diagram.puml`.
+and update `diagram.puml`. If you want to check that the generated TypeScript
+files compile, execute:
+
+```bash
+./check-ts.sh
+```
+
+This utility is optional and not part of the automated CI pipeline.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/node/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `check-ts.sh` for optional TypeScript validation
- include a simple `tsconfig.json`
- document the utility in README and build docs

## Testing
- `./test.sh`
- `./check-ts.sh` *(fails – generated stubs have tsc errors)*

------
https://chatgpt.com/codex/tasks/task_e_684094df9e748321a2d99cdaca30689e