### PR TITLE
Add tsc compilation errors output

### DIFF
--- a/tsc-errors.log
+++ b/tsc-errors.log
@@ -1,0 +1,571 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+src/node/magma/GenerateDiagram.ts(6,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/GenerateDiagram.ts(7,46): error TS1109: Expression expected.
+src/node/magma/GenerateDiagram.ts(8,11): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(8,44): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(9,16): error TS1005: '(' expected.
+src/node/magma/GenerateDiagram.ts(9,47): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(10,7): error TS1005: ':' expected.
+src/node/magma/GenerateDiagram.ts(10,54): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(11,7): error TS1005: ':' expected.
+src/node/magma/GenerateDiagram.ts(11,46): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(12,10): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(13,3): error TS1109: Expression expected.
+src/node/magma/GenerateDiagram.ts(13,10): error TS1005: ':' expected.
+src/node/magma/GenerateDiagram.ts(13,37): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(15,2): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(15,11): error TS1005: ',' expected.
+src/node/magma/GenerateDiagram.ts(15,16): error TS1109: Expression expected.
+src/node/magma/GenerateDiagram.ts(16,2): error TS1128: Declaration or statement expected.
+src/node/magma/GenerateDiagram.ts(17,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/GenerateDiagram.ts(18,15): error TS1005: ';' expected.
+src/node/magma/GenerateDiagram.ts(18,20): error TS1005: ';' expected.
+src/node/magma/GenerateDiagram.ts(18,22): error TS1435: Unknown keyword or identifier. Did you mean 'class'?
+src/node/magma/GenerateDiagram.ts(18,29): error TS1128: Declaration or statement expected.
+src/node/magma/GenerateDiagram.ts(19,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/GenerateDiagram.ts(20,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/GenerateDiagram.ts(24,17): error TS1005: ';' expected.
+src/node/magma/GenerateDiagram.ts(24,22): error TS1109: Expression expected.
+src/node/magma/GenerateDiagram.ts(25,2): error TS1128: Declaration or statement expected.
+src/node/magma/GenerateDiagram.ts(26,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/GenerateDiagram.ts(28,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/GenerateDiagram.ts(30,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/GenerateDiagram.ts(36,1): error TS1005: '}' expected.
+src/node/magma/JVMPath.ts(10,39): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(10,42): error TS1003: Identifier expected.
+src/node/magma/JVMPath.ts(23,3): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JVMPath.ts(26,3): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JVMPath.ts(28,22): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(28,23): error TS1135: Argument expression expected.
+src/node/magma/JVMPath.ts(28,44): error TS1109: Expression expected.
+src/node/magma/JVMPath.ts(30,13): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(30,15): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JVMPath.ts(31,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JVMPath.ts(34,18): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(34,29): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(34,31): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JVMPath.ts(37,21): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(37,30): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(38,8): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(38,35): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(39,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(39,22): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(40,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(40,23): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(42,21): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(43,8): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(43,32): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(44,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(44,22): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(45,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(45,23): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(47,10): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(47,12): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JVMPath.ts(50,14): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(51,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(51,42): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(52,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(52,22): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(54,15): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(55,9): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(55,13): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(55,33): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(56,9): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(56,24): error TS1005: '(' expected.
+src/node/magma/JVMPath.ts(56,94): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(57,9): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(57,13): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(58,12): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(58,13): error TS1135: Argument expression expected.
+src/node/magma/JVMPath.ts(58,23): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(59,10): error TS1005: ':' expected.
+src/node/magma/JVMPath.ts(59,48): error TS1005: ',' expected.
+src/node/magma/JVMPath.ts(61,17): error TS1005: ';' expected.
+src/node/magma/JVMPath.ts(61,19): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JVMPath.ts(65,1): error TS1005: '}' expected.
+src/node/magma/JavaFile.ts(7,45): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(8,7): error TS1005: ':' expected.
+src/node/magma/JavaFile.ts(8,76): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(9,7): error TS1005: ':' expected.
+src/node/magma/JavaFile.ts(9,39): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(10,14): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(10,21): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(10,23): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(14,7): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(14,18): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(14,19): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(14,21): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(17,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(21,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(21,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(21,39): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(22,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(26,20): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(26,46): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(26,47): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(26,52): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(27,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(28,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(29,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(31,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(33,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(36,8): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(36,15): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(36,16): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(36,18): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(39,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(41,3): error TS1135: Argument expression expected.
+src/node/magma/JavaFile.ts(42,21): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(44,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(46,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(47,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(49,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(52,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(53,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(54,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(58,21): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(60,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(60,19): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(60,21): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(60,25): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(63,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(63,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(63,41): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(65,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(66,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(67,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(68,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(69,12): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(69,42): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(69,47): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(70,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(71,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(73,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(77,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(79,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(79,18): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(79,45): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(79,65): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(79,78): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(82,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(85,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(86,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(91,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(91,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(91,39): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(94,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(96,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(98,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(99,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(100,26): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(101,32): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(101,33): error TS1135: Argument expression expected.
+src/node/magma/JavaFile.ts(102,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(118,10): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(119,3): error TS1130: 'case' or 'default' expected.
+src/node/magma/JavaFile.ts(119,31): error TS1005: '(' expected.
+src/node/magma/JavaFile.ts(119,55): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(120,22): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(121,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(122,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(123,12): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(123,35): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(123,40): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(124,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(126,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(127,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(132,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(132,31): error TS1005: '(' expected.
+src/node/magma/JavaFile.ts(132,48): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(132,55): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(132,62): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(133,26): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(134,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(134,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(134,22): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(134,27): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(137,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(137,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(137,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(137,43): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(137,50): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(139,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(139,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(139,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(139,32): error TS1011: An element access expression should take an argument.
+src/node/magma/JavaFile.ts(139,34): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(139,64): error TS1011: An element access expression should take an argument.
+src/node/magma/JavaFile.ts(139,65): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(142,11): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(142,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(142,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(143,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(143,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(143,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(143,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(144,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(144,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(144,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(144,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(145,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(145,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(145,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(145,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(146,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(146,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(146,18): error TS1435: Unknown keyword or identifier. Did you mean 'finally'?
+src/node/magma/JavaFile.ts(146,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(147,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(147,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(147,52): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(147,58): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(148,25): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(149,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(149,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(149,39): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(150,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(152,16): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(152,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(152,22): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(152,38): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(156,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(156,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(156,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(156,47): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(156,56): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(158,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(160,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(161,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(162,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(165,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(168,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(169,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(174,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(177,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(178,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(180,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(181,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(182,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(183,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(186,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(186,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(186,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(186,45): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(186,57): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(186,64): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(187,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(188,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(190,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(192,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(194,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(194,11): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(194,18): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(194,49): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(194,55): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(204,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(204,23): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,47): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,65): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,85): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,99): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,115): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,130): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,151): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,166): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(204,175): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(205,10): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(205,51): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(206,10): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(206,61): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(207,10): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(207,37): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(208,19): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(208,39): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(211,21): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(213,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(213,19): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(213,21): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(213,25): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(217,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(217,28): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(217,37): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(217,39): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(219,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(220,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(221,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(222,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(223,12): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(223,42): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(223,47): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(224,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(225,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(227,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(231,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(234,17): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(234,22): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(235,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(235,25): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(235,38): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(235,60): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(235,70): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(235,72): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(238,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(241,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(242,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(248,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(248,24): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(248,33): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(248,35): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(251,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(253,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(255,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(256,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(257,26): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(258,32): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(258,33): error TS1135: Argument expression expected.
+src/node/magma/JavaFile.ts(259,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(275,10): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(277,9): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(277,10): error TS1005: '{' expected.
+src/node/magma/JavaFile.ts(277,12): error TS1130: 'case' or 'default' expected.
+src/node/magma/JavaFile.ts(278,10): error TS1005: ':' expected.
+src/node/magma/JavaFile.ts(278,11): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(280,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(280,30): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(280,39): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(281,16): error TS1005: '(' expected.
+src/node/magma/JavaFile.ts(281,40): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(282,7): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(282,15): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(283,7): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(283,15): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,12): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,16): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,20): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,26): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,35): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,38): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(284,40): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(285,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(287,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(288,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(294,8): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(294,15): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(294,16): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(294,18): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(297,31): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(297,32): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(297,34): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(301,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(301,27): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(301,42): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(302,16): error TS1005: '(' expected.
+src/node/magma/JavaFile.ts(302,44): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(303,15): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(307,2): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(310,2): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(311,25): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(312,15): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(312,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(312,39): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(313,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(315,16): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(315,20): error TS1005: ';' expected.
+src/node/magma/JavaFile.ts(315,22): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(315,38): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(320,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(322,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(324,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(325,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(326,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(329,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(332,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(333,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(338,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(341,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(342,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(344,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(345,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(346,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(347,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/JavaFile.ts(351,2): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(352,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(353,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(355,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/JavaFile.ts(357,3): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(360,8): error TS1005: ')' expected.
+src/node/magma/JavaFile.ts(360,15): error TS1109: Expression expected.
+src/node/magma/JavaFile.ts(360,16): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(360,18): error TS1128: Declaration or statement expected.
+src/node/magma/JavaFile.ts(360,23): error TS1005: ':' expected.
+src/node/magma/JavaFile.ts(361,10): error TS1005: ':' expected.
+src/node/magma/JavaFile.ts(361,11): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(363,2): error TS1005: ',' expected.
+src/node/magma/JavaFile.ts(374,1): error TS1005: '}' expected.
+src/node/magma/Main.ts(4,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Main.ts(5,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(8,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(10,22): error TS1005: ',' expected.
+src/node/magma/Sources.ts(10,44): error TS1005: ')' expected.
+src/node/magma/Sources.ts(11,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(11,19): error TS1005: ';' expected.
+src/node/magma/Sources.ts(11,21): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(11,25): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(13,22): error TS1005: ';' expected.
+src/node/magma/Sources.ts(17,28): error TS1005: ';' expected.
+src/node/magma/Sources.ts(18,11): error TS1005: ',' expected.
+src/node/magma/Sources.ts(20,3): error TS1005: ',' expected.
+src/node/magma/Sources.ts(20,11): error TS1005: ',' expected.
+src/node/magma/Sources.ts(22,3): error TS1005: ',' expected.
+src/node/magma/Sources.ts(22,28): error TS1005: ',' expected.
+src/node/magma/Sources.ts(22,46): error TS1005: ')' expected.
+src/node/magma/Sources.ts(23,15): error TS1005: ',' expected.
+src/node/magma/Sources.ts(30,2): error TS1005: ',' expected.
+src/node/magma/Sources.ts(31,27): error TS1005: ';' expected.
+src/node/magma/Sources.ts(32,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(33,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(33,19): error TS1005: ';' expected.
+src/node/magma/Sources.ts(33,21): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(33,25): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(34,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/Sources.ts(35,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(40,33): error TS1005: ',' expected.
+src/node/magma/Sources.ts(40,60): error TS1005: ',' expected.
+src/node/magma/Sources.ts(40,93): error TS1005: ',' expected.
+src/node/magma/Sources.ts(40,121): error TS1005: ';' expected.
+src/node/magma/Sources.ts(41,11): error TS1005: ',' expected.
+src/node/magma/Sources.ts(41,80): error TS1005: ',' expected.
+src/node/magma/Sources.ts(42,23): error TS1005: '(' expected.
+src/node/magma/Sources.ts(42,53): error TS1005: ',' expected.
+src/node/magma/Sources.ts(43,15): error TS1005: '(' expected.
+src/node/magma/Sources.ts(43,53): error TS1005: ',' expected.
+src/node/magma/Sources.ts(44,18): error TS1005: '(' expected.
+src/node/magma/Sources.ts(44,46): error TS1005: ',' expected.
+src/node/magma/Sources.ts(45,15): error TS1005: ',' expected.
+src/node/magma/Sources.ts(48,2): error TS1005: ',' expected.
+src/node/magma/Sources.ts(49,30): error TS1005: ';' expected.
+src/node/magma/Sources.ts(50,31): error TS1005: ';' expected.
+src/node/magma/Sources.ts(51,21): error TS1005: ';' expected.
+src/node/magma/Sources.ts(56,2): error TS1005: ',' expected.
+src/node/magma/Sources.ts(57,22): error TS1005: ';' expected.
+src/node/magma/Sources.ts(58,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(63,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(64,25): error TS1005: ';' expected.
+src/node/magma/Sources.ts(65,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(67,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/Sources.ts(68,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/Sources.ts(72,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(73,28): error TS1005: ';' expected.
+src/node/magma/Sources.ts(74,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(74,22): error TS1005: ';' expected.
+src/node/magma/Sources.ts(74,42): error TS1005: ';' expected.
+src/node/magma/Sources.ts(80,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(81,27): error TS1005: ';' expected.
+src/node/magma/Sources.ts(82,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(82,22): error TS1005: ';' expected.
+src/node/magma/Sources.ts(82,42): error TS1005: ';' expected.
+src/node/magma/Sources.ts(88,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(90,24): error TS1002: Unterminated string literal.
+src/node/magma/Sources.ts(91,3): error TS1005: ',' expected.
+src/node/magma/Sources.ts(93,2): error TS1005: ',' expected.
+src/node/magma/Sources.ts(96,2): error TS1005: ',' expected.
+src/node/magma/Sources.ts(97,19): error TS1005: ';' expected.
+src/node/magma/Sources.ts(98,17): error TS1005: ';' expected.
+src/node/magma/Sources.ts(98,21): error TS1005: ';' expected.
+src/node/magma/Sources.ts(98,23): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(98,34): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(102,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(103,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(103,20): error TS1005: ';' expected.
+src/node/magma/Sources.ts(103,22): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(103,27): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(104,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(109,2): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(110,28): error TS1005: ';' expected.
+src/node/magma/Sources.ts(113,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(116,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/Sources.ts(117,41): error TS1005: ';' expected.
+src/node/magma/Sources.ts(118,15): error TS1005: ';' expected.
+src/node/magma/Sources.ts(118,21): error TS1005: ';' expected.
+src/node/magma/Sources.ts(118,23): error TS1435: Unknown keyword or identifier. Did you mean 'class'?
+src/node/magma/Sources.ts(118,30): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(120,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(123,28): error TS1005: ';' expected.
+src/node/magma/Sources.ts(125,22): error TS1005: ';' expected.
+src/node/magma/Sources.ts(130,25): error TS1005: ',' expected.
+src/node/magma/Sources.ts(130,56): error TS1005: ',' expected.
+src/node/magma/Sources.ts(130,84): error TS1005: ';' expected.
+src/node/magma/Sources.ts(130,86): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(131,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/Sources.ts(132,17): error TS1005: ';' expected.
+src/node/magma/Sources.ts(132,21): error TS1005: ';' expected.
+src/node/magma/Sources.ts(132,62): error TS1005: ';' expected.
+src/node/magma/Sources.ts(133,3): error TS1128: Declaration or statement expected.
+src/node/magma/Sources.ts(133,33): error TS1005: ',' expected.
+src/node/magma/Sources.ts(134,10): error TS1005: ':' expected.
+src/node/magma/Sources.ts(134,28): error TS1005: ',' expected.
+src/node/magma/Sources.ts(136,17): error TS1005: ';' expected.
+src/node/magma/Sources.ts(136,22): error TS1109: Expression expected.
+src/node/magma/Sources.ts(138,1): error TS1005: '}' expected.
+src/node/magma/TypeScriptStubs.ts(10,40): error TS1109: Expression expected.
+src/node/magma/TypeScriptStubs.ts(11,18): error TS1005: '(' expected.
+src/node/magma/TypeScriptStubs.ts(11,47): error TS1005: ',' expected.
+src/node/magma/TypeScriptStubs.ts(11,48): error TS1135: Argument expression expected.
+src/node/magma/TypeScriptStubs.ts(12,12): error TS1005: ',' expected.
+src/node/magma/TypeScriptStubs.ts(13,17): error TS1005: ',' expected.
+src/node/magma/TypeScriptStubs.ts(14,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(15,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(19,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(22,55): error TS1005: ')' expected.
+src/node/magma/TypeScriptStubs.ts(22,74): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(25,49): error TS1005: ')' expected.
+src/node/magma/TypeScriptStubs.ts(25,64): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(28,55): error TS1005: ')' expected.
+src/node/magma/TypeScriptStubs.ts(28,72): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(31,55): error TS1005: ')' expected.
+src/node/magma/TypeScriptStubs.ts(31,79): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(34,68): error TS1005: ')' expected.
+src/node/magma/TypeScriptStubs.ts(34,87): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(35,24): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(36,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/TypeScriptStubs.ts(37,23): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(38,15): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(38,19): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(38,21): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(38,27): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(39,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/TypeScriptStubs.ts(42,29): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(43,37): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(44,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/TypeScriptStubs.ts(45,3): error TS1135: Argument expression expected.
+src/node/magma/TypeScriptStubs.ts(50,12): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(50,17): error TS1109: Expression expected.
+src/node/magma/TypeScriptStubs.ts(51,2): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(52,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(53,36): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(61,17): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(61,22): error TS1109: Expression expected.
+src/node/magma/TypeScriptStubs.ts(62,2): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(63,35): error TS1005: ',' expected.
+src/node/magma/TypeScriptStubs.ts(63,36): error TS1109: Expression expected.
+src/node/magma/TypeScriptStubs.ts(63,37): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(69,2): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(71,3): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(72,15): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(72,20): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(72,22): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(72,34): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(77,2): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(82,3): error TS1435: Unknown keyword or identifier. Did you mean 'string'?
+src/node/magma/TypeScriptStubs.ts(83,22): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(88,15): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(88,22): error TS1005: ';' expected.
+src/node/magma/TypeScriptStubs.ts(88,24): error TS1434: Unexpected keyword or identifier.
+src/node/magma/TypeScriptStubs.ts(88,29): error TS1128: Declaration or statement expected.
+src/node/magma/TypeScriptStubs.ts(92,1): error TS1005: '}' expected.
+src/node/magma/result/Results.ts(5,22): error TS1005: ')' expected.
+src/node/magma/result/Results.ts(5,28): error TS1128: Declaration or statement expected.
+src/node/magma/result/Results.ts(5,29): error TS1128: Declaration or statement expected.
+src/node/magma/result/Results.ts(6,17): error TS1005: ';' expected.
+src/node/magma/result/Results.ts(6,30): error TS1005: ';' expected.
+src/node/magma/result/Results.ts(10,1): error TS1005: '}' expected.


### PR DESCRIPTION
## Summary
- record compilation output of generated TypeScript

## Testing
- `./run.sh > /tmp/run.log 2>&1`
- `npx tsc --noEmit -p tsconfig.json > /tmp/tsc.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_6841ad6f44108321a8418bee9d5f5a66