### PR TITLE
Remove throws keyword usage

### DIFF
--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -23,7 +23,8 @@ The code also follows several structural guidelines:
 2. Nesting is limited to two levels of braces.
 3. Guard clauses are preferred to reduce indentation.
 4. Production code never uses `null`; optional values are expressed with `Option<T>`.
-5. Exceptions are represented with `Result<T, X>` instead of `throws` clauses.
+5. Exceptions are represented with `Result<T, X>` instead of `throws` clauses
+   because TypeScript has no `throws` keyword.
 6. Methods other than `main` should not return `void`. I/O methods return
    `Option<IOException>`, and pure functions return a value useful for
    chaining.

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -33,9 +33,30 @@ public final class TypeScriptStubs {
             Path tsFile = tsRoot.resolve(relative.toString().replaceFirst("\\.java$", ".ts"));
             try {
                 Files.createDirectories(tsFile.getParent());
-                var imports = readImports(file);
-                var declarations = readDeclarations(file);
-                var methods = readMethods(file);
+            } catch (IOException e) {
+                return new Some<>(e);
+            }
+
+            var importsRes = readImports(file);
+            if (importsRes.isErr()) {
+                return new Some<>(((magma.result.Err<List<String>, IOException>) importsRes).error());
+            }
+
+            var declarationsRes = readDeclarations(file);
+            if (declarationsRes.isErr()) {
+                return new Some<>(((magma.result.Err<List<String>, IOException>) declarationsRes).error());
+            }
+
+            var methodsRes = readMethods(file);
+            if (methodsRes.isErr()) {
+                return new Some<>(((magma.result.Err<Map<String, List<String>>, IOException>) methodsRes).error());
+            }
+
+            List<String> imports = importsRes.unwrap();
+            List<String> declarations = declarationsRes.unwrap();
+            Map<String, List<String>> methods = methodsRes.unwrap();
+
+            try {
                 String content = stubContent(relative, tsFile.getParent(), tsRoot,
                         imports, declarations, methods);
                 Files.writeString(tsFile, content);
@@ -46,8 +67,13 @@ public final class TypeScriptStubs {
         return new None<>();
     }
 
-    private static List<String> readImports(Path file) throws IOException {
-        String source = Files.readString(file);
+    private static magma.result.Result<List<String>, IOException> readImports(Path file) {
+        String source;
+        try {
+            source = Files.readString(file);
+        } catch (IOException e) {
+            return new magma.result.Err<>(e);
+        }
         var pattern = java.util.regex.Pattern.compile("^import\\s+([\\w.]+);", java.util.regex.Pattern.MULTILINE);
         var matcher = pattern.matcher(source);
         List<String> imports = new java.util.ArrayList<>();
@@ -57,11 +83,16 @@ public final class TypeScriptStubs {
                 imports.add(name);
             }
         }
-        return imports;
+        return new magma.result.Ok<>(imports);
     }
 
-    private static List<String> readDeclarations(Path file) throws IOException {
-        String source = Files.readString(file);
+    private static magma.result.Result<List<String>, IOException> readDeclarations(Path file) {
+        String source;
+        try {
+            source = Files.readString(file);
+        } catch (IOException e) {
+            return new magma.result.Err<>(e);
+        }
         source = source.replaceAll("(?s)/\\*.*?\\*/", "");
         source = source.replaceAll("//.*", "");
 
@@ -110,11 +141,16 @@ public final class TypeScriptStubs {
             decl.append(" {}");
             declarations.add(decl.toString());
         }
-        return declarations;
+        return new magma.result.Ok<>(declarations);
     }
 
-    private static Map<String, List<String>> readMethods(Path file) throws IOException {
-        String source = Files.readString(file);
+    private static magma.result.Result<Map<String, List<String>>, IOException> readMethods(Path file) {
+        String source;
+        try {
+            source = Files.readString(file);
+        } catch (IOException e) {
+            return new magma.result.Err<>(e);
+        }
         source = source.replaceAll("(?s)/\\*.*?\\*/", "");
         source = source.replaceAll("//.*", "");
         Map<String, List<String>> map = new java.util.LinkedHashMap<>();
@@ -127,7 +163,7 @@ public final class TypeScriptStubs {
             List<String> list = parseMethods(body, name);
             map.put(name, list);
         }
-        return map;
+        return new magma.result.Ok<>(map);
     }
 
     private static String extractClassBody(String source, int start) {

--- a/src/java/magma/option/Option.java
+++ b/src/java/magma/option/Option.java
@@ -13,7 +13,7 @@ public interface Option<T> {
     boolean isPresent();
 
     /**
-     * Gets the contained value or throws if absent.
+     * Gets the contained value or raises an exception if absent.
      */
     T get();
 

--- a/src/java/magma/result/Result.java
+++ b/src/java/magma/result/Result.java
@@ -34,7 +34,7 @@ public interface Result<T, X extends Exception> {
     <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper);
 
     /**
-     * Gets the successful value or throws a runtime exception if this result
+     * Gets the successful value or raises a runtime exception if this result
      * represents an error. Most code should avoid calling this method and
      * handle both cases explicitly.
      */

--- a/test/java/magma/OptionDependencyTest.java
+++ b/test/java/magma/OptionDependencyTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class OptionDependencyTest {
 
     @Test
-    public void stubsDependOnSomeAndNoneNotOption() throws IOException {
+    public void stubsDependOnSomeAndNoneNotOption() {
         Result<List<String>, IOException> res = Sources.read(Path.of("src/java"));
         assertTrue(res.isOk(), "reading sources failed");
         Sources sources = new Sources(res.unwrap());

--- a/test/java/magma/TestUtil.java
+++ b/test/java/magma/TestUtil.java
@@ -8,10 +8,14 @@ import java.util.List;
 final class TestUtil {
     private TestUtil() {}
 
-    static Path writeSource(Path root, String relPath, String content) throws IOException {
+    static Path writeSource(Path root, String relPath, String content) {
         Path file = root.resolve(relPath);
-        Files.createDirectories(file.getParent());
-        Files.writeString(file, content);
+        try {
+            Files.createDirectories(file.getParent());
+            Files.writeString(file, content);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         return file;
     }
 

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -13,50 +13,72 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TypeScriptStubsTest {
 
-    private Path generateStubs() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    private Path generateStubs() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java", "package test;\npublic class A {}\n");
         writeSource(javaRoot, "test/B.java", "package test;\nimport test.A;\npublic class B {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
         return tsRoot;
     }
 
     @Test
-    public void createsAStub() throws IOException {
+    public void createsAStub() {
         Path tsRoot = generateStubs();
         assertTrue(Files.exists(tsRoot.resolve("test/A.ts")));
     }
 
     @Test
-    public void createsBStub() throws IOException {
+    public void createsBStub() {
         Path tsRoot = generateStubs();
         assertTrue(Files.exists(tsRoot.resolve("test/B.ts")));
     }
 
     @Test
-    public void addsImportForDependency() throws IOException {
+    public void addsImportForDependency() {
         Path tsRoot = generateStubs();
-        String content = Files.readString(tsRoot.resolve("test/B.ts"));
+        String content;
+        try {
+            content = Files.readString(tsRoot.resolve("test/B.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(content.contains("import { A } from \"./A\";"));
     }
 
     @Test
-    public void stubDeclaresBClass() throws IOException {
+    public void stubDeclaresBClass() {
         Path tsRoot = generateStubs();
-        String content = Files.readString(tsRoot.resolve("test/B.ts"));
+        String content;
+        try {
+            content = Files.readString(tsRoot.resolve("test/B.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(content.contains("export class B {}"));
     }
   
     @Test
-    public void stubCopiesClasses() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void stubCopiesClasses() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java", "package test;\npublic class A<T> {}\n");
         writeSource(javaRoot, "test/I.java", "package test;\npublic interface I<T> {}\n");
@@ -64,22 +86,38 @@ public class TypeScriptStubsTest {
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
-        long count = Files.list(tsRoot.resolve("test")).count();
+        long count;
+        try {
+            count = Files.list(tsRoot.resolve("test")).count();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertEquals(3, count);
     }
 
     @Test
-    public void copiesClassDeclaration() throws IOException {
+    public void copiesClassDeclaration() {
         Path tsRoot = generateGenericStubs();
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("export class A<T> {}"));
     }
 
-    private Path generateGenericStubs() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    private Path generateGenericStubs() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java", "package test;\npublic class A<T> {}\n");
         writeSource(javaRoot, "test/I.java", "package test;\npublic interface I<T> {}\n");
@@ -87,80 +125,128 @@ public class TypeScriptStubsTest {
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
         return tsRoot;
     }
 
     @Test
-    public void copiesInterfaceDeclaration() throws IOException {
+    public void copiesInterfaceDeclaration() {
         Path tsRoot = generateGenericStubs();
-        String i = Files.readString(tsRoot.resolve("test/I.ts"));
+        String i;
+        try {
+            i = Files.readString(tsRoot.resolve("test/I.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(i.contains("export interface I<T> {}"));
     }
 
     @Test
-    public void copiesRecordDeclaration() throws IOException {
+    public void copiesRecordDeclaration() {
         Path tsRoot = generateGenericStubs();
-        String r = Files.readString(tsRoot.resolve("test/R.ts"));
+        String r;
+        try {
+            r = Files.readString(tsRoot.resolve("test/R.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(r.contains("export class R<T> {}"));
     }
 
-    private Path generateMethodStubs() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    private Path generateMethodStubs() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         writeSource(javaRoot, "test/A.java",
                 "package test;\npublic class A { public void foo(){} public static int bar(){return 0;} public String baz(){return \"\";} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
         return tsRoot;
     }
 
     @Test
-    public void copiesInstanceMethod() throws IOException {
+    public void copiesInstanceMethod() {
         Path tsRoot = generateMethodStubs();
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("foo(): void {"));
     }
 
     @Test
-    public void copiesStaticMethod() throws IOException {
+    public void copiesStaticMethod() {
         Path tsRoot = generateMethodStubs();
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("static bar(): number {"), "A.ts missing static bar method");
     }
 
     @Test
-    public void copiesBazMethod() throws IOException {
+    public void copiesBazMethod() {
         Path tsRoot = generateMethodStubs();
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("baz(): string {"), "A.ts missing baz method");
     }
 
     @Test
-    public void stubCopiesMethodsOnGenericClass() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void stubCopiesMethodsOnGenericClass() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/C.java",
                 "package test;\npublic class C<T> { public void foo(){} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String c = Files.readString(tsRoot.resolve("test/C.ts"));
+        String c;
+        try {
+            c = Files.readString(tsRoot.resolve("test/C.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(c.contains("foo(): void {"), "C.ts missing foo method");
     }
 
     @Test
-    public void preservesGenericReturnType() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void preservesGenericReturnType() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/Base.java", "package test;\npublic class Base<T> {}\n");
         writeSource(javaRoot, "test/Test.java", "package test;\npublic class Test {}\n");
@@ -169,68 +255,112 @@ public class TypeScriptStubsTest {
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("foo(): Base<Test> {"));
     }
 
     @Test
-    public void convertsPrimitiveGenericArgument() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void convertsPrimitiveGenericArgument() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java",
                 "package test;\nimport java.util.Optional;\npublic class A { public Optional<String> foo(){return null;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("foo(): Optional<string> {"));
     }
 
     @Test
-    public void preservesParameterTypes() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void preservesParameterTypes() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java",
                 "package test;\npublic class A { int add(int x, int y){return 0;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("add(x: number, y: number): number {"));
     }
 
     @Test
-    public void preservesMethodTypeParameter() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void preservesMethodTypeParameter() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/A.java",
                 "package test;\npublic class A { public <R> R id(R x){return x;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("id<R>(x: R): R {"));
     }
 
     @Test
-    public void preservesExtendsAndImplements() throws IOException {
-        Path javaRoot = Files.createTempDirectory("java");
-        Path tsRoot = Files.createTempDirectory("ts");
+    public void preservesExtendsAndImplements() {
+        Path javaRoot;
+        Path tsRoot;
+        try {
+            javaRoot = Files.createTempDirectory("java");
+            tsRoot = Files.createTempDirectory("ts");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         writeSource(javaRoot, "test/I.java", "package test;\npublic interface I {}\n");
         writeSource(javaRoot, "test/Base.java", "package test;\npublic class Base {}\n");
@@ -239,10 +369,15 @@ public class TypeScriptStubsTest {
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         if (result.isPresent()) {
-            throw result.get();
+            throw new RuntimeException(result.get());
         }
 
-        String a = Files.readString(tsRoot.resolve("test/A.ts"));
+        String a;
+        try {
+            a = Files.readString(tsRoot.resolve("test/A.ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertTrue(a.contains("export class A extends Base implements I {}"));
     }
 }


### PR DESCRIPTION
## Summary
- switch Option and Result docs to use "raises" wording
- rewrite `TypeScriptStubs` helpers to return `Result` instead of throwing
- update tests to avoid `throws` clauses and handle IO errors internally
- document why `throws` is avoided

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840bd5ee8b883219d44105d5d861850