### PR TITLE
Remove PathLike.unwrap usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The project is an early experiment for a future Magma compiler pipeline.
 - Preserves `extends` and `implements` on class declarations
 - Provides an `npm` command to type-check the generated stubs
 - Abstracts `java.nio.file.Path` behind a `PathLike` interface so TypeScript
-  declarations do not reference JDK classes
+  declarations do not reference JDK classes. `PathLike` includes helpers such as
+  `writeString`, `createDirectories` and `walk` and `JVMPath` simply forwards to
+  the standard library implementation.
 
 
 ## Getting Started

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,5 +18,9 @@ their relationships.
 The Java sources use a lightweight `PathLike` interface instead of
 `java.nio.file.Path`. The wrapper (`JVMPath`) delegates to the JDK class but
 keeps it out of the public API so the generated TypeScript declarations remain
-valid. When you need a path object, call `PathLike.of(...)` rather than
-`Path.of(...)`.
+valid. `PathLike` exposes convenience methods such as `writeString`,
+`createDirectories` and `walk` so callers never interact with a raw
+`java.nio.file.Path`. When you need a path object, call `PathLike.of(...)`
+rather than `Path.of(...)`.
+`JVMPath` is intentionally small and forwards each call directly to the
+underlying JDK path.

--- a/src/java/magma/GenerateDiagram.java
+++ b/src/java/magma/GenerateDiagram.java
@@ -6,7 +6,6 @@ import magma.result.Err;
 import magma.result.Ok;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import magma.PathLike;
 import java.util.List;
 import magma.option.Option;
@@ -36,12 +35,7 @@ public class GenerateDiagram {
         content.append(classesSection(classes, sourceMap));
         content.append(analysis.formatRelations(classes, implementations));
         content.append("@enduml\n");
-        try {
-            Files.writeString(output.unwrap(), content.toString());
-            return new None<>();
-        } catch (IOException e) {
-            return new Some<>(e);
-        }
+        return output.writeString(content.toString());
     }
 
     private static String classesSection(List<String> classes,

--- a/src/java/magma/PathLike.java
+++ b/src/java/magma/PathLike.java
@@ -28,6 +28,32 @@ public interface PathLike {
         return new JVMPath(unwrap().relativize(other.unwrap()));
     }
 
+    /** Writes {@code content} to this path, returning any I/O error wrapped
+     * in {@link magma.option.Option}. */
+    default magma.option.Option<java.io.IOException> writeString(String content) {
+        try {
+            java.nio.file.Files.writeString(unwrap(), content);
+            return new magma.option.None<>();
+        } catch (java.io.IOException e) {
+            return new magma.option.Some<>(e);
+        }
+    }
+
+    /** Creates the directories represented by this path if necessary. */
+    default magma.option.Option<java.io.IOException> createDirectories() {
+        try {
+            java.nio.file.Files.createDirectories(unwrap());
+            return new magma.option.None<>();
+        } catch (java.io.IOException e) {
+            return new magma.option.Some<>(e);
+        }
+    }
+
+    /** Returns a lazily populated stream of the files under this path. */
+    default java.util.stream.Stream<java.nio.file.Path> walk() throws java.io.IOException {
+        return java.nio.file.Files.walk(unwrap());
+    }
+
     /** Creates a new wrapper from a string path. */
     static PathLike of(String first, String... more) {
         return new JVMPath(java.nio.file.Path.of(first, more));

--- a/src/java/magma/Sources.java
+++ b/src/java/magma/Sources.java
@@ -25,7 +25,7 @@ public record Sources(List<String> list) {
 
     public static Result<List<String>, IOException> read(PathLike directory) {
         List<java.nio.file.Path> files;
-        try (Stream<java.nio.file.Path> stream = Files.walk(directory.unwrap())) {
+        try (Stream<java.nio.file.Path> stream = directory.walk()) {
             files = stream.filter(Files::isRegularFile)
                     .filter(p -> p.toString().endsWith(".java"))
                     .toList();

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -25,7 +25,7 @@ public final class TypeScriptStubs {
 
     public static Option<IOException> write(PathLike javaRoot, PathLike tsRoot) {
         List<java.nio.file.Path> files;
-        try (Stream<java.nio.file.Path> stream = Files.walk(javaRoot.unwrap())) {
+        try (Stream<java.nio.file.Path> stream = javaRoot.walk()) {
             files = stream.filter(Files::isRegularFile)
                     .filter(p -> p.toString().endsWith(".java"))
                     .toList();
@@ -35,10 +35,9 @@ public final class TypeScriptStubs {
         for (java.nio.file.Path file : files) {
             PathLike relative = javaRoot.relativize(new JVMPath(file));
             PathLike tsFile = tsRoot.resolve(relative.toString().replaceFirst("\\.java$", ".ts"));
-            try {
-                Files.createDirectories(tsFile.getParent().unwrap());
-            } catch (IOException e) {
-                return new Some<>(e);
+            var dirResult = tsFile.getParent().createDirectories();
+            if (dirResult.isPresent()) {
+                return dirResult;
             }
 
             var importsRes = readImports(file);
@@ -60,12 +59,11 @@ public final class TypeScriptStubs {
             List<String> declarations = declarationsRes.unwrap();
             Map<String, List<String>> methods = methodsRes.unwrap();
 
-            try {
-                String content = stubContent(relative, tsFile.getParent(), tsRoot,
-                        imports, declarations, methods);
-                Files.writeString(tsFile.unwrap(), content);
-            } catch (IOException e) {
-                return new Some<>(e);
+            String content = stubContent(relative, tsFile.getParent(), tsRoot,
+                    imports, declarations, methods);
+            var writeRes = tsFile.writeString(content);
+            if (writeRes.isPresent()) {
+                return writeRes;
             }
         }
         return new None<>();


### PR DESCRIPTION
## Summary
- embed core file operations into `PathLike`
- update `GenerateDiagram` and `TypeScriptStubs` to use new helpers
- read sources using `PathLike.walk`
- document the simplified `JVMPath` wrapper

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840c6d31c4483218fd73a342619ad21