### PR TITLE
Remove Option.get usages

### DIFF
--- a/src/java/magma/Tuple.java
+++ b/src/java/magma/Tuple.java
@@ -1,0 +1,4 @@
+package magma;
+
+/** Simple generic tuple of two elements. */
+public record Tuple<L, R>(L left, R right) {}

--- a/src/java/magma/option/None.java
+++ b/src/java/magma/option/None.java
@@ -1,5 +1,9 @@
 package magma.option;
 
+import magma.Tuple;
+
+import java.util.function.Function;
+
 /**
  * Option variant representing absence of a value.
  */
@@ -12,5 +16,25 @@ public final class None<T> implements Option<T> {
     @Override
     public T get() {
         throw new java.util.NoSuchElementException("No value present");
+    }
+
+    @Override
+    public <U> Option<U> map(Function<? super T, ? extends U> mapper) {
+        return new None<>();
+    }
+
+    @Override
+    public <U> Option<U> flatMap(Function<? super T, Option<U>> mapper) {
+        return new None<>();
+    }
+
+    @Override
+    public Option<T> orElse(Option<T> other) {
+        return other;
+    }
+
+    @Override
+    public Tuple<Boolean, T> toTuple(T defaultValue) {
+        return new Tuple<>(false, defaultValue);
     }
 }

--- a/src/java/magma/option/Option.java
+++ b/src/java/magma/option/Option.java
@@ -1,6 +1,9 @@
 package magma.option;
 
+import magma.Tuple;
+
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Minimal replacement for {@code java.util.Optional}.
@@ -17,12 +20,21 @@ public interface Option<T> {
      */
     T get();
 
+    <U> Option<U> map(Function<? super T, ? extends U> mapper);
+
+    <U> Option<U> flatMap(Function<? super T, Option<U>> mapper);
+
+    Option<T> orElse(Option<T> other);
+
+    Tuple<Boolean, T> toTuple(T defaultValue);
+
     /**
      * Executes {@code action} if a value is present.
      */
     default void ifPresent(Consumer<? super T> action) {
-        if (isPresent()) {
-            action.accept(get());
+        Tuple<Boolean, T> tuple = toTuple(null);
+        if (tuple.left()) {
+            action.accept(tuple.right());
         }
     }
 }

--- a/src/java/magma/option/Some.java
+++ b/src/java/magma/option/Some.java
@@ -1,5 +1,9 @@
 package magma.option;
 
+import magma.Tuple;
+
+import java.util.function.Function;
+
 /**
  * Option variant representing presence of a value.
  */
@@ -18,5 +22,25 @@ public final class Some<T> implements Option<T> {
     @Override
     public T get() {
         return value;
+    }
+
+    @Override
+    public <U> Option<U> map(Function<? super T, ? extends U> mapper) {
+        return new Some<>(mapper.apply(value));
+    }
+
+    @Override
+    public <U> Option<U> flatMap(Function<? super T, Option<U>> mapper) {
+        return mapper.apply(value);
+    }
+
+    @Override
+    public Option<T> orElse(Option<T> other) {
+        return this;
+    }
+
+    @Override
+    public Tuple<Boolean, T> toTuple(T defaultValue) {
+        return new Tuple<>(true, value);
     }
 }

--- a/test/java/magma/TestUtil.java
+++ b/test/java/magma/TestUtil.java
@@ -11,12 +11,14 @@ final class TestUtil {
         PathLike file = root.resolve(relPath);
         try {
             var dirResult = file.getParent().createDirectories();
-            if (dirResult.isPresent()) {
-                throw dirResult.get();
+            var dirTuple = dirResult.toTuple(null);
+            if (dirTuple.left()) {
+                throw dirTuple.right();
             }
             var writeResult = file.writeString(content);
-            if (writeResult.isPresent()) {
-                throw writeResult.get();
+            var writeTuple = writeResult.toTuple(null);
+            if (writeTuple.left()) {
+                throw writeTuple.right();
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -27,9 +27,7 @@ public class TypeScriptStubsTest {
         writeSource(javaRoot, "test/B.java", "package test;\nimport test.A;\npublic class B {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
         return tsRoot;
     }
 
@@ -67,9 +65,7 @@ public class TypeScriptStubsTest {
         writeSource(javaRoot, "test/Err.java", "package test;\npublic class Err implements Result {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String err = Results.unwrap(tsRoot.resolve("test/Err.ts").readString());
         assertTrue(err.contains("import { Result } from \"./Result\";"));
@@ -98,9 +94,7 @@ public class TypeScriptStubsTest {
         writeSource(javaRoot, "test/R.java", "package test;\npublic record R<T>(T x) {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
         long count = Results.unwrap(tsRoot.resolve("test").list()).count();
         assertEquals(3, count);
     }
@@ -127,9 +121,7 @@ public class TypeScriptStubsTest {
         writeSource(javaRoot, "test/R.java", "package test;\npublic record R<T>(T x) {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
         return tsRoot;
     }
 
@@ -160,9 +152,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A { public void foo(){} public static int bar(){return 0;} public String baz(){return \"\";} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
         return tsRoot;
     }
 
@@ -209,9 +199,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class C<T> { public void foo(){} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String c = Results.unwrap(tsRoot.resolve("test/C.ts").readString());
         assertTrue(c.contains("foo(): void {"), "C.ts missing foo method");
@@ -234,9 +222,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A { public Base<Test> foo(){return null;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("foo(): Base<Test> {"));
@@ -257,9 +243,7 @@ public class TypeScriptStubsTest {
                 "package test;\nimport java.util.Optional;\npublic class A { public Optional<String> foo(){return null;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("foo(): Optional<string> {"));
@@ -280,9 +264,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A { int add(int x, int y){return 0;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("add(x: number, y: number): number {"));
@@ -303,9 +285,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A { public <R> R id(R x){return x;} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("id<R>(x: R): R {"));
@@ -328,9 +308,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A extends Base implements I {}\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
 
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("export class A extends Base implements I {}"));
@@ -350,9 +328,7 @@ public class TypeScriptStubsTest {
                 "package test;\npublic class A { int foo(){ int x=1; bar(); return x; } void bar(){} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
-        if (result.isPresent()) {
-            throw new RuntimeException(result.get());
-        }
+        result.ifPresent(e -> { throw new RuntimeException(e); });
         return tsRoot;
     }
 


### PR DESCRIPTION
## Summary
- add a tiny `Tuple` record
- extend `Option` with map/flatMap/orElse/toTuple
- update `Some` and `None` implementations
- refactor tests to avoid `Option.get`

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841bda22b4c8321ae17cde70926bf5f