### PR TITLE
Remove Exception bound from Result

### DIFF
--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -56,9 +56,9 @@ public final class TypeScriptStubs {
                 return new Some<>(((magma.result.Err<Map<String, List<String>>, IOException>) methodsRes).error());
             }
 
-            List<String> imports = importsRes.unwrap();
-            List<String> declarations = declarationsRes.unwrap();
-            Map<String, List<String>> methods = methodsRes.unwrap();
+            List<String> imports = magma.result.Results.unwrap(importsRes);
+            List<String> declarations = magma.result.Results.unwrap(declarationsRes);
+            Map<String, List<String>> methods = magma.result.Results.unwrap(methodsRes);
 
             try {
                 String content = stubContent(relative, tsFile.getParent(), tsRoot,

--- a/src/java/magma/result/Err.java
+++ b/src/java/magma/result/Err.java
@@ -4,7 +4,7 @@ package magma.result;
  * Result variant representing failure.
  * See {@code Ok} for the success case.
  */
-public final class Err<T, X extends Exception> implements Result<T, X> {
+public final class Err<T, X> implements Result<T, X> {
     private final X error;
 
     public Err(X error) {
@@ -35,8 +35,4 @@ public final class Err<T, X extends Exception> implements Result<T, X> {
         return new Err<>(error);
     }
 
-    @Override
-    public T unwrap() {
-        throw new RuntimeException(error);
-    }
 }

--- a/src/java/magma/result/Ok.java
+++ b/src/java/magma/result/Ok.java
@@ -4,7 +4,7 @@ package magma.result;
  * Result variant representing success.
  * See {@code Err} for the failure case.
  */
-public final class Ok<T, X extends Exception> implements Result<T, X> {
+public final class Ok<T, X> implements Result<T, X> {
     private final T value;
 
     public Ok(T value) {
@@ -35,8 +35,4 @@ public final class Ok<T, X extends Exception> implements Result<T, X> {
         return mapper.apply(value);
     }
 
-    @Override
-    public T unwrap() {
-        return value;
-    }
 }

--- a/src/java/magma/result/Result.java
+++ b/src/java/magma/result/Result.java
@@ -7,9 +7,9 @@ package magma.result;
  * Option} or another type instead of {@code Result}.
  *
  * @param <T> the successful value type
- * @param <X> the exception type, which must extend {@link Exception}
+ * @param <X> the error type
  */
-public interface Result<T, X extends Exception> {
+public interface Result<T, X> {
     /**
      * Convenience method to check if this result is successful.
      */
@@ -33,11 +33,5 @@ public interface Result<T, X extends Exception> {
      */
     <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper);
 
-    /**
-     * Gets the successful value or raises a runtime exception if this result
-     * represents an error. Most code should avoid calling this method and
-     * handle both cases explicitly.
-     */
-    T unwrap();
 }
 

--- a/src/java/magma/result/Results.java
+++ b/src/java/magma/result/Results.java
@@ -1,0 +1,20 @@
+package magma.result;
+
+/** Utility methods for working with {@link Result}. */
+public final class Results {
+    private Results() {}
+
+    /**
+     * Unwraps the given result. If the result is {@code Ok}, the contained
+     * value is returned. If it is {@code Err}, a {@link RuntimeException}
+     * wrapping the error is thrown.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T, X extends Exception> T unwrap(Result<T, X> result) {
+        if (result.isOk()) {
+            return ((Ok<T, X>) result).value();
+        }
+        Err<T, X> err = (Err<T, X>) result;
+        throw new RuntimeException(err.error());
+    }
+}

--- a/test/java/magma/OptionDependencyTest.java
+++ b/test/java/magma/OptionDependencyTest.java
@@ -19,7 +19,7 @@ public class OptionDependencyTest {
     public void stubsDependOnSomeAndNoneNotOption() {
         Result<List<String>, IOException> res = Sources.read(PathLike.of("src/java"));
         assertTrue(res.isOk(), "reading sources failed");
-        Sources sources = new Sources(res.unwrap());
+        Sources sources = new Sources(magma.result.Results.unwrap(res));
         List<String> classes = sources.findClasses();
         Map<String, List<String>> impl = sources.findImplementations();
         List<Relation> all = sources.findRelations(classes, impl);


### PR DESCRIPTION
## Summary
- drop the `Exception` bound from `Result`
- move `unwrap` to new `Results` utility class
- adjust Ok/Err implementations
- use `Results.unwrap` in code and tests

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840faa131488321bb1f7efe2e545443