### PR TITLE
Fix lambda arrow syntax in Node TypeScript sources

### DIFF
--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -376,6 +376,7 @@ public record JavaFile(PathLike file) {
      * a FIXME comment so future revisions can handle them properly.
      */
     private static String parseValue(String value) {
+        value = value.replace("->", "=>");
         StringBuilder out = new StringBuilder();
         int i = 0;
         while (i < value.length()) {
@@ -383,6 +384,12 @@ public record JavaFile(PathLike file) {
             if (Character.isWhitespace(ch)) {
                 out.append(ch);
                 i++;
+                continue;
+            }
+
+            if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
+                out.append("=>");
+                i += 2;
                 continue;
             }
 
@@ -518,6 +525,7 @@ public record JavaFile(PathLike file) {
     }
 
     private static String processSegment(String segment) {
+        String result = segment;
         if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
             int eq = segment.indexOf('=');
             if (eq != -1) {
@@ -536,10 +544,11 @@ public record JavaFile(PathLike file) {
                     String name = declMatch.group(2);
                     boolean isConst = before.startsWith("final ");
                     String kw = isConst ? "const" : "let";
-                    return kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
+                    result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
+                } else {
+                    result = before + " = " + value + (semi ? ";" : "");
                 }
-
-                return before + " = " + value + (semi ? ";" : "");
+                return result.replace("->", "=>");
             }
         }
         if (RETURN_PATTERN.matcher(segment).find()) {
@@ -549,10 +558,11 @@ public record JavaFile(PathLike file) {
                 rest = rest.substring(0, rest.length() - 1).trim();
             }
             if (rest.isEmpty()) {
-                return segment;
+                return segment.replace("->", "=>");
             }
             String value = parseValue(rest);
-            return "return " + value + (semi ? ";" : "");
+            result = "return " + value + (semi ? ";" : "");
+            return result.replace("->", "=>");
         }
         if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
             int open = segment.indexOf('(');
@@ -562,10 +572,11 @@ public record JavaFile(PathLike file) {
                 String inner = segment.substring(open + 1, close);
                 String suffix = segment.substring(close);
                 String value = parseValue(inner);
-                return prefix + value + suffix;
+                result = prefix + value + suffix;
+                return result.replace("->", "=>");
             }
         }
-        return segment;
+        return result.replace("->", "=>");
     }
 
     private static String extractBlock(String source, int start) {

--- a/src/node/magma/GenerateDiagram.ts
+++ b/src/node/magma/GenerateDiagram.ts
@@ -4,7 +4,7 @@ import { Some } from "./option/Some";
 export class GenerateDiagram {
 	static writeDiagram(output: PathLike): Option<IOException> {
 		let src: PathLike = JVMPath.of("src/java/magma");
-		return Sources.read(src).match(allSources -> {
+		return Sources.read(src).match(allSources => {
 		let analysis: Sources = new Sources(allSources);
 		let classes: List<string> = analysis.findClasses();
 		let implementations: var = analysis.findImplementations();

--- a/src/node/magma/JVMPath.ts
+++ b/src/node/magma/JVMPath.ts
@@ -25,7 +25,7 @@ export class JVMPath implements PathLike {
 		return Paths.get("");
 		const first: var = Paths.get(names.getFirst());
 		return names.subList(1, names.size())
-		.reduce(first, Path::resolve, (_, next) -> next);
+		.reduce(first, Path::resolve, (_, next) => next);
 	}
 	getParent(): PathLike {
 		let parent: Path = path.getParent();

--- a/src/node/magma/JavaFile.ts
+++ b/src/node/magma/JavaFile.ts
@@ -4,7 +4,7 @@ import { Ok } from "./result/Ok";
 import { Result } from "./result/Result";
 export class JavaFile {
 	packageName(): Result<string, IOException> {
-		return file.readString().mapValue(source -> {
+		return file.readString().mapValue(source => {
 		let pattern: var = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
 		let matcher: var = pattern.matcher(source);
 		if (matcher.find()) {
@@ -135,12 +135,16 @@ export class JavaFile {
 		converted.add(tsType(part));
 		return converted;
 		private static String parseValue(String value) {
+		value = value.replace("=>", "=>");
 		let out: StringBuilder = new StringBuilder();
 		let i: number = 0;
 		while (i < value.length()) {
 		let ch: string = value.charAt(i);
 		if (Character.isWhitespace(ch)) {
 		out.append(ch);
+		if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
+		out.append(" = >");
+		i + = 2;
 		if (ch == '"' || ch == '\'') {
 		i = scanStringLiteral(value, i, out);
 		if (Character.isDigit(ch)) {
@@ -210,6 +214,7 @@ export class JavaFile {
 		return processSegment(stripped);
 		return null;
 		private static String processSegment(String segment) {
+		let result: string = segment;
 		if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
 		let eq: number = segment.indexOf('=');
 		if (eq != -1) {
@@ -226,17 +231,19 @@ export class JavaFile {
 		let name: string = declMatch.group(2);
 		let isConst: boolean = before.startsWith("final ");
 		let kw: string = isConst ? "const" : "let";
-		return kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
-		return before + " = " + value + (semi ? ";" : "");
+		result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
+		result = before + " = " + value + (semi ? ";" : "");
+		return result.replace("=>", " = >");
 		if (RETURN_PATTERN.matcher(segment).find()) {
 		let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
 		let semi: boolean = rest.endsWith(";");
 		if (semi) {
 		rest = rest.substring(0, rest.length() - 1).trim();
 		if (rest.isEmpty()) {
-		return segment;
+		return segment.replace("=>", " = >");
 		let value: string = parseValue(rest);
-		return "return " + value + (semi ? ";" : "");
+		result = "return " + value + (semi ? ";" : "");
+		return result.replace("=>", " = >");
 		if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
 		let open: number = segment.indexOf('(');
 		let close: number = segment.lastIndexOf(')');
@@ -245,8 +252,9 @@ export class JavaFile {
 		let inner: string = segment.substring(open + 1, close);
 		let suffix: string = segment.substring(close);
 		let value: string = parseValue(inner);
-		return prefix + value + suffix;
-		return segment;
+		result = prefix + value + suffix;
+		return result.replace("=>", " = >");
+		return result.replace("=>", " = >");
 		private static String extractBlock(String source, int start) {
 		let level: number = 1;
 		let i: number = start;
@@ -369,12 +377,16 @@ export class JavaFile {
 		return converted;
 	}
 	static parseValue(value: string): string {
+		value = value.replace("=>", "=>");
 		let out: StringBuilder = new StringBuilder();
 		let i: number = 0;
 		while (i < value.length()) {
 		let ch: string = value.charAt(i);
 		if (Character.isWhitespace(ch)) {
 		out.append(ch);
+		if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
+		out.append(" = >");
+		i + = 2;
 		if (ch == '"' || ch == '\'') {
 		i = scanStringLiteral(value, i, out);
 		if (Character.isDigit(ch)) {
@@ -450,6 +462,7 @@ export class JavaFile {
 	}
 	processSegment(): return;
 	static processSegment(segment: string): string {
+		let result: string = segment;
 		if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
 		let eq: number = segment.indexOf('=');
 		if (eq != -1) {
@@ -466,17 +479,19 @@ export class JavaFile {
 		let name: string = declMatch.group(2);
 		let isConst: boolean = before.startsWith("final ");
 		let kw: string = isConst ? "const" : "let";
-		return kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
-		return before + " = " + value + (semi ? ";" : "");
+		result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
+		result = before + " = " + value + (semi ? ";" : "");
+		return result.replace("=>", " = >");
 		if (RETURN_PATTERN.matcher(segment).find()) {
 		let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
 		let semi: boolean = rest.endsWith(";");
 		if (semi) {
 		rest = rest.substring(0, rest.length() - 1).trim();
 		if (rest.isEmpty()) {
-		return segment;
+		return segment.replace("=>", " = >");
 		let value: string = parseValue(rest);
-		return "return " + value + (semi ? ";" : "");
+		result = "return " + value + (semi ? ";" : "");
+		return result.replace("=>", " = >");
 		if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
 		let open: number = segment.indexOf('(');
 		let close: number = segment.lastIndexOf(')');
@@ -485,8 +500,9 @@ export class JavaFile {
 		let inner: string = segment.substring(open + 1, close);
 		let suffix: string = segment.substring(close);
 		let value: string = parseValue(inner);
-		return prefix + value + suffix;
-		return segment;
+		result = prefix + value + suffix;
+		return result.replace("=>", " = >");
+		return result.replace("=>", " = >");
 	}
 	static extractBlock(source: string, start: number): string {
 		let level: number = 1;

--- a/src/node/magma/TypeScriptStubs.ts
+++ b/src/node/magma/TypeScriptStubs.ts
@@ -7,7 +7,7 @@ import { JavaFile } from "./JavaFile";
 import { Results } from "./result/Results";
 export class TypeScriptStubs {
 	static write(javaRoot: PathLike, tsRoot: PathLike): Option<IOException> {
-		return javaRoot.walk().match(stream -> {
+		return javaRoot.walk().match(stream => {
 		let files: List<PathLike> = stream.filter(PathLike::isRegularFile)
 		.toList();
 		for (PathLike file : files) {


### PR DESCRIPTION
## Summary
- update Java compiler to replace `->` with `=>`
- regenerate Node TS files using the updated compiler

## Testing
- `./build.sh`
- `java --enable-preview -cp out magma.Main`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841c271e544832192865093ffa5bbaf