### PR TITLE
Inline Option.Some and Option.None

### DIFF
--- a/src/java/magma/option/None.java
+++ b/src/java/magma/option/None.java
@@ -4,14 +4,7 @@ package magma.option;
  * Option variant representing absence of a value.
  */
 public final class None<T> implements Option<T> {
-    private static final None<?> INSTANCE = new None<>();
-
-    private None() {}
-
-    @SuppressWarnings("unchecked")
-    static <T> None<T> instance() {
-        return (None<T>) INSTANCE;
-    }
+    None() {}
 
     @Override
     public boolean isPresent() {

--- a/src/java/magma/option/Option.java
+++ b/src/java/magma/option/Option.java
@@ -42,9 +42,9 @@ public interface Option<T> {
     }
 
     /**
-     * Returns the singleton {@link None} instance.
+     * Returns an empty {@link Option}.
      */
     static <T> Option<T> none() {
-        return None.instance();
+        return new None<>();
     }
 }


### PR DESCRIPTION
## Summary
- restore `Some` and `None` as top-level classes
- instantiate `None` directly instead of using a singleton

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840b513e2f88321b05ff8be9b3906d6