### PR TITLE
Improve generic type conversion for stubs

### DIFF
--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -166,6 +166,32 @@ public final class TypeScriptStubs {
     }
 
     private static String tsType(String javaType) {
+        javaType = javaType.trim();
+        if (javaType.endsWith("[]")) {
+            String inner = javaType.substring(0, javaType.length() - 2);
+            return tsType(inner) + "[]";
+        }
+        int lt = javaType.indexOf('<');
+        if (lt != -1 && javaType.endsWith(">")) {
+            String base = javaType.substring(0, lt);
+            String args = javaType.substring(lt + 1, javaType.length() - 1);
+            java.util.List<String> parts = new java.util.ArrayList<>();
+            int depth = 0;
+            int start = 0;
+            for (int i = 0; i < args.length(); i++) {
+                char ch = args.charAt(i);
+                if (ch == '<') depth++; else if (ch == '>') depth--; else if (ch == ',' && depth == 0) {
+                    parts.add(args.substring(start, i).trim());
+                    start = i + 1;
+                }
+            }
+            parts.add(args.substring(start).trim());
+            java.util.List<String> converted = new java.util.ArrayList<>();
+            for (String part : parts) {
+                converted.add(tsType(part));
+            }
+            return base + "<" + String.join(", ", converted) + ">";
+        }
         return switch (javaType) {
             case "byte", "short", "int", "long", "float", "double" -> "number";
             case "boolean" -> "boolean";

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -178,4 +178,21 @@ public class GenerateDiagramStubsTest {
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
         assertTrue(a.contains("foo(): Base<Test> {"));
     }
+
+    @Test
+    public void convertsPrimitiveGenericArgument() throws IOException {
+        Path javaRoot = Files.createTempDirectory("java");
+        Path tsRoot = Files.createTempDirectory("ts");
+
+        writeSource(javaRoot, "test/A.java",
+                "package test;\nimport java.util.Optional;\npublic class A { public Optional<String> foo(){return null;} }\n");
+
+        Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
+        if (result.isPresent()) {
+            throw result.get();
+        }
+
+        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        assertTrue(a.contains("foo(): Optional<string> {"));
+    }
 }


### PR DESCRIPTION
## Summary
- adjust `tsType` to recursively convert generic arguments
- add regression test for primitive generic arguments

## Testing
- `./test.sh`
- `./check-ts.sh` *(fails: Cannot find names in generated stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68409a030c0883219bd36e999caf7d52