### PR TITLE
Add PlantUML rendering to build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.out
 /out/
 /diagram.puml
+/diagram.png
+/plantuml.jar
 /junit-platform-console-standalone.jar
 /src/node/
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The project is an early experiment for a future Magma compiler pipeline.
 - Extracts classes and interfaces from Java source files
 - Generates PlantUML diagrams of inheritance and dependencies with
   orthogonal line routing
+- Renders `diagram.puml` to `diagram.png` using PlantUML
 - Produces TypeScript stubs mirroring the Java hierarchy
 - Provides build, run and test helper scripts
 - Includes a simple `Result` type for functional-style error handling
@@ -52,7 +53,8 @@ For convenience there are helper scripts at the repository root:
 ```
 
 Running the program creates a `diagram.puml` file in the repository root and
-generates `.ts` stubs under `src/node`. Primitive Java types are translated to
+automatically renders `diagram.png`. It also generates `.ts` stubs under
+`src/node`. Primitive Java types are translated to
 their TypeScript equivalents. Numeric primitives (`byte`, `short`, `int`, `long`,
 `float`, `double`) become `number`, `boolean` stays `boolean` and `char` or
 `String` are emitted as `string`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,6 +4,7 @@
 - Detects inheritance and dependency relationships
 - Generates a PlantUML diagram summarizing the relations with
   orthogonal line routing
+- Converts the PlantUML file to an image for convenience
 - Omits interface dependencies when an implementing class is referenced. For
   example `TypeScriptStubs` depends directly on `Some` and `None` instead of the
   `Option` interface

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,7 +7,8 @@ Run the program using the provided helper script:
 ```
 
 `./run.sh` compiles the project if necessary and then executes
-`magma.Main`.
+`magma.Main`. After execution it converts `diagram.puml` to `diagram.png`
+using PlantUML.
 
 Executing the program creates a file named `diagram.puml` in the repository
 root. The file contains a PlantUML diagram describing the discovered classes and

--- a/render-diagram.sh
+++ b/render-diagram.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUML_FILE="$SCRIPT_DIR/diagram.puml"
+
+if [ ! -f "$PUML_FILE" ]; then
+  echo "diagram.puml not found. Run ./run.sh first." >&2
+  exit 1
+fi
+
+PLANTUML_VERSION="1.2024.5"
+PLANTUML_JAR="$SCRIPT_DIR/plantuml.jar"
+
+if [ ! -f "$PLANTUML_JAR" ]; then
+  curl -L -o "$PLANTUML_JAR" "https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar"
+fi
+
+java -jar "$PLANTUML_JAR" -tpng "$PUML_FILE"

--- a/run.sh
+++ b/run.sh
@@ -10,3 +10,5 @@ fi
 
 java --enable-preview -cp "$OUT_DIR" magma.Main "$@"
 
+"$SCRIPT_DIR/render-diagram.sh"
+


### PR DESCRIPTION
## Summary
- ignore PlantUML artifacts
- convert `diagram.puml` to `diagram.png` via new `render-diagram.sh`
- call rendering step from `run.sh`
- document new behaviour in README and docs

## Testing
- `./test.sh`
- `npm run check-ts` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841140244108321bd234e9070792d82