### PR TITLE
General cleanup

### DIFF
--- a/test/java/magma/OptionDependencyTest.java
+++ b/test/java/magma/OptionDependencyTest.java
@@ -14,19 +14,35 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionDependencyTest {
 
-    @Test
-    public void stubsDependOnSomeAndNoneNotOption() {
+    private Set<Relation> tsDeps() {
         Result<List<String>, IOException> res = Sources.read(JVMPath.of("src/java"));
-        assertTrue(res.isOk(), "reading sources failed");
+        if (res.isErr()) {
+            throw new RuntimeException(((magma.result.Err<List<String>, IOException>) res).error());
+        }
         Sources sources = new Sources(magma.result.Results.unwrap(res));
         List<String> classes = sources.findClasses();
         Map<String, List<String>> impl = sources.findImplementations();
         List<Relation> all = sources.findRelations(classes, impl);
-        Set<Relation> tsDeps = all.stream()
+        return all.stream()
                 .filter(r -> r.from().equals("TypeScriptStubs"))
                 .collect(Collectors.toSet());
-        assertTrue(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "Some")));
-        assertTrue(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "None")));
-        assertFalse(tsDeps.contains(new Relation("TypeScriptStubs", "-->", "Option")));
+    }
+
+    @Test
+    public void dependsOnSome() {
+        Set<Relation> deps = tsDeps();
+        assertTrue(deps.contains(new Relation("TypeScriptStubs", "-->", "Some")));
+    }
+
+    @Test
+    public void dependsOnNone() {
+        Set<Relation> deps = tsDeps();
+        assertTrue(deps.contains(new Relation("TypeScriptStubs", "-->", "None")));
+    }
+
+    @Test
+    public void doesNotDependOnOptionInterface() {
+        Set<Relation> deps = tsDeps();
+        assertFalse(deps.contains(new Relation("TypeScriptStubs", "-->", "Option")));
     }
 }


### PR DESCRIPTION
## Summary
- follow the coding guidelines by splitting `OptionDependencyTest` into tests with single assertions

## Testing
- `./test.sh`
- `./check-ts.sh` *(fails: JavaFile.ts syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68419015534c832181f085058dac23bd