### PR TITLE
Fix spurious Main dependency

### DIFF
--- a/src/java/magma/Sources.java
+++ b/src/java/magma/Sources.java
@@ -154,6 +154,7 @@ public record Sources(List<String> list) {
     private static Map<String, List<String>> implementationsForSource(String src, Pattern pattern) {
         src = src.replaceAll("<[^>]*>", "");
         src = stripComments(src);
+        src = stripStrings(src);
         Matcher matcher = pattern.matcher(src);
         Map<String, List<String>> map = new java.util.HashMap<>();
         while (matcher.find()) {
@@ -179,6 +180,10 @@ public record Sources(List<String> list) {
         src = src.replaceAll("(?s)/\\*.*?\\*/", "");
         src = src.replaceAll("//.*", "");
         return src;
+    }
+
+    private static String stripStrings(String src) {
+        return src.replaceAll("\"(?:\\\\.|[^\"\\\\])*\"", "");
     }
 
     private static Set<String> toInheritedSet(List<Relation> inheritance) {
@@ -216,6 +221,7 @@ public record Sources(List<String> list) {
                                                          Map<String, List<String>> implementations) {
         List<Relation> relations = new ArrayList<>();
         src = stripComments(src);
+        src = stripStrings(src);
         Matcher matcher = classPattern.matcher(src);
         if (!matcher.find()) {
             return relations;

--- a/test/java/magma/DependencyIgnoreStringTest.java
+++ b/test/java/magma/DependencyIgnoreStringTest.java
@@ -1,0 +1,23 @@
+package magma;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DependencyIgnoreStringTest {
+    @Test
+    public void ignoresStringLiteralReferences() {
+        String main = "public class Main {}";
+        String util = "public class Util { String s = \"Main.main([])\"; }";
+
+        Sources sources = new Sources(List.of(main, util));
+        List<String> classes = sources.findClasses();
+        Map<String, List<String>> impl = sources.findImplementations();
+        List<Relation> relations = sources.findRelations(classes, impl);
+
+        assertFalse(relations.contains(new Relation("Util", "-->", "Main")));
+    }
+}


### PR DESCRIPTION
## Summary
- ignore string literals when parsing sources
- add regression test for ignoring dependencies in strings

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840ba885fb483218eb20ece212018cf