### PR TITLE
Advocate TDD in coding guidelines

### DIFF
--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -8,6 +8,8 @@ change should ensure that:
 3. **The code expresses the programmer's intent as clearly as possible.**
 4. **Any code that doesn't support the above goals is removed.**
 5. **Each test should contain exactly one assertion.**
+6. **Use test-driven development (TDD) whenever possible.** Write a failing test
+   before implementing new behavior and commit only when the test passes.
 
 Following these principles helps keep the codebase easy to understand and
 maintain. We also keep methods focused on a single task in line with the


### PR DESCRIPTION
## Summary
- add guideline promoting TDD to `docs/coding_guidelines.md`
- remove previously added `CodingGuidelinesTest`

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840bb0b22008321985d8ad0e63a29ba