### PR TITLE
Preserve inheritance keywords in stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The project is an early experiment for a future Magma compiler pipeline.
 - Includes a simple `Result` type for functional-style error handling
 - Handles generic type arguments when generating TypeScript
 - Preserves the `static` modifier on methods in the stubs
+- Preserves `extends` and `implements` on class declarations
 - Offers a `check-ts.sh` script to type-check the generated stubs
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,4 +9,5 @@
 - Handles generic type arguments when converting return values
 - Preserves method type parameters on generated methods
 - Preserves the `static` modifier on generated methods
+- Preserves `extends` and `implements` on class declarations
 - Includes a `check-ts.sh` utility to validate the TypeScript output

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -58,18 +58,53 @@ public final class TypeScriptStubs {
 
     private static List<String> readDeclarations(Path file) throws IOException {
         String source = Files.readString(file);
-        var pattern = java.util.regex.Pattern.compile(
-                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+(?:<[^>]+>)?)",
+        source = source.replaceAll("(?s)/\\*.*?\\*/", "");
+        source = source.replaceAll("//.*", "");
+
+        var classPat = java.util.regex.Pattern.compile(
+                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+(?:<[^>{}]+>)?)",
                 java.util.regex.Pattern.MULTILINE);
-        var matcher = pattern.matcher(source);
+
+        var matcher = classPat.matcher(source);
         List<String> declarations = new java.util.ArrayList<>();
         while (matcher.find()) {
             String kind = matcher.group(1);
             String name = matcher.group(2);
+            int start = matcher.end();
+            int brace = source.indexOf('{', start);
+            if (brace == -1) {
+                continue;
+            }
+            String rest = source.substring(start, brace);
+            rest = rest.replaceAll("\\s+", " ").trim();
+
+            String extendsPart = null;
+            String implementsPart = null;
+            int extIdx = rest.indexOf("extends ");
+            int implIdx = rest.indexOf("implements ");
+            if (extIdx != -1) {
+                if (implIdx != -1) {
+                    extendsPart = rest.substring(extIdx + 8, implIdx).trim();
+                } else {
+                    extendsPart = rest.substring(extIdx + 8).trim();
+                }
+            }
+            if (implIdx != -1) {
+                implementsPart = rest.substring(implIdx + 11).trim();
+            }
+
             if ("record".equals(kind)) {
                 kind = "class";
             }
-            declarations.add("export " + kind + " " + name + " {}");
+            StringBuilder decl = new StringBuilder("export " + kind + " " + name);
+            if (extendsPart != null && !extendsPart.isEmpty()) {
+                decl.append(" extends ").append(extendsPart);
+            }
+            if (implementsPart != null && !implementsPart.isEmpty()) {
+                decl.append(" implements ").append(implementsPart);
+            }
+            decl.append(" {}");
+            declarations.add(decl.toString());
         }
         return declarations;
     }
@@ -147,10 +182,10 @@ public final class TypeScriptStubs {
             return builder.toString();
         }
 
-        var namePattern = java.util.regex.Pattern.compile("export \\w+ (\\w+)(?:<[^>]+>)? \\{\\}");
+        var namePattern = java.util.regex.Pattern.compile("export \\w+ (\\w+)(?:<[^>]+>)?");
         for (String decl : declarations) {
             var m = namePattern.matcher(decl);
-            if (!m.matches()) {
+            if (!m.find()) {
                 builder.append(decl).append(System.lineSeparator());
                 continue;
             }

--- a/test/java/magma/GenerateDiagramStubsTest.java
+++ b/test/java/magma/GenerateDiagramStubsTest.java
@@ -226,4 +226,23 @@ public class GenerateDiagramStubsTest {
         String a = Files.readString(tsRoot.resolve("test/A.ts"));
         assertTrue(a.contains("id<R>(x: R): R {"));
     }
+
+    @Test
+    public void preservesExtendsAndImplements() throws IOException {
+        Path javaRoot = Files.createTempDirectory("java");
+        Path tsRoot = Files.createTempDirectory("ts");
+
+        writeSource(javaRoot, "test/I.java", "package test;\npublic interface I {}\n");
+        writeSource(javaRoot, "test/Base.java", "package test;\npublic class Base {}\n");
+        writeSource(javaRoot, "test/A.java",
+                "package test;\npublic class A extends Base implements I {}\n");
+
+        Optional<IOException> result = GenerateDiagram.writeTypeScriptStubs(javaRoot, tsRoot);
+        if (result.isPresent()) {
+            throw result.get();
+        }
+
+        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        assertTrue(a.contains("export class A extends Base implements I {}"));
+    }
 }


### PR DESCRIPTION
## Summary
- keep `extends` and `implements` clauses when generating TypeScript stubs
- test preserving these clauses
- document the new behaviour

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840ae48539c8321afd04a1d9fe1c675