### PR TITLE
Fix interface dependency detection

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -3,6 +3,9 @@
 - Parses Java sources to find classes, interfaces and records
 - Detects inheritance and dependency relationships
 - Generates a PlantUML diagram summarizing the relations
+- Omits interface dependencies when an implementing class is referenced. For
+  example `TypeScriptStubs` depends directly on `Some` and `None` instead of the
+  `Option` interface
 - Creates TypeScript stubs that match the Java hierarchy
 - Provides helper scripts for building, running and testing
 - Uses a small `Result` type for explicit error handling

--- a/src/java/magma/Sources.java
+++ b/src/java/magma/Sources.java
@@ -189,18 +189,20 @@ public record Sources(List<String> list) {
         return set;
     }
 
-    private static List<String> interfacesFor(String dependency,
-                                              Map<String, List<String>> implementations) {
-        return implementations.getOrDefault(dependency, Collections.emptyList());
+    private static Map<String, List<String>> invertImplementations(Map<String, List<String>> implementations) {
+        Map<String, List<String>> map = new java.util.LinkedHashMap<>();
+        for (var entry : implementations.entrySet()) {
+            String child = entry.getKey();
+            for (String iface : entry.getValue()) {
+                map.computeIfAbsent(iface, k -> new java.util.ArrayList<>()).add(child);
+            }
+        }
+        return map;
     }
 
-    private static boolean omitDependency(String source, List<String> interfaces) {
-        return !interfaces.isEmpty() && containsInterfaceReference(source, interfaces);
-    }
-
-    private static boolean containsInterfaceReference(String source, List<String> interfaces) {
-        for (String iface : interfaces) {
-            Pattern word = Pattern.compile("\\b" + Pattern.quote(iface) + "\\b");
+    private static boolean containsReference(String source, List<String> names) {
+        for (String name : names) {
+            Pattern word = Pattern.compile("\\b" + Pattern.quote(name) + "\\b");
             if (word.matcher(source).find()) {
                 return true;
             }
@@ -221,6 +223,7 @@ public record Sources(List<String> list) {
             return relations;
         }
         String name = matcher.group(1);
+        Map<String, List<String>> byInterface = invertImplementations(implementations);
         for (String other : classes) {
             if (other.equals(name)) {
                 continue;
@@ -232,9 +235,8 @@ public record Sources(List<String> list) {
             if (inherited.contains(name + "->" + other)) {
                 continue;
             }
-            List<String> interfaces = interfacesFor(other, implementations);
-            String selfSource = sourceMap.get(name);
-            if (selfSource != null && omitDependency(selfSource, interfaces)) {
+            List<String> impls = byInterface.get(other);
+            if (impls != null && containsReference(src, impls)) {
                 continue;
             }
             relations.add(new Relation(name, "-->", other));

--- a/test/java/magma/OptionDependencyTest.java
+++ b/test/java/magma/OptionDependencyTest.java
@@ -1,0 +1,33 @@
+package magma;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import magma.result.Result;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OptionDependencyTest {
+
+    @Test
+    public void stubsDependOnSomeAndNoneNotOption() throws IOException {
+        Result<List<String>, IOException> res = Sources.read(Path.of("src/java"));
+        assertTrue(res.isOk(), "reading sources failed");
+        Sources sources = new Sources(res.unwrap());
+        List<String> classes = sources.findClasses();
+        Map<String, List<String>> impl = sources.findImplementations();
+        List<Relation> all = sources.findRelations(classes, impl);
+        Set<Relation> tsDeps = all.stream()
+                .filter(r -> r.from().equals("TypeScriptStubs"))
+                .collect(Collectors.toSet());
+        assertTrue(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "Some")));
+        assertTrue(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "None")));
+        assertFalse(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "Option")));
+    }
+}


### PR DESCRIPTION
## Summary
- handle interface dependencies by skipping interfaces when their implementations are referenced
- expand Features documentation
- add regression test ensuring TypeScriptStubs depends on Some and None

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840baa3a5488321bd3ab9d7d97948ec