### PR TITLE
Fix lambda arrow syntax in Node TypeScript sources

### DIFF
--- a/src/node/magma/GenerateDiagram.ts
+++ b/src/node/magma/GenerateDiagram.ts
@@ -4,7 +4,7 @@ import { Some } from "./option/Some";
 export class GenerateDiagram {
 	static writeDiagram(output: PathLike): Option<IOException> {
 		let src: PathLike = JVMPath.of("src/java/magma");
-		return Sources.read(src).match(allSources -> {
+                return Sources.read(src).match(allSources => {
 		let analysis: Sources = new Sources(allSources);
 		let classes: List<string> = analysis.findClasses();
 		let implementations: var = analysis.findImplementations();

--- a/src/node/magma/JVMPath.ts
+++ b/src/node/magma/JVMPath.ts
@@ -25,7 +25,7 @@ export class JVMPath implements PathLike {
 		return Paths.get("");
 		const first: var = Paths.get(names.getFirst());
 		return names.subList(1, names.size())
-		.reduce(first, Path::resolve, (_, next) -> next);
+                .reduce(first, Path::resolve, (_, next) => next);
 	}
 	getParent(): PathLike {
 		let parent: Path = path.getParent();

--- a/src/node/magma/JavaFile.ts
+++ b/src/node/magma/JavaFile.ts
@@ -4,7 +4,7 @@ import { Ok } from "./result/Ok";
 import { Result } from "./result/Result";
 export class JavaFile {
 	packageName(): Result<string, IOException> {
-		return file.readString().mapValue(source -> {
+                return file.readString().mapValue(source => {
 		let pattern: var = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
 		let matcher: var = pattern.matcher(source);
 		if (matcher.find()) {

--- a/src/node/magma/TypeScriptStubs.ts
+++ b/src/node/magma/TypeScriptStubs.ts
@@ -7,7 +7,7 @@ import { JavaFile } from "./JavaFile";
 import { Results } from "./result/Results";
 export class TypeScriptStubs {
 	static write(javaRoot: PathLike, tsRoot: PathLike): Option<IOException> {
-		return javaRoot.walk().match(stream -> {
+                return javaRoot.walk().match(stream => {
 		let files: List<PathLike> = stream.filter(PathLike::isRegularFile)
 		.toList();
 		for (PathLike file : files) {


### PR DESCRIPTION
## Summary
- update generated Node TS files to use `=>` arrow syntax
- maintain diagram, stubs and path logic using new syntax

## Testing
- `bash test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841c271e544832192865093ffa5bbaf