### PR TITLE
Add TypeScript tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /diagram.puml
 /junit-platform-console-standalone.jar
 /src/node/
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project is an early experiment for a future Magma compiler pipeline.
 - Handles generic type arguments when generating TypeScript
 - Preserves the `static` modifier on methods in the stubs
 - Preserves `extends` and `implements` on class declarations
-- Offers a `check-ts.sh` script to type-check the generated stubs
+- Provides an `npm` command to type-check the generated stubs
 
 
 ## Getting Started
@@ -72,4 +72,4 @@ It compiles the Java sources with the JDK available on the runner
 The workflow calls `build.sh` and `test.sh` to keep the CI steps in sync with
 the local helper scripts.
 Compilation of the generated TypeScript is not part of the pipeline. You can
-manually verify the stubs by running `./check-ts.sh` after generating them.
+manually verify the stubs by running `npm run check-ts` after generating them.

--- a/check-ts.sh
+++ b/check-ts.sh
@@ -9,4 +9,4 @@ if [ ! -d "$SCRIPT_DIR/src/node" ]; then
 fi
 
 # Type check the generated TypeScript
-exec tsc --noEmit -p "$SCRIPT_DIR/tsconfig.json"
+exec npx tsc --noEmit -p "$SCRIPT_DIR/tsconfig.json"

--- a/docs/build.md
+++ b/docs/build.md
@@ -13,7 +13,7 @@ and update `diagram.puml`. If you want to check that the generated TypeScript
 files compile, execute:
 
 ```bash
-./check-ts.sh
+npm run check-ts
 ```
 
 This utility is optional and not part of the automated CI pipeline.

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,4 +10,4 @@
 - Preserves method type parameters on generated methods
 - Preserves the `static` modifier on generated methods
 - Preserves `extends` and `implements` on class declarations
-- Includes a `check-ts.sh` utility to validate the TypeScript output
+- Includes an `npm` command to validate the TypeScript output

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "magma",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "magma",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "magma",
+  "version": "1.0.0",
+  "description": "This repository contains a small set of tools written in Java. The code scans Java source files and extracts the class hierarchy and simple dependencies. From that information it generates a PlantUML diagram and matching TypeScript stubs. The project is an early experiment for a future Magma compiler pipeline.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "test": "test"
+  },
+  "scripts": {
+    "check-ts": "bash check-ts.sh"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `package.json` and install TypeScript as a dev dependency
- ignore `node_modules`
- provide an `npm` script that wraps the existing `check-ts.sh`
- update docs to reference the new command
- use `npx tsc` inside `check-ts.sh`

## Testing
- `./test.sh`
- `npm run check-ts` *(fails: TS errors in generated stubs)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcd001a08321a511ae8ef3d6f1b6