### PR TITLE
Add auto-call for Main.main in TypeScript stubs

### DIFF
--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -183,6 +183,7 @@ public final class TypeScriptStubs {
         }
 
         var namePattern = java.util.regex.Pattern.compile("export \\w+ (\\w+)(?:<[^>]+>)?");
+        boolean isMain = relative.toString().replace('\\', '/').equals("magma/Main.java");
         for (String decl : declarations) {
             var m = namePattern.matcher(decl);
             if (!m.find()) {
@@ -200,6 +201,9 @@ public final class TypeScriptStubs {
                 builder.append(method).append(System.lineSeparator());
             }
             builder.append("}").append(System.lineSeparator());
+        }
+        if (isMain) {
+            builder.append("Main.main([]);").append(System.lineSeparator());
         }
         return builder.toString();
     }


### PR DESCRIPTION
## Summary
- modify stub generator so Main.main is called

## Testing
- `./build.sh`
- `./run.sh`
- `./test.sh`
- `./check-ts.sh` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840b161993c8321951a62fcb858cd32