### PR TITLE
Fix local imports for TypeScript stubs

### DIFF
--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -44,8 +44,9 @@ public record JVMPath(Path path) implements PathLike {
     private Path toPath(PathLike other) {
         final var names = other.streamNames().toList();
         if (names.isEmpty()) {
-            return Path.of("");
+            return Paths.get("");
         }
+
         final var first = Paths.get(names.getFirst());
         return names.subList(1, names.size())
                 .stream()

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -14,6 +14,9 @@ import java.nio.file.Paths;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+/**
+ * Wrapper implementation backed by {@code java.nio.file.Path}.
+ */
 public record JVMPath(Path path) implements PathLike {
     /**
      * Creates a new wrapper from a string path.

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -14,9 +14,6 @@ import java.nio.file.Paths;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-/**
- * Wrapper implementation backed by {@code java.nio.file.Path}.
- */
 public record JVMPath(Path path) implements PathLike {
     /**
      * Creates a new wrapper from a string path.

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -80,12 +80,9 @@ public record JVMPath(Path path) implements PathLike {
             Files.createDirectories(path);
             return new None<>();
         } catch (IOException e) {
-        Stream<String> rootStream = path.getRoot() == null
-                ? Stream.of()
-                : Stream.of(path.getRoot().toString());
-        Stream<String> names = IntStream.range(0, path.getNameCount())
-                .mapToObj(i -> path.getName(i).toString());
-        return Stream.concat(rootStream, names);
+            return new Some<>(e);
+        }
+    }
 
     @Override
     public Result<Stream<PathLike>, IOException> walk() {

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -80,9 +80,12 @@ public record JVMPath(Path path) implements PathLike {
             Files.createDirectories(path);
             return new None<>();
         } catch (IOException e) {
-            return new Some<>(e);
-        }
-    }
+        Stream<String> rootStream = path.getRoot() == null
+                ? Stream.of()
+                : Stream.of(path.getRoot().toString());
+        Stream<String> names = IntStream.range(0, path.getNameCount())
+                .mapToObj(i -> path.getName(i).toString());
+        return Stream.concat(rootStream, names);
 
     @Override
     public Result<Stream<PathLike>, IOException> walk() {

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -118,9 +118,13 @@ public record JVMPath(Path path) implements PathLike {
 
     @Override
     public Stream<String> streamNames() {
-        return IntStream.range(0, path.getNameCount())
+        final var root = path.getRoot();
+        final Stream<String> rootStream = root == null ? Stream.empty() : Stream.of(root.toString());
+        final var namesStream = IntStream.range(0, path.getNameCount())
                 .mapToObj(path::getName)
                 .map(Path::toString);
+
+        return Stream.concat(rootStream, namesStream);
     }
 
     @Override

--- a/src/java/magma/JVMPath.java
+++ b/src/java/magma/JVMPath.java
@@ -39,7 +39,13 @@ public record JVMPath(Path path) implements PathLike {
 
 
     private Path toPath(PathLike other) {
+        if (other instanceof JVMPath jvm) {
+            return jvm.path;
+        }
         final var names = other.streamNames().toList();
+        if (names.isEmpty()) {
+            return Path.of("");
+        }
         final var first = Paths.get(names.getFirst());
         return names.subList(1, names.size())
                 .stream()

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /**
  * Utility for generating TypeScript stub files mirroring the Java sources.
@@ -26,71 +25,66 @@ public final class TypeScriptStubs {
     }
 
     public static Option<IOException> write(PathLike javaRoot, PathLike tsRoot) {
-        List<PathLike> files;
-        var walkRes = javaRoot.walk();
-        if (walkRes.isErr()) {
-            return new Some<>(((Err<Stream<PathLike>, IOException>) walkRes).error());
-        }
-        try (Stream<PathLike> stream = ((Ok<Stream<PathLike>, IOException>) walkRes).value()) {
-            files = stream.filter(PathLike::isRegularFile)
+        return javaRoot.walk().match(stream -> {
+            List<PathLike> files = stream.filter(PathLike::isRegularFile)
                     .filter(p -> p.toString().endsWith(".java"))
                     .toList();
-        }
 
-        for (PathLike file : files) {
-            PathLike relative = javaRoot.relativize(file);
-            PathLike tsFile = tsRoot.resolve(relative.toString().replaceFirst("\\.java$", ".ts"));
-            var dirResult = tsFile.getParent().createDirectories();
-            if (dirResult.isPresent()) {
-                return dirResult;
-            }
+            for (PathLike file : files) {
+                PathLike relative = javaRoot.relativize(file);
+                PathLike tsFile = tsRoot.resolve(relative.toString().replaceFirst("\\.java$", ".ts"));
+                var dirResult = tsFile.getParent().createDirectories();
+                if (dirResult.isPresent()) {
+                    return dirResult;
+                }
 
-            var importsRes = readImports(file);
-            if (importsRes.isErr()) {
-                return new Some<>(((Err<List<String>, IOException>) importsRes).error());
-            }
+                var importsRes = readImports(file);
+                if (importsRes.isErr()) {
+                    return new Some<>(((Err<List<String>, IOException>) importsRes).error());
+                }
 
-            var pkgRes = readPackage(file);
-            if (pkgRes.isErr()) {
-                return new Some<>(((Err<String, IOException>) pkgRes).error());
-            }
+                var pkgRes = readPackage(file);
+                if (pkgRes.isErr()) {
+                    return new Some<>(((Err<String, IOException>) pkgRes).error());
+                }
 
-            var localRes = readLocalDependencies(file);
-            if (localRes.isErr()) {
-                return new Some<>(((Err<List<String>, IOException>) localRes).error());
-            }
+                var localRes = readLocalDependencies(file);
+                if (localRes.isErr()) {
+                    return new Some<>(((Err<List<String>, IOException>) localRes).error());
+                }
 
-            var declarationsRes = readDeclarations(file);
-            if (declarationsRes.isErr()) {
-                return new Some<>(((Err<List<String>, IOException>) declarationsRes).error());
-            }
+                var declarationsRes = readDeclarations(file);
+                if (declarationsRes.isErr()) {
+                    return new Some<>(((Err<List<String>, IOException>) declarationsRes).error());
+                }
 
-            var methodsRes = readMethods(file);
-            if (methodsRes.isErr()) {
-                return new Some<>(((Err<Map<String, List<String>>, IOException>) methodsRes).error());
-            }
+                var methodsRes = readMethods(file);
+                if (methodsRes.isErr()) {
+                    return new Some<>(((Err<Map<String, List<String>>, IOException>) methodsRes).error());
+                }
 
-            List<String> imports = Results.unwrap(importsRes);
-            String pkgName = Results.unwrap(pkgRes);
-            List<String> locals = Results.unwrap(localRes);
-            for (String dep : locals) {
-                String fqn = pkgName.isEmpty() ? dep : pkgName + "." + dep;
-                if (!imports.contains(fqn)) {
-                    imports.add(fqn);
+                List<String> imports = Results.unwrap(importsRes);
+                String pkgName = Results.unwrap(pkgRes);
+                List<String> locals = Results.unwrap(localRes);
+                for (String dep : locals) {
+                    String fqn = pkgName.isEmpty() ? dep : pkgName + "." + dep;
+                    if (!imports.contains(fqn)) {
+                        imports.add(fqn);
+                    }
+                }
+
+                List<String> declarations = Results.unwrap(declarationsRes);
+                Map<String, List<String>> methods = Results.unwrap(methodsRes);
+
+                String content = stubContent(relative, tsFile.getParent(), tsRoot,
+                        imports, declarations, methods);
+                var writeRes = tsFile.writeString(content);
+                if (writeRes.isPresent()) {
+                    return writeRes;
                 }
             }
-
-            List<String> declarations = Results.unwrap(declarationsRes);
-            Map<String, List<String>> methods = Results.unwrap(methodsRes);
-
-            String content = stubContent(relative, tsFile.getParent(), tsRoot,
-                    imports, declarations, methods);
-            var writeRes = tsFile.writeString(content);
-            if (writeRes.isPresent()) {
-                return writeRes;
-            }
-        }
-        return new None<>();
+            return new None<>();
+        }, Some::new);
     }
 
     private static Result<List<String>, IOException> readImports(PathLike file) {

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -48,6 +48,16 @@ public final class TypeScriptStubs {
                 return new Some<>(((Err<List<String>, IOException>) importsRes).error());
             }
 
+            var pkgRes = readPackage(file);
+            if (pkgRes.isErr()) {
+                return new Some<>(((Err<String, IOException>) pkgRes).error());
+            }
+
+            var localRes = readLocalDependencies(file);
+            if (localRes.isErr()) {
+                return new Some<>(((Err<List<String>, IOException>) localRes).error());
+            }
+
             var declarationsRes = readDeclarations(file);
             if (declarationsRes.isErr()) {
                 return new Some<>(((Err<List<String>, IOException>) declarationsRes).error());
@@ -59,6 +69,15 @@ public final class TypeScriptStubs {
             }
 
             List<String> imports = Results.unwrap(importsRes);
+            String pkgName = Results.unwrap(pkgRes);
+            List<String> locals = Results.unwrap(localRes);
+            for (String dep : locals) {
+                String fqn = pkgName.isEmpty() ? dep : pkgName + "." + dep;
+                if (!imports.contains(fqn)) {
+                    imports.add(fqn);
+                }
+            }
+
             List<String> declarations = Results.unwrap(declarationsRes);
             Map<String, List<String>> methods = Results.unwrap(methodsRes);
 
@@ -90,6 +109,88 @@ public final class TypeScriptStubs {
             }
         }
         return new Ok<>(imports);
+    }
+
+    private static Result<String, IOException> readPackage(PathLike file) {
+        String source;
+        try {
+            source = file.readString();
+        } catch (IOException e) {
+            return new Err<>(e);
+        }
+
+        var pattern = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
+        var matcher = pattern.matcher(source);
+        if (matcher.find()) {
+            return new Ok<>(matcher.group(1));
+        }
+        return new Ok<>("");
+    }
+
+    private static Result<List<String>, IOException> readLocalDependencies(PathLike file) {
+        String source;
+        try {
+            source = file.readString();
+        } catch (IOException e) {
+            return new Err<>(e);
+        }
+
+        source = source.replaceAll("(?s)/\\*.*?\\*/", "");
+        source = source.replaceAll("//.*", "");
+
+        var classPat = Pattern.compile(
+                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+)",
+                Pattern.MULTILINE);
+
+        var matcher = classPat.matcher(source);
+        List<String> deps = new ArrayList<>();
+        List<String> defined = new ArrayList<>();
+        while (matcher.find()) {
+            String name = matcher.group(2);
+            defined.add(name);
+            int start = matcher.end();
+            int brace = source.indexOf('{', start);
+            if (brace == -1) {
+                continue;
+            }
+            String rest = source.substring(start, brace);
+            rest = rest.replaceAll("\\s+", " ").trim();
+
+            String extendsPart = null;
+            String implementsPart = null;
+            int extIdx = rest.indexOf("extends ");
+            int implIdx = rest.indexOf("implements ");
+            if (extIdx != -1) {
+                if (implIdx != -1) {
+                    extendsPart = rest.substring(extIdx + 8, implIdx).trim();
+                } else {
+                    extendsPart = rest.substring(extIdx + 8).trim();
+                }
+            }
+            if (implIdx != -1) {
+                implementsPart = rest.substring(implIdx + 11).trim();
+            }
+
+            if (extendsPart != null && !extendsPart.isEmpty()) {
+                extendsPart = extendsPart.replaceAll("<.*?>", "");
+                for (String part : extendsPart.split(",")) {
+                    String base = part.trim();
+                    if (!base.isEmpty() && !defined.contains(base)) {
+                        deps.add(base);
+                    }
+                }
+            }
+            if (implementsPart != null && !implementsPart.isEmpty()) {
+                implementsPart = implementsPart.replaceAll("<.*?>", "");
+                for (String part : implementsPart.split(",")) {
+                    String base = part.trim();
+                    if (!base.isEmpty() && !defined.contains(base)) {
+                        deps.add(base);
+                    }
+                }
+            }
+        }
+        return new Ok<>(deps);
     }
 
     private static Result<List<String>, IOException> readDeclarations(PathLike file) {
@@ -163,13 +264,15 @@ public final class TypeScriptStubs {
         source = source.replaceAll("(?s)/\\*.*?\\*/", "");
         source = source.replaceAll("//.*", "");
         Map<String, List<String>> map = new LinkedHashMap<>();
-        var classPat = Pattern.compile("(?:class|interface|record)\\s+(\\w+)[^{]*\\{");
+        var classPat = Pattern.compile("(class|interface|record)\\s+(\\w+)[^{]*\\{");
         var cMatcher = classPat.matcher(source);
         while (cMatcher.find()) {
-            String name = cMatcher.group(1);
+            String kind = cMatcher.group(1);
+            String name = cMatcher.group(2);
             int start = cMatcher.end();
             String body = extractClassBody(source, start);
-            List<String> list = parseMethods(body, name);
+            boolean isInterface = "interface".equals(kind);
+            List<String> list = parseMethods(body, name, isInterface);
             map.put(name, list);
         }
         return new Ok<>(map);
@@ -191,9 +294,9 @@ public final class TypeScriptStubs {
         return source.substring(start, i - 1);
     }
 
-    private static List<String> parseMethods(String body, String className) {
+    private static List<String> parseMethods(String body, String className, boolean isInterface) {
         var methodPat = Pattern.compile(
-                "(?:public\\s+|protected\\s+|private\\s+)?(static\\s+)?(?:final\\s+)?(<[^>]+>\\s+)?([\\w.]+(?:<[^>]+>)?(?:\\[\\])*)\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*\\{");
+                "(?:public\\s+|protected\\s+|private\\s+)?(static\\s+)?(?:final\\s+)?(<[^>]+>\\s+)?([\\w.]+(?:<[^>]+>)?(?:\\[\\])*)\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*(\\{|;)");
         var mMatcher = methodPat.matcher(body);
         List<String> list = new ArrayList<>();
         while (mMatcher.find()) {
@@ -202,12 +305,17 @@ public final class TypeScriptStubs {
             String returnType = mMatcher.group(3);
             String mName = mMatcher.group(4);
             String params = mMatcher.group(5);
+            String delim = mMatcher.group(6);
             if (!mName.equals(className)) {
                 String prefix = staticKw == null ? "" : "static ";
                 String typeParams = generics == null ? "" : generics.trim();
                 String paramList = tsParams(params);
-                list.add("\t" + prefix + mName + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
-                list.add("\t}");
+                if (isInterface || ";".equals(delim)) {
+                    list.add("\t" + prefix + mName + typeParams + "(" + paramList + "): " + tsType(returnType) + ";");
+                } else {
+                    list.add("\t" + prefix + mName + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
+                    list.add("\t}");
+                }
             }
         }
         return list;

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -113,85 +113,76 @@ public final class TypeScriptStubs {
     }
 
     private static Result<String, IOException> readPackage(PathLike file) {
-        String source;
-        try {
-            source = file.readString();
-        } catch (IOException e) {
-            return new Err<>(e);
-        }
-
-        var pattern = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
-        var matcher = pattern.matcher(source);
-        if (matcher.find()) {
-            return new Ok<>(matcher.group(1));
-        }
-        return new Ok<>("");
+        return file.readString().mapValue(source -> {
+            var pattern = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
+            var matcher = pattern.matcher(source);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+            return "";
+        });
     }
 
     private static Result<List<String>, IOException> readLocalDependencies(PathLike file) {
-        String source;
-        try {
-            source = file.readString();
-        } catch (IOException e) {
-            return new Err<>(e);
-        }
+        return file.readString().flatMapValue(source -> {
+            source = source.replaceAll("(?s)/\\*.*?\\*/", "");
+            source = source.replaceAll("//.*", "");
 
-        source = source.replaceAll("(?s)/\\*.*?\\*/", "");
-        source = source.replaceAll("//.*", "");
+            var classPat = Pattern.compile(
+                    "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+)",
+                    Pattern.MULTILINE);
 
-        var classPat = Pattern.compile(
-                "^(?:public\\s+|protected\\s+|private\\s+)?(?:static\\s+)?(?:final\\s+)?(?:sealed\\s+)?(class|interface|record)\\s+(\\w+)",
-                Pattern.MULTILINE);
+            var matcher = classPat.matcher(source);
+            List<String> deps = new ArrayList<>();
+            List<String> defined = new ArrayList<>();
+            while (matcher.find()) {
+                String name = matcher.group(2);
+                defined.add(name);
+                int start = matcher.end();
+                int brace = source.indexOf('{', start);
+                if (brace == -1) {
+                    continue;
+                }
+                String rest = source.substring(start, brace);
+                rest = rest.replaceAll("\\s+", " ").trim();
 
-        var matcher = classPat.matcher(source);
-        List<String> deps = new ArrayList<>();
-        List<String> defined = new ArrayList<>();
-        while (matcher.find()) {
-            String name = matcher.group(2);
-            defined.add(name);
-            int start = matcher.end();
-            int brace = source.indexOf('{', start);
-            if (brace == -1) {
-                continue;
-            }
-            String rest = source.substring(start, brace);
-            rest = rest.replaceAll("\\s+", " ").trim();
-
-            String extendsPart = null;
-            String implementsPart = null;
-            int extIdx = rest.indexOf("extends ");
-            int implIdx = rest.indexOf("implements ");
-            if (extIdx != -1) {
+                String extendsPart = null;
+                String implementsPart = null;
+                int extIdx = rest.indexOf("extends ");
+                int implIdx = rest.indexOf("implements ");
+                if (extIdx != -1) {
+                    if (implIdx != -1) {
+                        extendsPart = rest.substring(extIdx + 8, implIdx).trim();
+                    }
+                    else {
+                        extendsPart = rest.substring(extIdx + 8).trim();
+                    }
+                }
                 if (implIdx != -1) {
-                    extendsPart = rest.substring(extIdx + 8, implIdx).trim();
-                } else {
-                    extendsPart = rest.substring(extIdx + 8).trim();
+                    implementsPart = rest.substring(implIdx + 11).trim();
                 }
-            }
-            if (implIdx != -1) {
-                implementsPart = rest.substring(implIdx + 11).trim();
-            }
 
-            if (extendsPart != null && !extendsPart.isEmpty()) {
-                extendsPart = extendsPart.replaceAll("<.*?>", "");
-                for (String part : extendsPart.split(",")) {
-                    String base = part.trim();
-                    if (!base.isEmpty() && !defined.contains(base)) {
-                        deps.add(base);
+                if (extendsPart != null && !extendsPart.isEmpty()) {
+                    extendsPart = extendsPart.replaceAll("<.*?>", "");
+                    for (String part : extendsPart.split(",")) {
+                        String base = part.trim();
+                        if (!base.isEmpty() && !defined.contains(base)) {
+                            deps.add(base);
+                        }
+                    }
+                }
+                if (implementsPart != null && !implementsPart.isEmpty()) {
+                    implementsPart = implementsPart.replaceAll("<.*?>", "");
+                    for (String part : implementsPart.split(",")) {
+                        String base = part.trim();
+                        if (!base.isEmpty() && !defined.contains(base)) {
+                            deps.add(base);
+                        }
                     }
                 }
             }
-            if (implementsPart != null && !implementsPart.isEmpty()) {
-                implementsPart = implementsPart.replaceAll("<.*?>", "");
-                for (String part : implementsPart.split(",")) {
-                    String base = part.trim();
-                    if (!base.isEmpty() && !defined.contains(base)) {
-                        deps.add(base);
-                    }
-                }
-            }
-        }
-        return new Ok<>(deps);
+            return new Ok<>(deps);
+        });
     }
 
     private static Result<List<String>, IOException> readDeclarations(PathLike file) {
@@ -311,7 +302,8 @@ public final class TypeScriptStubs {
                 String paramList = tsParams(params);
                 if (isInterface || ";".equals(delim)) {
                     list.add("\t" + prefix + mName + typeParams + "(" + paramList + "): " + tsType(returnType) + ";");
-                } else {
+                }
+                else {
                     list.add("\t" + prefix + mName + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
                     list.add("\t}");
                 }

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -27,9 +27,6 @@ public final class TypeScriptStubs {
 
     public static Option<IOException> write(PathLike javaRoot, PathLike tsRoot) {
         List<PathLike> files;
-            if (relative.toString().replace('\\', '/').equals("magma/TypeScriptStubs.java")) {
-                continue;
-            }
         var walkRes = javaRoot.walk();
         if (walkRes.isErr()) {
             return new Some<>(((Err<Stream<PathLike>, IOException>) walkRes).error());
@@ -296,16 +293,6 @@ public final class TypeScriptStubs {
             String staticKw = mMatcher.group(1);
             String generics = mMatcher.group(2);
             String returnType = mMatcher.group(3);
-            if ("new".equals(returnType)) {
-                continue;
-            }
-            int startIdx = mMatcher.start();
-            if (startIdx > 0) {
-                char prev = body.charAt(startIdx - 1);
-                if (Character.isJavaIdentifierPart(prev) || prev == '.') {
-                    continue;
-                }
-            }
             String mName = mMatcher.group(4);
             String params = mMatcher.group(5);
             String delim = mMatcher.group(6);
@@ -417,18 +404,10 @@ public final class TypeScriptStubs {
                     if (last != -1) {
                         String type = part.substring(0, last).trim();
                         String name = part.substring(last + 1).trim();
-                        boolean varArgs = type.endsWith("...");
-                        if (varArgs) {
-                            type = type.substring(0, type.length() - 3);
-                        }
                         if (!first) {
                             out.append(", ");
                         }
-                        out.append(varArgs ? "..." : "");
                         out.append(name).append(": ").append(tsType(type));
-                        if (varArgs) {
-                            out.append("[]");
-                        }
                         first = false;
                     }
                 }

--- a/src/java/magma/TypeScriptStubs.java
+++ b/src/java/magma/TypeScriptStubs.java
@@ -27,6 +27,9 @@ public final class TypeScriptStubs {
 
     public static Option<IOException> write(PathLike javaRoot, PathLike tsRoot) {
         List<PathLike> files;
+            if (relative.toString().replace('\\', '/').equals("magma/TypeScriptStubs.java")) {
+                continue;
+            }
         var walkRes = javaRoot.walk();
         if (walkRes.isErr()) {
             return new Some<>(((Err<Stream<PathLike>, IOException>) walkRes).error());
@@ -293,6 +296,16 @@ public final class TypeScriptStubs {
             String staticKw = mMatcher.group(1);
             String generics = mMatcher.group(2);
             String returnType = mMatcher.group(3);
+            if ("new".equals(returnType)) {
+                continue;
+            }
+            int startIdx = mMatcher.start();
+            if (startIdx > 0) {
+                char prev = body.charAt(startIdx - 1);
+                if (Character.isJavaIdentifierPart(prev) || prev == '.') {
+                    continue;
+                }
+            }
             String mName = mMatcher.group(4);
             String params = mMatcher.group(5);
             String delim = mMatcher.group(6);
@@ -404,10 +417,18 @@ public final class TypeScriptStubs {
                     if (last != -1) {
                         String type = part.substring(0, last).trim();
                         String name = part.substring(last + 1).trim();
+                        boolean varArgs = type.endsWith("...");
+                        if (varArgs) {
+                            type = type.substring(0, type.length() - 3);
+                        }
                         if (!first) {
                             out.append(", ");
                         }
+                        out.append(varArgs ? "..." : "");
                         out.append(name).append(": ").append(tsType(type));
+                        if (varArgs) {
+                            out.append("[]");
+                        }
                         first = false;
                     }
                 }

--- a/src/java/magma/result/Err.java
+++ b/src/java/magma/result/Err.java
@@ -1,5 +1,7 @@
 package magma.result;
 
+import java.util.function.Function;
+
 /**
  * Result variant representing failure.
  * See {@code Ok} for the success case.
@@ -26,13 +28,18 @@ public final class Err<T, X> implements Result<T, X> {
     }
 
     @Override
-    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+    public <U> Result<U, X> mapValue(Function<? super T, ? extends U> mapper) {
         return new Err<>(error);
     }
 
     @Override
-    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+    public <U> Result<U, X> flatMapValue(Function<? super T, Result<U, X>> mapper) {
         return new Err<>(error);
+    }
+
+    @Override
+    public <R> R match(Function<T, R> whenOk, Function<X, R> whenErr) {
+        return whenErr.apply(error);
     }
 
 }

--- a/src/java/magma/result/Ok.java
+++ b/src/java/magma/result/Ok.java
@@ -1,5 +1,7 @@
 package magma.result;
 
+import java.util.function.Function;
+
 /**
  * Result variant representing success.
  * See {@code Err} for the failure case.
@@ -26,13 +28,18 @@ public final class Ok<T, X> implements Result<T, X> {
     }
 
     @Override
-    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+    public <U> Result<U, X> mapValue(Function<? super T, ? extends U> mapper) {
         return new Ok<>(mapper.apply(value));
     }
 
     @Override
-    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+    public <U> Result<U, X> flatMapValue(Function<? super T, Result<U, X>> mapper) {
         return mapper.apply(value);
+    }
+
+    @Override
+    public <R> R match(Function<T, R> whenOk, Function<X, R> whenErr) {
+        return whenOk.apply(value);
     }
 
 }

--- a/src/java/magma/result/Result.java
+++ b/src/java/magma/result/Result.java
@@ -1,5 +1,7 @@
 package magma.result;
 
+import java.util.function.Function;
+
 /**
  * A simple result type representing either a successful value or an error.
  * It is meant for situations where a returned value is meaningful. If there is
@@ -24,14 +26,15 @@ public interface Result<T, X> {
      * Transforms the successful value using {@code mapper}. If this result is
      * an error, the same error is returned unchanged.
      */
-    <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper);
+    <U> Result<U, X> mapValue(Function<? super T, ? extends U> mapper);
 
     /**
      * Transforms the successful value using a function that itself returns a
      * {@code Result}. This allows for chaining operations without explicit
      * casts.
      */
-    <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper);
+    <U> Result<U, X> flatMapValue(Function<? super T, Result<U, X>> mapper);
 
+    <R> R match(Function<T, R> whenOk, Function<X, R> whenErr);
 }
 

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -1,16 +1,15 @@
 package magma;
 
+import magma.option.Option;
+import magma.result.Results;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
-import magma.option.Option;
-import magma.result.Results;
-
 import static magma.TestUtil.writeSource;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypeScriptStubsTest {
 
@@ -72,12 +71,7 @@ public class TypeScriptStubsTest {
             throw new RuntimeException(result.get());
         }
 
-        String err;
-        try {
-            err = tsRoot.resolve("test/Err.ts").readString();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        String err = Results.unwrap(tsRoot.resolve("test/Err.ts").readString());
         assertTrue(err.contains("import { Result } from \"./Result\";"));
     }
 
@@ -87,7 +81,7 @@ public class TypeScriptStubsTest {
         String content = Results.unwrap(tsRoot.resolve("test/B.ts").readString());
         assertTrue(content.contains("export class B {}"));
     }
-  
+
     @Test
     public void stubCopiesClasses() {
         PathLike javaRoot;

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -58,6 +58,34 @@ public class TypeScriptStubsTest {
     }
 
     @Test
+    public void addsImportForLocalDependency() {
+        PathLike javaRoot;
+        PathLike tsRoot;
+        try {
+            javaRoot = new JVMPath(Files.createTempDirectory("java"));
+            tsRoot = new JVMPath(Files.createTempDirectory("ts"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        writeSource(javaRoot, "test/Result.java", "package test;\npublic interface Result {}\n");
+        writeSource(javaRoot, "test/Err.java", "package test;\npublic class Err implements Result {}\n");
+
+        Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
+        if (result.isPresent()) {
+            throw new RuntimeException(result.get());
+        }
+
+        String err;
+        try {
+            err = tsRoot.resolve("test/Err.ts").readString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertTrue(err.contains("import { Result } from \"./Result\";"));
+    }
+
+    @Test
     public void stubDeclaresBClass() {
         PathLike tsRoot = generateStubs();
         String content;


### PR DESCRIPTION
## Summary
- ensure JVMPath properly handles absolute paths
- add detection of local inheritance dependencies when generating TS
- handle abstract methods and interfaces when generating stubs
- test for local dependency import

## Testing
- `./test.sh`
- `./check-ts.sh` *(fails: tsc reports syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841069e9ab083218d6b0768cb36da82