### PR TITLE
Remove unwrap usage from TestUtil

### DIFF
--- a/test/java/magma/TestUtil.java
+++ b/test/java/magma/TestUtil.java
@@ -1,7 +1,6 @@
 package magma;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import magma.PathLike;
 import java.util.List;
 
@@ -11,8 +10,14 @@ final class TestUtil {
     static PathLike writeSource(PathLike root, String relPath, String content) {
         PathLike file = root.resolve(relPath);
         try {
-            Files.createDirectories(file.getParent().unwrap());
-            Files.writeString(file.unwrap(), content);
+            var dirResult = file.getParent().createDirectories();
+            if (dirResult.isPresent()) {
+                throw dirResult.get();
+            }
+            var writeResult = file.writeString(content);
+            if (writeResult.isPresent()) {
+                throw writeResult.get();
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary
- stop calling `Files.createDirectories` and `Files.writeString` directly
- use the new `PathLike` helpers instead

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841010f1cdc8321abcf5eb339fe0660