### PR TITLE
Stub method body generation

### DIFF
--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -235,6 +235,7 @@ public record JavaFile(PathLike file) {
             return;
         }
         list.add("\t" + prefix + name + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
+        list.add("\t\treturn 0;");
         list.add("\t}");
     }
 

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -188,6 +188,13 @@ public class TypeScriptStubsTest {
     }
 
     @Test
+    public void stubsMethodBody() {
+        PathLike tsRoot = generateMethodStubs();
+        String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
+        assertTrue(a.contains("return 0;"));
+    }
+
+    @Test
     public void stubCopiesMethodsOnGenericClass() {
         PathLike javaRoot;
         PathLike tsRoot;


### PR DESCRIPTION
## Summary
- stub method bodies with a placeholder `return 0;`
- test that the stubbed body contains the placeholder

## Testing
- `./test.sh`
- `./run.sh` *(fails: `Cannot run program "/opt/local/bin/dot"`)*

------
https://chatgpt.com/codex/tasks/task_e_68419b8297e08321887aad1bb797c96a