### PR TITLE
Fix TypeScript stub indentation

### DIFF
--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -491,7 +491,8 @@ public record JavaFile(PathLike file) {
             Pattern.compile("\\breturn\\b"),
             Pattern.compile("\\bif\\s*\\("),
             Pattern.compile("\\bwhile\\s*\\("),
-            Pattern.compile("\\bfor\\s*\\(")
+            Pattern.compile("\\bfor\\s*\\("),
+            Pattern.compile("\\belse\\b")
     };
 
     private static final Pattern ASSIGNMENT_PATTERN = Pattern.compile("[^=!<>]=[^=]");
@@ -502,14 +503,31 @@ public record JavaFile(PathLike file) {
 
     private static List<String> parseSegments(String body) {
         List<String> segments = new ArrayList<>();
+        int indent = 0;
         for (String line : body.split("\\R")) {
-            String stripped = line.trim();
-            if (stripped.isEmpty()) {
-                continue;
-            }
-            String seg = matchSegment(stripped);
-            if (seg != null) {
-                segments.add(seg);
+            for (String token : line.split("(?<=[;{}])")) {
+                String stripped = token.trim();
+                if (stripped.isEmpty()) {
+                    continue;
+                }
+
+                if (stripped.startsWith("}")) {
+                    indent = Math.max(0, indent - 1);
+                    segments.add("\t".repeat(indent) + "}");
+                    stripped = stripped.substring(1).trim();
+                    if (stripped.isEmpty()) {
+                        continue;
+                    }
+                }
+
+                String seg = matchSegment(stripped);
+                if (seg != null) {
+                    segments.add("\t".repeat(indent) + seg);
+                }
+
+                if (stripped.endsWith("{")) {
+                    indent++;
+                }
             }
         }
         return segments;

--- a/src/node/magma/GenerateDiagram.ts
+++ b/src/node/magma/GenerateDiagram.ts
@@ -5,20 +5,22 @@ export class GenerateDiagram {
 	static writeDiagram(output: PathLike): Option<IOException> {
 		let src: PathLike = JVMPath.of("src/java/magma");
 		return Sources.read(src).match(allSources => {
-		let analysis: Sources = new Sources(allSources);
-		let classes: List<string> = analysis.findClasses();
-		let implementations: var = analysis.findImplementations();
-		let sourceMap: var = analysis.mapSourcesByClass();
-		let content: string = "@startuml\n" + "skinparam linetype ortho\n" +
-		return output.writeString(content);
+			let analysis: Sources = new Sources(allSources);
+			let classes: List<string> = analysis.findClasses();
+			let implementations: var = analysis.findImplementations();
+			let sourceMap: var = analysis.mapSourcesByClass();
+			let content: string = "@startuml\n" + "skinparam linetype ortho\n" +
+			return output.writeString(content);
+		}
 	}
 	Sources(): new;
 	static classesSection(classes: List<string>, sourceMap: Map<string, string>): string {
 		let builder: StringBuilder = new StringBuilder();
 		for (String name : classes) {
-		let source: string = sourceMap.getOrDefault(name, "");
-		let type: string = classType(name, source);
-		builder.append(type).append(' ').append(name).append("\n");
+			let source: string = sourceMap.getOrDefault(name, "");
+			let type: string = classType(name, source);
+			builder.append(type).append(' ').append(name).append("\n");
+		}
 		return builder.toString();
 	}
 	StringBuilder(): new;
@@ -27,9 +29,11 @@ export class GenerateDiagram {
 		"(class|interface|record)\\s+" + Pattern.quote(name) + "\\b");
 		let matcher: Matcher = pattern.matcher(source);
 		if (matcher.find()) {
-		let kind: string = matcher.group(1);
-		if ("interface".equals(kind)) {
-		return "interface";
+			let kind: string = matcher.group(1);
+			if ("interface".equals(kind)) {
+				return "interface";
+			}
+		}
 		return "class";
 	}
 }

--- a/src/node/magma/JVMPath.ts
+++ b/src/node/magma/JVMPath.ts
@@ -22,7 +22,8 @@ export class JVMPath implements PathLike {
 	toPath(other: PathLike): Path {
 		const names: var = other.streamNames().toList();
 		if (names.isEmpty()) {
-		return Paths.get("");
+			return Paths.get("");
+		}
 		const first: var = Paths.get(names.getFirst());
 		return names.subList(1, names.size())
 		.reduce(first, Path::resolve, (_, next) => next);
@@ -35,21 +36,27 @@ export class JVMPath implements PathLike {
 		return new JVMPath(path.relativize(toPath(other)));
 	}
 	writeString(content: string): Option<IOException> {
-		Files.writeString(path, content);
-		return new None<>();
-		return new Some<>(e);
+			Files.writeString(path, content);
+			return new None<>();
+		}
+			return new Some<>(e);
+		}
 	}
 	createDirectories(): Option<IOException> {
-		Files.createDirectories(path);
-		return new None<>();
-		return new Some<>(e);
+			Files.createDirectories(path);
+			return new None<>();
+		}
+			return new Some<>(e);
+		}
 	}
 	exists(): boolean {
 		return Files.exists(path);
 	}
 	readString(): Result<string, IOException> {
-		return new Ok<>(Files.readString(path));
-		return new Err<>(e);
+			return new Ok<>(Files.readString(path));
+		}
+			return new Err<>(e);
+		}
 	}
 	streamNames(): Stream<string> {
 		const root: var = path.getRoot();

--- a/src/node/magma/JavaFile.ts
+++ b/src/node/magma/JavaFile.ts
@@ -5,286 +5,396 @@ import { Result } from "./result/Result";
 export class JavaFile {
 	packageName(): Result<string, IOException> {
 		return file.readString().mapValue(source => {
-		let pattern: var = Pattern.compile("^package\\s+([\\w.]+);", Pattern.MULTILINE);
-		let matcher: var = pattern.matcher(source);
-		if (matcher.find()) {
-		return matcher.group(1);
-		return "";
+			let pattern: var = Pattern.compile("^package\\s+([\\w.]+);
+			let matcher: var = pattern.matcher(source);
+			if (matcher.find()) {
+				return matcher.group(1);
+			}
+			return "";
+		}
 	}
 	if(-1: extIdx !=): else {
 		extendsPart = rest.substring(extIdx + 8).trim();
 	}
 	static addParts(clause: string, deps: List<string>, defined: List<string>): void {
 		if (clause == null || clause.isEmpty()) {
-		return;
+			return;
+		}
 		clause = clause.replaceAll("<.*?>", "");
 		for (String part : clause.split(",")) {
-		let base: string = part.trim();
-		if (!base.isEmpty() && !defined.contains(base)) {
-		deps.add(base);
+			let base: string = part.trim();
+			if (!base.isEmpty() && !defined.contains(base)) {
+				deps.add(base);
+			}
+		}
 	}
 	StringBuilder(name: "export " + kind + " " +): new;
 	static extractClassBody(source: string, start: number): string {
 		let level: number = 1;
 		let i: number = start;
 		while (i < source.length() && level > 0) {
-		let ch: string = source.charAt(i);
-		if (ch == '{') {
-		else if (ch == '}') {
-		return source.substring(start, i - 1);
+			let ch: string = source.charAt(i);
+			if (ch == '{
+				}
+				else if (ch == '}
+				}
+			}
+			return source.substring(start, i - 1);
 	}
 	if('}': ch ==): else {
 		return 0;
 	}
 	static parseMethods(body: string, className: string, isInterface: boolean): List<string> {
 		let methodPat: var = Pattern.compile(
-		let mMatcher: var = methodPat.matcher(body);
-		let list: List<string> = new ArrayList<>();
-		while (mMatcher.find()) {
-		let mName: string = mMatcher.group(4);
-		if (mName.equals(className)) {
-		let delim: string = mMatcher.group(6);
-		let methodBody: string = "";
-		if ("{".equals(delim)) {
-		let start: number = mMatcher.end();
-		methodBody = extractBlock(body, start);
-		return list;
-		let prefix: string = staticKw == null ? "" : "static ";
-		let typeParams: string = generics == null ? "" : generics.trim();
-		let paramList: string = tsParams(params);
-		if (isInterface || ";".equals(delim)) {
-		return;
-		list.add("\t" + prefix + name + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
-		let segs: List<string> = parseSegments(body);
-		if (segs.isEmpty()) {
-		for (String seg : segs) {
-		list.add("\t\t" + seg);
-		list.add("\t}");
-		private static String tsParams(String javaParams) {
-		javaParams = javaParams.trim();
-		let out: StringBuilder = new StringBuilder();
-		let depth: number = 0;
-		let start: number = 0;
-		let first: boolean = true;
-		for (int i = 0; i <= javaParams.length(); i++) {
-		let atEnd: boolean = i == javaParams.length();
-		let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
-		if (atEnd || atComma) {
-		let part: string = javaParams.substring(start, i).trim();
-		first = appendParam(part, out, first);
-		start = i + 1;
-		if (javaParams.charAt(i) == '<') {
-		else if (javaParams.charAt(i) == '>') {
-		return out.toString();
-		private static boolean appendParam(String part, StringBuilder out, boolean first) {
-		if (part.isEmpty()) {
-		return first;
-		let last: number = part.lastIndexOf(' ');
-		if (last == -1) {
-		return first;
-		let type: string = part.substring(0, last).trim();
-		let name: string = part.substring(last + 1).trim();
-		if (!first) {
-		out.append(", ");
-		out.append(name).append(": ").append(tsType(type));
-		return false;
-		private static String tsType(String javaType) {
-		javaType = javaType.trim();
-		if (javaType.endsWith("[]")) {
-		let inner: string = javaType.substring(0, javaType.length() - 2);
-		return tsType(inner) + "[]";
-		let lt: number = javaType.indexOf('<');
-		if (lt != -1 && javaType.endsWith(">")) {
-		let base: string = javaType.substring(0, lt);
-		let args: string = javaType.substring(lt + 1, javaType.length() - 1);
-		let converted: List<string> = convertTypes(splitGenericArgs(args));
-		converted.replaceAll(JavaFile::sanitizeWildcard);
-		let simple: string = base.replace("java.util.function.", "");
-		if ("Function".equals(simple) && converted.size() >= 2) {
-		return "(arg0: " + converted.get(0) + ") = > " + converted.get(1);
-		if ("BiFunction".equals(simple) && converted.size() >= 3) {
-		return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
-		+ ") = > " + converted.get(2);
-		if ("Supplier".equals(simple) && !converted.isEmpty()) {
-		return "() = > " + converted.getFirst();
-		if ("Consumer".equals(simple) && !converted.isEmpty()) {
-		return "(arg0: " + converted.getFirst() + ") = > void";
-		if ("BiConsumer".equals(simple) && converted.size() >= 2) {
-		return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
-		+ ") = > void";
-		if ("Predicate".equals(simple) && !converted.isEmpty()) {
-		return "(arg0: " + converted.getFirst() + ") = > boolean";
-		return base + "<" + String.join(", ", converted) + ">";
-		return switch (javaType) {
-		private static List<String> splitGenericArgs(String args) {
-		let parts: List<string> = new ArrayList<>();
-		let depth: number = 0;
-		let start: number = 0;
-		for (int i = 0; i < args.length(); i++) {
-		let ch: string = args.charAt(i);
-		if (ch == '<') {
-		else if (ch == '>') {
-		else if (ch == ',' && depth == 0) {
-		parts.add(args.substring(start, i).trim());
-		start = i + 1;
-		parts.add(args.substring(start).trim());
-		return parts;
-		private static List<String> convertTypes(List<String> parts) {
-		let converted: List<string> = new ArrayList<>();
-		for (String part : parts) {
-		converted.add(tsType(part));
-		return converted;
-		private static String parseValue(String value) {
-		value = value.replace("=>", "=>");
-		let out: StringBuilder = new StringBuilder();
-		let i: number = 0;
-		while (i < value.length()) {
-		let ch: string = value.charAt(i);
-		if (Character.isWhitespace(ch)) {
-		out.append(ch);
-		if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
-		out.append(" = >");
-		i + = 2;
-		if (ch == '"' || ch == '\'') {
-		i = scanStringLiteral(value, i, out);
-		if (Character.isDigit(ch)) {
-		i = scanNumberLiteral(value, i, out);
-		if (Character.isJavaIdentifierStart(ch)) {
-		i = scanIdentifier(value, i, out);
-		out.append(ch);
-		return out.toString().trim();
-		private static int scanStringLiteral(String value, int start, StringBuilder out) {
-		let quote: string = value.charAt(start);
-		let i: number = start + 1;
-		let esc: boolean = false;
-		while (i < value.length()) {
-		let c: string = value.charAt(i);
-		if (esc) {
-		esc = false;
-		} else if (c == '\\') {
-		esc = true;
-		} else if (c == quote) {
-		out.append(value, start, i);
-		return i;
-		private static int scanNumberLiteral(String value, int start, StringBuilder out) {
-		let i: number = start;
-		let exp: boolean = false;
-		let endDigits: number = start;
-		while (i < value.length()) {
-		let c: string = value.charAt(i);
-		if (c == '_' || Character.isDigit(c) || c == '.' || c == 'x' || c == 'X'
-		endDigits = i;
-		if ((c == 'e' || c == 'E') && !exp) {
-		exp = true;
-		endDigits = i;
-		if ((c == '+' || c == '-') && exp
-		endDigits = i;
-		if ("lLfFdD".indexOf(c) != -1) {
-		let num: string = value.substring(start, endDigits).replace("_", "");
-		out.append(num);
-		return i;
-		private static int scanIdentifier(String value, int start, StringBuilder out) {
-		let i: number = start + 1;
-		while (i < value.length() && Character.isJavaIdentifierPart(value.charAt(i))) {
-		let id: string = value.substring(start, i);
-		if ("instanceof".equals(id)) {
-		out.append(" instanceof");
-		out.append(id);
-		return i;
-		private static final Pattern[] SEGMENT_PATTERNS = new Pattern[]{
-		Pattern.compile("\\b(class|interface|record)\\b"),
-		Pattern.compile("[^ = !<>]=[^=]"),
-		private static final Pattern ASSIGNMENT_PATTERN = Pattern.compile("[^=!<>]=[^=]");
-		private static final Pattern RETURN_PATTERN = Pattern.compile("\\breturn\\b");
-		private static final Pattern IF_PATTERN = Pattern.compile("\\bif\\s*\\(");
-		private static final Pattern WHILE_PATTERN = Pattern.compile("\\bwhile\\s*\\(");
-		private static final Pattern FOR_PATTERN = Pattern.compile("\\bfor\\s*\\(");
-		private static List<String> parseSegments(String body) {
-		let segments: List<string> = new ArrayList<>();
-		for (String line : body.split("\\R")) {
-		let stripped: string = line.trim();
-		if (stripped.isEmpty()) {
-		let seg: string = matchSegment(stripped);
-		if (seg != null) {
-		segments.add(seg);
-		return segments;
-		private static String matchSegment(String stripped) {
-		for (Pattern pat : SEGMENT_PATTERNS) {
-		if (pat.matcher(stripped).find()) {
-		return processSegment(stripped);
-		return null;
-		private static String processSegment(String segment) {
-		let result: string = segment;
-		if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
-		let eq: number = segment.indexOf('=');
-		if (eq != -1) {
-		let before: string = segment.substring(0, eq).trim();
-		let after: string = segment.substring(eq + 1).trim();
-		let semi: boolean = after.endsWith(";");
-		if (semi) {
-		after = after.substring(0, after.length() - 1).trim();
-		let value: string = parseValue(after);
-		let declPat: var = Pattern.compile("^(?:final\\s+)?([\\w.<>\\[\\]]+)\\s+(\\w+)$");
-		let declMatch: var = declPat.matcher(before);
-		if (declMatch.find()) {
-		let type: string = tsType(declMatch.group(1));
-		let name: string = declMatch.group(2);
-		let isConst: boolean = before.startsWith("final ");
-		let kw: string = isConst ? "const" : "let";
-		result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
-		result = before + " = " + value + (semi ? ";" : "");
-		return result.replace("=>", " = >");
-		if (RETURN_PATTERN.matcher(segment).find()) {
-		let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
-		let semi: boolean = rest.endsWith(";");
-		if (semi) {
-		rest = rest.substring(0, rest.length() - 1).trim();
-		if (rest.isEmpty()) {
-		return segment.replace("=>", " = >");
-		let value: string = parseValue(rest);
-		result = "return " + value + (semi ? ";" : "");
-		return result.replace("=>", " = >");
-		if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
-		let open: number = segment.indexOf('(');
-		let close: number = segment.lastIndexOf(')');
-		if (open != -1 && close != -1 && close > open) {
-		let prefix: string = segment.substring(0, open + 1);
-		let inner: string = segment.substring(open + 1, close);
-		let suffix: string = segment.substring(close);
-		let value: string = parseValue(inner);
-		result = prefix + value + suffix;
-		return result.replace("=>", " = >");
-		return result.replace("=>", " = >");
-		private static String extractBlock(String source, int start) {
-		let level: number = 1;
-		let i: number = start;
-		while (i < source.length() && level > 0) {
-		let ch: string = source.charAt(i);
-		if (ch == '{') {
-		else if (ch == '}') {
-		return source.substring(start, i - 1);
-		private static String sanitizeWildcard(String type) {
-		type = type.trim();
-		if (type.startsWith("? extends ")) {
-		return type.substring(10).trim();
-		if (type.startsWith("? super ")) {
-		return type.substring(8).trim();
-		if ("?".equals(type)) {
-		return "any";
-		return type;
+			let mMatcher: var = methodPat.matcher(body);
+			let list: List<string> = new ArrayList<>();
+			while (mMatcher.find()) {
+				let mName: string = mMatcher.group(4);
+				if (mName.equals(className)) {
+				}
+				let delim: string = mMatcher.group(6);
+				let methodBody: string = "";
+				if ("{
+						let start: number = mMatcher.end();
+						methodBody = extractBlock(body, start);
+					}
+				}
+				return list;
+			}
+				let prefix: string = staticKw == null ? "" : "static ";
+				let typeParams: string = generics == null ? "" : generics.trim();
+				let paramList: string = tsParams(params);
+				if (isInterface || ";
+					return;
+				}
+					let segs: List<string> = parseSegments(body);
+					if (segs.isEmpty()) {
+					}
+					else {
+						for (String seg : segs) {
+							list.add("\t\t" + seg);
+						}
+					}
+				}
+				private static String tsParams(String javaParams) {
+					javaParams = javaParams.trim();
+					let out: StringBuilder = new StringBuilder();
+					let depth: number = 0;
+					let start: number = 0;
+					let first: boolean = true;
+					for (int i = 0;
+					i <= javaParams.length();
+						let atEnd: boolean = i == javaParams.length();
+						let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+						if (atEnd || atComma) {
+							let part: string = javaParams.substring(start, i).trim();
+							first = appendParam(part, out, first);
+							start = i + 1;
+						}
+						if (javaParams.charAt(i) == '<') {
+						}
+						else if (javaParams.charAt(i) == '>') {
+						}
+					}
+					return out.toString();
+				}
+				private static boolean appendParam(String part, StringBuilder out, boolean first) {
+					if (part.isEmpty()) {
+						return first;
+					}
+					let last: number = part.lastIndexOf(' ');
+					if (last == -1) {
+						return first;
+					}
+					let type: string = part.substring(0, last).trim();
+					let name: string = part.substring(last + 1).trim();
+					if (!first) {
+						out.append(", ");
+					}
+					out.append(name).append(": ").append(tsType(type));
+					return false;
+				}
+				private static String tsType(String javaType) {
+					javaType = javaType.trim();
+					if (javaType.endsWith("[]")) {
+						let inner: string = javaType.substring(0, javaType.length() - 2);
+						return tsType(inner) + "[]";
+					}
+					let lt: number = javaType.indexOf('<');
+					if (lt != -1 && javaType.endsWith(">")) {
+						let base: string = javaType.substring(0, lt);
+						let args: string = javaType.substring(lt + 1, javaType.length() - 1);
+						let converted: List<string> = convertTypes(splitGenericArgs(args));
+						converted.replaceAll(JavaFile::sanitizeWildcard);
+						let simple: string = base.replace("java.util.function.", "");
+						if ("Function".equals(simple) && converted.size() >= 2) {
+							return "(arg0: " + converted.get(0) + ") = > " + converted.get(1);
+						}
+						if ("BiFunction".equals(simple) && converted.size() >= 3) {
+							return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
+							+ ") = > " + converted.get(2);
+						}
+						if ("Supplier".equals(simple) && !converted.isEmpty()) {
+							return "() = > " + converted.getFirst();
+						}
+						if ("Consumer".equals(simple) && !converted.isEmpty()) {
+							return "(arg0: " + converted.getFirst() + ") = > void";
+						}
+						if ("BiConsumer".equals(simple) && converted.size() >= 2) {
+							return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
+							+ ") = > void";
+						}
+						if ("Predicate".equals(simple) && !converted.isEmpty()) {
+							return "(arg0: " + converted.getFirst() + ") = > boolean";
+						}
+						return base + "<" + String.join(", ", converted) + ">";
+					}
+					return switch (javaType) {
+					}
+				}
+				private static List<String> splitGenericArgs(String args) {
+					let parts: List<string> = new ArrayList<>();
+					let depth: number = 0;
+					let start: number = 0;
+					for (int i = 0;
+					i < args.length();
+						let ch: string = args.charAt(i);
+						if (ch == '<') {
+						}
+						else if (ch == '>') {
+						}
+						else if (ch == ',' && depth == 0) {
+							parts.add(args.substring(start, i).trim());
+							start = i + 1;
+						}
+					}
+					parts.add(args.substring(start).trim());
+					return parts;
+				}
+				private static List<String> convertTypes(List<String> parts) {
+					let converted: List<string> = new ArrayList<>();
+					for (String part : parts) {
+						converted.add(tsType(part));
+					}
+					return converted;
+				}
+				private static String parseValue(String value) {
+					value = value.replace("=>", "=>");
+					let out: StringBuilder = new StringBuilder();
+					let i: number = 0;
+					while (i < value.length()) {
+						let ch: string = value.charAt(i);
+						if (Character.isWhitespace(ch)) {
+							out.append(ch);
+						}
+						if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
+							out.append(" = >");
+							i + = 2;
+						}
+						if (ch == '"' || ch == '\'') {
+							i = scanStringLiteral(value, i, out);
+						}
+						if (Character.isDigit(ch)) {
+							i = scanNumberLiteral(value, i, out);
+						}
+						if (Character.isJavaIdentifierStart(ch)) {
+							i = scanIdentifier(value, i, out);
+						}
+						out.append(ch);
+					}
+					return out.toString().trim();
+				}
+				private static int scanStringLiteral(String value, int start, StringBuilder out) {
+					let quote: string = value.charAt(start);
+					let i: number = start + 1;
+					let esc: boolean = false;
+					while (i < value.length()) {
+						let c: string = value.charAt(i);
+						if (esc) {
+							esc = false;
+						}
+						else if (c == '\\') {
+							esc = true;
+						}
+						else if (c == quote) {
+						}
+					}
+					out.append(value, start, i);
+					return i;
+				}
+				private static int scanNumberLiteral(String value, int start, StringBuilder out) {
+					let i: number = start;
+					let exp: boolean = false;
+					let endDigits: number = start;
+					while (i < value.length()) {
+						let c: string = value.charAt(i);
+						if (c == '_' || Character.isDigit(c) || c == '.' || c == 'x' || c == 'X'
+							endDigits = i;
+						}
+						if ((c == 'e' || c == 'E') && !exp) {
+							exp = true;
+							endDigits = i;
+						}
+						if ((c == '+' || c == '-') && exp
+							endDigits = i;
+						}
+						if ("lLfFdD".indexOf(c) != -1) {
+						}
+					}
+					let num: string = value.substring(start, endDigits).replace("_", "");
+					out.append(num);
+					return i;
+				}
+				private static int scanIdentifier(String value, int start, StringBuilder out) {
+					let i: number = start + 1;
+					while (i < value.length() && Character.isJavaIdentifierPart(value.charAt(i))) {
+					}
+					let id: string = value.substring(start, i);
+					if ("instanceof".equals(id)) {
+						out.append(" instanceof");
+					}
+					else {
+						out.append(id);
+					}
+					return i;
+				}
+				private static final Pattern[] SEGMENT_PATTERNS = new Pattern[]{
+					Pattern.compile("\\b(class|interface|record)\\b"),
+						Pattern.compile("[^ = !<>]=[^=]"),
+					}
+					private static final Pattern ASSIGNMENT_PATTERN = Pattern.compile("[^=!<>]=[^=]");
+					private static final Pattern RETURN_PATTERN = Pattern.compile("\\breturn\\b");
+					private static final Pattern IF_PATTERN = Pattern.compile("\\bif\\s*\\(");
+					private static final Pattern WHILE_PATTERN = Pattern.compile("\\bwhile\\s*\\(");
+					private static final Pattern FOR_PATTERN = Pattern.compile("\\bfor\\s*\\(");
+					private static List<String> parseSegments(String body) {
+						let segments: List<string> = new ArrayList<>();
+						let indent: number = 0;
+						for (String line : body.split("\\R")) {
+							for (String token : line.split("(?<=[;
+							}
+								let stripped: string = token.trim();
+								if (stripped.isEmpty()) {
+								}
+								if (stripped.startsWith("}
+									indent = Math.max(0, indent - 1);
+									stripped = stripped.substring(1).trim();
+									if (stripped.isEmpty()) {
+									}
+								}
+								let seg: string = matchSegment(stripped);
+								if (seg != null) {
+									segments.add("\t".repeat(indent) + seg);
+								}
+								if (stripped.endsWith("{
+									}
+								}
+							}
+							return segments;
+						}
+						private static String matchSegment(String stripped) {
+							for (Pattern pat : SEGMENT_PATTERNS) {
+								if (pat.matcher(stripped).find()) {
+									return processSegment(stripped);
+								}
+							}
+							return null;
+						}
+						private static String processSegment(String segment) {
+							let result: string = segment;
+							if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
+								let eq: number = segment.indexOf('=');
+								if (eq != -1) {
+									let before: string = segment.substring(0, eq).trim();
+									let after: string = segment.substring(eq + 1).trim();
+									let semi: boolean = after.endsWith(";
+									if (semi) {
+										after = after.substring(0, after.length() - 1).trim();
+									}
+									let value: string = parseValue(after);
+									let declPat: var = Pattern.compile("^(?:final\\s+)?([\\w.<>\\[\\]]+)\\s+(\\w+)$");
+									let declMatch: var = declPat.matcher(before);
+									if (declMatch.find()) {
+										let type: string = tsType(declMatch.group(1));
+										let name: string = declMatch.group(2);
+										let isConst: boolean = before.startsWith("final ");
+										let kw: string = isConst ? "const" : "let";
+										result = kw + " " + name + ": " + type + " = " + value + (semi ? ";
+									}
+									else {
+										result = before + " = " + value + (semi ? ";
+									}
+									return result.replace("=>", " = >");
+								}
+							}
+							if (RETURN_PATTERN.matcher(segment).find()) {
+								let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
+								let semi: boolean = rest.endsWith(";
+								if (semi) {
+									rest = rest.substring(0, rest.length() - 1).trim();
+								}
+								if (rest.isEmpty()) {
+									return segment.replace("=>", " = >");
+								}
+								let value: string = parseValue(rest);
+								result = "return " + value + (semi ? ";
+								return result.replace("=>", " = >");
+							}
+							if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
+								let open: number = segment.indexOf('(');
+								let close: number = segment.lastIndexOf(')');
+								if (open != -1 && close != -1 && close > open) {
+									let prefix: string = segment.substring(0, open + 1);
+									let inner: string = segment.substring(open + 1, close);
+									let suffix: string = segment.substring(close);
+									let value: string = parseValue(inner);
+									result = prefix + value + suffix;
+									return result.replace("=>", " = >");
+								}
+							}
+							return result.replace("=>", " = >");
+						}
+						private static String extractBlock(String source, int start) {
+							let level: number = 1;
+							let i: number = start;
+							while (i < source.length() && level > 0) {
+								let ch: string = source.charAt(i);
+								if (ch == '{
+									}
+									else if (ch == '}
+									}
+								}
+								return source.substring(start, i - 1);
+							}
+							private static String sanitizeWildcard(String type) {
+								type = type.trim();
+								if (type.startsWith("? extends ")) {
+									return type.substring(10).trim();
+								}
+								if (type.startsWith("? super ")) {
+									return type.substring(8).trim();
+								}
+								if ("?".equals(type)) {
+									return "any";
+								}
+								return type;
+							}
 	}
 	static addMethod(list: List<string>, staticKw: string, generics: string, returnType: string, name: string, params: string, delim: string, isInterface: boolean, body: string): void {
 		let prefix: string = staticKw == null ? "" : "static ";
 		let typeParams: string = generics == null ? "" : generics.trim();
 		let paramList: string = tsParams(params);
-		if (isInterface || ";".equals(delim)) {
-		return;
-		list.add("\t" + prefix + name + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
-		let segs: List<string> = parseSegments(body);
-		if (segs.isEmpty()) {
-		for (String seg : segs) {
-		list.add("\t\t" + seg);
-		list.add("\t}");
+		if (isInterface || ";
+			return;
+		}
+			let segs: List<string> = parseSegments(body);
+			if (segs.isEmpty()) {
+			}
+			else {
+				for (String seg : segs) {
+					list.add("\t\t" + seg);
+				}
+			}
 	}
 	static tsParams(javaParams: string): string {
 		javaParams = javaParams.trim();
@@ -292,59 +402,76 @@ export class JavaFile {
 		let depth: number = 0;
 		let start: number = 0;
 		let first: boolean = true;
-		for (int i = 0; i <= javaParams.length(); i++) {
-		let atEnd: boolean = i == javaParams.length();
-		let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
-		if (atEnd || atComma) {
-		let part: string = javaParams.substring(start, i).trim();
-		first = appendParam(part, out, first);
-		start = i + 1;
-		if (javaParams.charAt(i) == '<') {
-		else if (javaParams.charAt(i) == '>') {
+		for (int i = 0;
+		i <= javaParams.length();
+			let atEnd: boolean = i == javaParams.length();
+			let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+			if (atEnd || atComma) {
+				let part: string = javaParams.substring(start, i).trim();
+				first = appendParam(part, out, first);
+				start = i + 1;
+			}
+			if (javaParams.charAt(i) == '<') {
+			}
+			else if (javaParams.charAt(i) == '>') {
+			}
+		}
 		return out.toString();
 	}
 	StringBuilder(): new;
 	static appendParam(part: string, out: StringBuilder, first: boolean): boolean {
 		if (part.isEmpty()) {
-		return first;
+			return first;
+		}
 		let last: number = part.lastIndexOf(' ');
 		if (last == -1) {
-		return first;
+			return first;
+		}
 		let type: string = part.substring(0, last).trim();
 		let name: string = part.substring(last + 1).trim();
 		if (!first) {
-		out.append(", ");
+			out.append(", ");
+		}
 		out.append(name).append(": ").append(tsType(type));
 		return false;
 	}
 	static tsType(javaType: string): string {
 		javaType = javaType.trim();
 		if (javaType.endsWith("[]")) {
-		let inner: string = javaType.substring(0, javaType.length() - 2);
-		return tsType(inner) + "[]";
+			let inner: string = javaType.substring(0, javaType.length() - 2);
+			return tsType(inner) + "[]";
+		}
 		let lt: number = javaType.indexOf('<');
 		if (lt != -1 && javaType.endsWith(">")) {
-		let base: string = javaType.substring(0, lt);
-		let args: string = javaType.substring(lt + 1, javaType.length() - 1);
-		let converted: List<string> = convertTypes(splitGenericArgs(args));
-		converted.replaceAll(JavaFile::sanitizeWildcard);
-		let simple: string = base.replace("java.util.function.", "");
-		if ("Function".equals(simple) && converted.size() >= 2) {
-		return "(arg0: " + converted.get(0) + ") = > " + converted.get(1);
-		if ("BiFunction".equals(simple) && converted.size() >= 3) {
-		return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
-		+ ") = > " + converted.get(2);
-		if ("Supplier".equals(simple) && !converted.isEmpty()) {
-		return "() = > " + converted.getFirst();
-		if ("Consumer".equals(simple) && !converted.isEmpty()) {
-		return "(arg0: " + converted.getFirst() + ") = > void";
-		if ("BiConsumer".equals(simple) && converted.size() >= 2) {
-		return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
-		+ ") = > void";
-		if ("Predicate".equals(simple) && !converted.isEmpty()) {
-		return "(arg0: " + converted.getFirst() + ") = > boolean";
-		return base + "<" + String.join(", ", converted) + ">";
+			let base: string = javaType.substring(0, lt);
+			let args: string = javaType.substring(lt + 1, javaType.length() - 1);
+			let converted: List<string> = convertTypes(splitGenericArgs(args));
+			converted.replaceAll(JavaFile::sanitizeWildcard);
+			let simple: string = base.replace("java.util.function.", "");
+			if ("Function".equals(simple) && converted.size() >= 2) {
+				return "(arg0: " + converted.get(0) + ") = > " + converted.get(1);
+			}
+			if ("BiFunction".equals(simple) && converted.size() >= 3) {
+				return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
+				+ ") = > " + converted.get(2);
+			}
+			if ("Supplier".equals(simple) && !converted.isEmpty()) {
+				return "() = > " + converted.getFirst();
+			}
+			if ("Consumer".equals(simple) && !converted.isEmpty()) {
+				return "(arg0: " + converted.getFirst() + ") = > void";
+			}
+			if ("BiConsumer".equals(simple) && converted.size() >= 2) {
+				return "(arg0: " + converted.get(0) + ", arg1: " + converted.get(1)
+				+ ") = > void";
+			}
+			if ("Predicate".equals(simple) && !converted.isEmpty()) {
+				return "(arg0: " + converted.getFirst() + ") = > boolean";
+			}
+			return base + "<" + String.join(", ", converted) + ">";
+		}
 		return switch (javaType) {
+		}
 	}
 	switch(): return {
 		return 0;
@@ -353,13 +480,18 @@ export class JavaFile {
 		let parts: List<string> = new ArrayList<>();
 		let depth: number = 0;
 		let start: number = 0;
-		for (int i = 0; i < args.length(); i++) {
-		let ch: string = args.charAt(i);
-		if (ch == '<') {
-		else if (ch == '>') {
-		else if (ch == ',' && depth == 0) {
-		parts.add(args.substring(start, i).trim());
-		start = i + 1;
+		for (int i = 0;
+		i < args.length();
+			let ch: string = args.charAt(i);
+			if (ch == '<') {
+			}
+			else if (ch == '>') {
+			}
+			else if (ch == ',' && depth == 0) {
+				parts.add(args.substring(start, i).trim());
+				start = i + 1;
+			}
+		}
 		parts.add(args.substring(start).trim());
 		return parts;
 	}
@@ -373,7 +505,8 @@ export class JavaFile {
 	static convertTypes(parts: List<string>): List<string> {
 		let converted: List<string> = new ArrayList<>();
 		for (String part : parts) {
-		converted.add(tsType(part));
+			converted.add(tsType(part));
+		}
 		return converted;
 	}
 	static parseValue(value: string): string {
@@ -381,19 +514,25 @@ export class JavaFile {
 		let out: StringBuilder = new StringBuilder();
 		let i: number = 0;
 		while (i < value.length()) {
-		let ch: string = value.charAt(i);
-		if (Character.isWhitespace(ch)) {
-		out.append(ch);
-		if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
-		out.append(" = >");
-		i + = 2;
-		if (ch == '"' || ch == '\'') {
-		i = scanStringLiteral(value, i, out);
-		if (Character.isDigit(ch)) {
-		i = scanNumberLiteral(value, i, out);
-		if (Character.isJavaIdentifierStart(ch)) {
-		i = scanIdentifier(value, i, out);
-		out.append(ch);
+			let ch: string = value.charAt(i);
+			if (Character.isWhitespace(ch)) {
+				out.append(ch);
+			}
+			if (ch == '-' && i + 1 < value.length() && value.charAt(i + 1) == '>') {
+				out.append(" = >");
+				i + = 2;
+			}
+			if (ch == '"' || ch == '\'') {
+				i = scanStringLiteral(value, i, out);
+			}
+			if (Character.isDigit(ch)) {
+				i = scanNumberLiteral(value, i, out);
+			}
+			if (Character.isJavaIdentifierStart(ch)) {
+				i = scanIdentifier(value, i, out);
+			}
+			out.append(ch);
+		}
 		return out.toString().trim();
 	}
 	StringBuilder(): new;
@@ -402,12 +541,16 @@ export class JavaFile {
 		let i: number = start + 1;
 		let esc: boolean = false;
 		while (i < value.length()) {
-		let c: string = value.charAt(i);
-		if (esc) {
-		esc = false;
-		} else if (c == '\\') {
-		esc = true;
-		} else if (c == quote) {
+			let c: string = value.charAt(i);
+			if (esc) {
+				esc = false;
+			}
+			else if (c == '\\') {
+				esc = true;
+			}
+			else if (c == quote) {
+			}
+		}
 		out.append(value, start, i);
 		return i;
 	}
@@ -422,15 +565,20 @@ export class JavaFile {
 		let exp: boolean = false;
 		let endDigits: number = start;
 		while (i < value.length()) {
-		let c: string = value.charAt(i);
-		if (c == '_' || Character.isDigit(c) || c == '.' || c == 'x' || c == 'X'
-		endDigits = i;
-		if ((c == 'e' || c == 'E') && !exp) {
-		exp = true;
-		endDigits = i;
-		if ((c == '+' || c == '-') && exp
-		endDigits = i;
-		if ("lLfFdD".indexOf(c) != -1) {
+			let c: string = value.charAt(i);
+			if (c == '_' || Character.isDigit(c) || c == '.' || c == 'x' || c == 'X'
+				endDigits = i;
+			}
+			if ((c == 'e' || c == 'E') && !exp) {
+				exp = true;
+				endDigits = i;
+			}
+			if ((c == '+' || c == '-') && exp
+				endDigits = i;
+			}
+			if ("lLfFdD".indexOf(c) != -1) {
+			}
+		}
 		let num: string = value.substring(start, endDigits).replace("_", "");
 		out.append(num);
 		return i;
@@ -438,80 +586,113 @@ export class JavaFile {
 	static scanIdentifier(value: string, start: number, out: StringBuilder): number {
 		let i: number = start + 1;
 		while (i < value.length() && Character.isJavaIdentifierPart(value.charAt(i))) {
+		}
 		let id: string = value.substring(start, i);
 		if ("instanceof".equals(id)) {
-		out.append(" instanceof");
-		out.append(id);
+			out.append(" instanceof");
+		}
+		else {
+			out.append(id);
+		}
 		return i;
 	}
 	static parseSegments(body: string): List<string> {
 		let segments: List<string> = new ArrayList<>();
+		let indent: number = 0;
 		for (String line : body.split("\\R")) {
-		let stripped: string = line.trim();
-		if (stripped.isEmpty()) {
-		let seg: string = matchSegment(stripped);
-		if (seg != null) {
-		segments.add(seg);
-		return segments;
+			for (String token : line.split("(?<=[;
+			}
+				let stripped: string = token.trim();
+				if (stripped.isEmpty()) {
+				}
+				if (stripped.startsWith("}
+					indent = Math.max(0, indent - 1);
+					stripped = stripped.substring(1).trim();
+					if (stripped.isEmpty()) {
+					}
+				}
+				let seg: string = matchSegment(stripped);
+				if (seg != null) {
+					segments.add("\t".repeat(indent) + seg);
+				}
+				if (stripped.endsWith("{
+					}
+				}
 	}
 	static matchSegment(stripped: string): string {
 		for (Pattern pat : SEGMENT_PATTERNS) {
-		if (pat.matcher(stripped).find()) {
-		return processSegment(stripped);
+			if (pat.matcher(stripped).find()) {
+				return processSegment(stripped);
+			}
+		}
 		return null;
 	}
 	processSegment(): return;
 	static processSegment(segment: string): string {
 		let result: string = segment;
 		if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
-		let eq: number = segment.indexOf('=');
-		if (eq != -1) {
-		let before: string = segment.substring(0, eq).trim();
-		let after: string = segment.substring(eq + 1).trim();
-		let semi: boolean = after.endsWith(";");
-		if (semi) {
-		after = after.substring(0, after.length() - 1).trim();
-		let value: string = parseValue(after);
-		let declPat: var = Pattern.compile("^(?:final\\s+)?([\\w.<>\\[\\]]+)\\s+(\\w+)$");
-		let declMatch: var = declPat.matcher(before);
-		if (declMatch.find()) {
-		let type: string = tsType(declMatch.group(1));
-		let name: string = declMatch.group(2);
-		let isConst: boolean = before.startsWith("final ");
-		let kw: string = isConst ? "const" : "let";
-		result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
-		result = before + " = " + value + (semi ? ";" : "");
-		return result.replace("=>", " = >");
+			let eq: number = segment.indexOf('=');
+			if (eq != -1) {
+				let before: string = segment.substring(0, eq).trim();
+				let after: string = segment.substring(eq + 1).trim();
+				let semi: boolean = after.endsWith(";
+				if (semi) {
+					after = after.substring(0, after.length() - 1).trim();
+				}
+				let value: string = parseValue(after);
+				let declPat: var = Pattern.compile("^(?:final\\s+)?([\\w.<>\\[\\]]+)\\s+(\\w+)$");
+				let declMatch: var = declPat.matcher(before);
+				if (declMatch.find()) {
+					let type: string = tsType(declMatch.group(1));
+					let name: string = declMatch.group(2);
+					let isConst: boolean = before.startsWith("final ");
+					let kw: string = isConst ? "const" : "let";
+					result = kw + " " + name + ": " + type + " = " + value + (semi ? ";
+				}
+				else {
+					result = before + " = " + value + (semi ? ";
+				}
+				return result.replace("=>", " = >");
+			}
+		}
 		if (RETURN_PATTERN.matcher(segment).find()) {
-		let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
-		let semi: boolean = rest.endsWith(";");
-		if (semi) {
-		rest = rest.substring(0, rest.length() - 1).trim();
-		if (rest.isEmpty()) {
-		return segment.replace("=>", " = >");
-		let value: string = parseValue(rest);
-		result = "return " + value + (semi ? ";" : "");
-		return result.replace("=>", " = >");
+			let rest: string = segment.substring(segment.indexOf("return") + 6).trim();
+			let semi: boolean = rest.endsWith(";
+			if (semi) {
+				rest = rest.substring(0, rest.length() - 1).trim();
+			}
+			if (rest.isEmpty()) {
+				return segment.replace("=>", " = >");
+			}
+			let value: string = parseValue(rest);
+			result = "return " + value + (semi ? ";
+			return result.replace("=>", " = >");
+		}
 		if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
-		let open: number = segment.indexOf('(');
-		let close: number = segment.lastIndexOf(')');
-		if (open != -1 && close != -1 && close > open) {
-		let prefix: string = segment.substring(0, open + 1);
-		let inner: string = segment.substring(open + 1, close);
-		let suffix: string = segment.substring(close);
-		let value: string = parseValue(inner);
-		result = prefix + value + suffix;
-		return result.replace("=>", " = >");
+			let open: number = segment.indexOf('(');
+			let close: number = segment.lastIndexOf(')');
+			if (open != -1 && close != -1 && close > open) {
+				let prefix: string = segment.substring(0, open + 1);
+				let inner: string = segment.substring(open + 1, close);
+				let suffix: string = segment.substring(close);
+				let value: string = parseValue(inner);
+				result = prefix + value + suffix;
+				return result.replace("=>", " = >");
+			}
+		}
 		return result.replace("=>", " = >");
 	}
 	static extractBlock(source: string, start: number): string {
 		let level: number = 1;
 		let i: number = start;
 		while (i < source.length() && level > 0) {
-		let ch: string = source.charAt(i);
-		if (ch == '{') {
-		else if (ch == '}') {
-		return source.substring(start, i - 1);
+			let ch: string = source.charAt(i);
+			if (ch == '{
+				}
+				else if (ch == '}
+				}
+			}
+			return source.substring(start, i - 1);
 	}
 	if('}': ch ==): else {
 		return 0;
@@ -519,11 +700,14 @@ export class JavaFile {
 	static sanitizeWildcard(type: string): string {
 		type = type.trim();
 		if (type.startsWith("? extends ")) {
-		return type.substring(10).trim();
+			return type.substring(10).trim();
+		}
 		if (type.startsWith("? super ")) {
-		return type.substring(8).trim();
+			return type.substring(8).trim();
+		}
 		if ("?".equals(type)) {
-		return "any";
+			return "any";
+		}
 		return type;
 	}
 }

--- a/src/node/magma/Main.ts
+++ b/src/node/magma/Main.ts
@@ -3,10 +3,12 @@ export class Main {
 	static main(args: string[]): void {
 		let javaRoot: PathLike = JVMPath.of("src/java");
 		let tsRoot: PathLike = JVMPath.of("src/node");
-		e.printStackTrace();
-		System.exit(1);
-		e.printStackTrace();
-		System.exit(1);
+			e.printStackTrace();
+			System.exit(1);
+		}
+			e.printStackTrace();
+			System.exit(1);
+		}
 	}
 }
 Main.main([]);

--- a/src/node/magma/Sources.ts
+++ b/src/node/magma/Sources.ts
@@ -9,7 +9,8 @@ export class Sources {
 		"(?:class|interface|record)\\s+(\\w+)",
 		let unique: Set<string> = new LinkedHashSet<>();
 		for (String src : list) {
-		unique.addAll(classesFromSource(src, pattern));
+			unique.addAll(classesFromSource(src, pattern));
+		}
 		let names: List<string> = new ArrayList<>(unique);
 		Collections.sort(names);
 		return names;
@@ -21,20 +22,23 @@ export class Sources {
 		+ "(?:class|record)\\s+(\\w+)(?:\\([^)]*\\))?"
 		let relations: List<Relation> = new ArrayList<>();
 		for (String src : list) {
-		src = src.replaceAll("<[^>]*>", "");
-		src = stripComments(src);
-		relations.addAll(inheritanceFromSource(src, extendsPattern));
-		relations.addAll(inheritanceFromSource(src, implementsPattern));
+			src = src.replaceAll("<[^>]*>", "");
+			src = stripComments(src);
+			relations.addAll(inheritanceFromSource(src, extendsPattern));
+			relations.addAll(inheritanceFromSource(src, implementsPattern));
+		}
 		return relations;
 	}
 	mapSourcesByClass(): Map<string, string> {
 		Map<String, String> map = new java.util.HashMap<>();
 		let classPattern: Pattern = Pattern.compile("(?:class|interface|record)\\s+(\\w+)");
 		for (String src : list) {
-		let stripped: string = stripComments(src);
-		let matcher: Matcher = classPattern.matcher(stripped);
-		if (matcher.find()) {
-		map.put(matcher.group(1), stripped);
+			let stripped: string = stripComments(src);
+			let matcher: Matcher = classPattern.matcher(stripped);
+			if (matcher.find()) {
+				map.put(matcher.group(1), stripped);
+			}
+		}
 		return map;
 	}
 	findDependencyRelations(classes: List<string>, inheritance: List<Relation>, implementations: Map<string, List<string>>): List<Relation> {
@@ -43,6 +47,7 @@ export class Sources {
 		let inherited: Set<string> = toInheritedSet(inheritance);
 		let relations: List<Relation> = new ArrayList<>();
 		for (String src : list) {
+		}
 		return relations;
 	}
 	findRelations(classes: List<string>, implementations: Map<string, List<string>>): List<Relation> {
@@ -57,32 +62,38 @@ export class Sources {
 		let result: Set<string> = new LinkedHashSet<>();
 		let matcher: Matcher = pattern.matcher(src);
 		while (matcher.find()) {
-		result.add(matcher.group(1));
+			result.add(matcher.group(1));
+		}
 		return result;
 	}
 	static inheritanceFromSource(src: string, pattern: Pattern): List<Relation> {
 		let result: List<Relation> = new ArrayList<>();
 		let matcher: Matcher = pattern.matcher(src);
 		while (matcher.find()) {
-		let child: string = matcher.group(1);
-		let parents: string = matcher.group(2);
-		result.addAll(parentRelations(child, parents));
+			let child: string = matcher.group(1);
+			let parents: string = matcher.group(2);
+			result.addAll(parentRelations(child, parents));
+		}
 		return result;
 	}
 	static parentRelations(child: string, parents: string): List<Relation> {
 		let relations: List<Relation> = new ArrayList<>();
 		for (String parent : parents.split(",")) {
-		parent = parent.replaceAll("<.*?>", "").trim();
-		if (!parent.isEmpty()) {
-		relations.add(new Relation(child, "--|>", parent));
+			parent = parent.replaceAll("<.*?>", "").trim();
+			if (!parent.isEmpty()) {
+				relations.add(new Relation(child, "--|>", parent));
+			}
+		}
 		return relations;
 	}
 	static parseInterfaces(parents: string): List<string> {
 		let interfaces: List<string> = new ArrayList<>();
 		for (String parent : parents.split(",")) {
-		parent = parent.replaceAll("<.*?>", "").trim();
-		if (!parent.isEmpty()) {
-		interfaces.add(parent);
+			parent = parent.replaceAll("<.*?>", "").trim();
+			if (!parent.isEmpty()) {
+				interfaces.add(parent);
+			}
+		}
 		return interfaces;
 	}
 	static stripComments(src: string): string {
@@ -96,14 +107,17 @@ export class Sources {
 	static toInheritedSet(inheritance: List<Relation>): Set<string> {
 		let set: Set<string> = new LinkedHashSet<>();
 		for (Relation rel : inheritance) {
-		set.add(rel.from() + "->" + rel.to());
+			set.add(rel.from() + "=>" + rel.to());
+		}
 		return set;
 	}
 	static containsReference(source: string, names: List<string>): boolean {
 		for (String name : names) {
-		let word: Pattern = Pattern.compile("\\b" + Pattern.quote(name) + "\\b");
-		if (word.matcher(source).find()) {
-		return true;
+			let word: Pattern = Pattern.compile("\\b" + Pattern.quote(name) + "\\b");
+			if (word.matcher(source).find()) {
+				return true;
+			}
+		}
 		return false;
 	}
 	static dependenciesForSource(src: string, classPattern: Pattern, classes: List<string>, inherited: Set<string>, sourceMap: Map<string, string>, implementations: Map<string, List<string>>): List<Relation> {
@@ -112,25 +126,33 @@ export class Sources {
 		src = stripStrings(src);
 		let matcher: Matcher = classPattern.matcher(src);
 		if (!matcher.find()) {
-		return relations;
+			return relations;
+		}
 		let name: string = matcher.group(1);
 		Map<String, List<String>> byInterface = invertImplementations(implementations);
 		for (String other : classes) {
-		if (other.equals(name)) {
-		let word: Pattern = Pattern.compile("\\b" + Pattern.quote(other) + "\\b");
-		if (!word.matcher(src).find()) {
-		if (inherited.contains(name + "->" + other)) {
-		let otherIfaces: List<string> = implementations.get(other);
-		if (otherIfaces != null && otherIfaces.contains(name)) {
-		let impls: List<string> = byInterface.get(other);
-		if (impls != null && containsReference(src, impls)) {
-		relations.add(new Relation(name, "-->", other));
+			if (other.equals(name)) {
+			}
+			let word: Pattern = Pattern.compile("\\b" + Pattern.quote(other) + "\\b");
+			if (!word.matcher(src).find()) {
+			}
+			if (inherited.contains(name + "=>" + other)) {
+			}
+			let otherIfaces: List<string> = implementations.get(other);
+			if (otherIfaces != null && otherIfaces.contains(name)) {
+			}
+			let impls: List<string> = byInterface.get(other);
+			if (impls != null && containsReference(src, impls)) {
+			}
+			relations.add(new Relation(name, "-=>", other));
+		}
 		return relations;
 	}
 	formatRelations(classes: List<string>, implementations: Map<string, List<string>>): string {
 		let builder: StringBuilder = new StringBuilder();
 		for (Relation rel : findRelations(classes, implementations)) {
-		.append(rel.to()).append("\n");
+			.append(rel.to()).append("\n");
+		}
 		return builder.toString();
 	}
 	StringBuilder(): new;

--- a/src/node/magma/Tuple.ts
+++ b/src/node/magma/Tuple.ts
@@ -1,0 +1,2 @@
+// Auto-generated from magma/Tuple.java
+export class Tuple<L, R> {}

--- a/src/node/magma/TypeScriptStubs.ts
+++ b/src/node/magma/TypeScriptStubs.ts
@@ -8,36 +8,45 @@ import { Results } from "./result/Results";
 export class TypeScriptStubs {
 	static write(javaRoot: PathLike, tsRoot: PathLike): Option<IOException> {
 		return javaRoot.walk().match(stream => {
-		let files: List<PathLike> = stream.filter(PathLike::isRegularFile)
-		.toList();
-		for (PathLike file : files) {
-		let res: Option<IOException> = processFile(javaRoot, tsRoot, file);
-		if (res.isPresent()) {
-		return res;
-		return new None<>();
+			let files: List<PathLike> = stream.filter(PathLike::isRegularFile)
+			.toList();
+			for (PathLike file : files) {
+				let res: Option<IOException> = processFile(javaRoot, tsRoot, file);
+				if (res.isPresent()) {
+					return res;
+				}
+			}
+			return new None<>();
+		}
 	}
 	static processFile(javaRoot: PathLike, tsRoot: PathLike, file: PathLike): Option<IOException> {
 		let relative: PathLike = javaRoot.relativize(file);
 		let tsFile: PathLike = tsRoot.resolve(relative.toString().replaceFirst("\\.java$", ".ts"));
 		let dirResult: var = tsFile.getParent().createDirectories();
 		if (dirResult.isPresent()) {
-		return dirResult;
+			return dirResult;
+		}
 		let jf: JavaFile = new JavaFile(file);
 		let importsRes: var = jf.imports();
 		if (importsRes.isErr()) {
-		return new Some<>(((Err<List<String>, IOException>) importsRes).error());
+			return new Some<>(((Err<List<String>, IOException>) importsRes).error());
+		}
 		let pkgRes: var = jf.packageName();
 		if (pkgRes.isErr()) {
-		return new Some<>(((Err<String, IOException>) pkgRes).error());
+			return new Some<>(((Err<String, IOException>) pkgRes).error());
+		}
 		let localRes: var = jf.localDependencies();
 		if (localRes.isErr()) {
-		return new Some<>(((Err<List<String>, IOException>) localRes).error());
+			return new Some<>(((Err<List<String>, IOException>) localRes).error());
+		}
 		let declarationsRes: var = jf.declarations();
 		if (declarationsRes.isErr()) {
-		return new Some<>(((Err<List<String>, IOException>) declarationsRes).error());
+			return new Some<>(((Err<List<String>, IOException>) declarationsRes).error());
+		}
 		let methodsRes: var = jf.methods();
 		if (methodsRes.isErr()) {
-		return new Some<>(((Err<Map<String, List<String>>, IOException>) methodsRes).error());
+			return new Some<>(((Err<Map<String, List<String>>, IOException>) methodsRes).error());
+		}
 		let imports: List<string> = Results.unwrap(importsRes);
 		let pkgName: string = Results.unwrap(pkgRes);
 		let locals: List<string> = Results.unwrap(localRes);
@@ -47,54 +56,65 @@ export class TypeScriptStubs {
 		let content: string = stubContent(relative, tsFile.getParent(), tsRoot,
 		let writeRes: var = tsFile.writeString(content);
 		if (writeRes.isPresent()) {
-		return writeRes;
+			return writeRes;
+		}
 		return new None<>();
 	}
 	JavaFile(): new;
 	static mergeLocalImports(imports: List<string>, locals: List<string>, pkgName: string): void {
 		for (String dep : locals) {
-		let fqn: string = pkgName.isEmpty() ? dep : pkgName + "." + dep;
-		if (!imports.contains(fqn)) {
-		imports.add(fqn);
+			let fqn: string = pkgName.isEmpty() ? dep : pkgName + "." + dep;
+			if (!imports.contains(fqn)) {
+				imports.add(fqn);
+			}
+		}
 	}
 	static stubContent(relative: PathLike, from: PathLike, root: PathLike, imports: List<string>, declarations: List<string>, methods: Map<string, List<string>>): string {
 		let builder: StringBuilder = new StringBuilder();
 		Map<String, List<String>> byPath = groupImports(imports, from, root);
 		appendImportLines(builder, byPath);
 		if (declarations.isEmpty()) {
-		builder.append("export {};").append(System.lineSeparator());
-		return builder.toString();
+			}
+			").append(System.lineSeparator());
+			return builder.toString();
+		}
 		appendDeclarations(builder, relative, declarations, methods);
 		return builder.toString();
 	}
 	StringBuilder(): new;
 	static appendImportLines(builder: StringBuilder, byPath: Map<string, List<string>>): void {
 		for (var entry : byPath.entrySet()) {
-		builder.append("import { ");
-		builder.append(String.join(", ", entry.getValue()));
-		builder.append(" } from \"").append(entry.getKey()).append("\"");
-		builder.append(";").append(System.lineSeparator());
+				builder.append(String.join(", ", entry.getValue()));
+				from \"").append(entry.getKey()).append("\"");
+				").append(System.lineSeparator());
+			}
 	}
 	static appendDeclarations(builder: StringBuilder, relative: PathLike, declarations: List<string>, methods: Map<string, List<string>>): void {
 		let namePattern: var = Pattern.compile("export \\w+ (\\w+)(?:<[^>]+>)?");
 		let isMain: boolean = relative.toString().replace('\\', '/').equals("magma/Main.java");
 		for (String decl : declarations) {
-		appendDeclaration(builder, decl, namePattern, methods);
+			appendDeclaration(builder, decl, namePattern, methods);
+		}
 		if (isMain) {
-		builder.append("Main.main([]);").append(System.lineSeparator());
+			builder.append("Main.main([]);
+			").append(System.lineSeparator());
+		}
 	}
 	static appendDeclaration(builder: StringBuilder, decl: string, namePattern: Pattern, methods: Map<string, List<string>>): void {
 		let m: var = namePattern.matcher(decl);
 		if (!m.find()) {
-		builder.append(decl).append(System.lineSeparator());
-		return;
+			builder.append(decl).append(System.lineSeparator());
+			return;
+		}
 		let name: string = m.group(1);
 		let mList: List<string> = methods.getOrDefault(name, Collections.emptyList());
 		if (mList.isEmpty()) {
-		builder.append(decl).append(System.lineSeparator());
-		return;
+			builder.append(decl).append(System.lineSeparator());
+			return;
+		}
 		builder.append(decl, 0, decl.length() - 1).append(System.lineSeparator());
 		for (String method : mList) {
-		builder.append(method).append(System.lineSeparator());
+			builder.append(method).append(System.lineSeparator());
+		}
 	}
 }

--- a/src/node/magma/option/None.ts
+++ b/src/node/magma/option/None.ts
@@ -1,4 +1,5 @@
 // Auto-generated from magma/option/None.java
+import { Tuple } from "../Tuple";
 import { Option } from "./Option";
 export class None<T> implements Option<T> {
 	isPresent(): boolean {
@@ -6,5 +7,17 @@ export class None<T> implements Option<T> {
 	}
 	get(): T {
 		throw new java.util.NoSuchElementException("No value present");
+	}
+	map<U>(mapper: (arg0: T) => U): Option<U> {
+		return new None<>();
+	}
+	flatMap<U>(mapper: (arg0: T) => Option<U>): Option<U> {
+		return new None<>();
+	}
+	orElse(other: Option<T>): Option<T> {
+		return other;
+	}
+	toTuple(defaultValue: T): Tuple<Boolean, T> {
+		return new Tuple<>(false, defaultValue);
 	}
 }

--- a/src/node/magma/option/Option.ts
+++ b/src/node/magma/option/Option.ts
@@ -1,6 +1,11 @@
 // Auto-generated from magma/option/Option.java
+import { Tuple } from "../Tuple";
 export interface Option<T> {
 	isPresent(): boolean;
 	get(): T;
+	map<U>(mapper: (arg0: T) => U): Option<U>;
+	flatMap<U>(mapper: (arg0: T) => Option<U>): Option<U>;
+	orElse(other: Option<T>): Option<T>;
+	toTuple(defaultValue: T): Tuple<Boolean, T>;
 	ifPresent(action: (arg0: T) => void): void;
 }

--- a/src/node/magma/option/Some.ts
+++ b/src/node/magma/option/Some.ts
@@ -1,4 +1,5 @@
 // Auto-generated from magma/option/Some.java
+import { Tuple } from "../Tuple";
 import { Option } from "./Option";
 export class Some<T> implements Option<T> {
 	isPresent(): boolean {
@@ -6,5 +7,17 @@ export class Some<T> implements Option<T> {
 	}
 	get(): T {
 		return value;
+	}
+	map<U>(mapper: (arg0: T) => U): Option<U> {
+		return new Some<>(mapper.apply(value));
+	}
+	flatMap<U>(mapper: (arg0: T) => Option<U>): Option<U> {
+		return mapper.apply(value);
+	}
+	orElse(other: Option<T>): Option<T> {
+		return this;
+	}
+	toTuple(defaultValue: T): Tuple<Boolean, T> {
+		return new Tuple<>(true, value);
 	}
 }

--- a/src/node/magma/result/Results.ts
+++ b/src/node/magma/result/Results.ts
@@ -2,7 +2,8 @@
 export class Results {
 	static unwrap<T, X extends Exception>(result: Result<T, X>): T {
 		if (result.isOk()) {
-		return ((Ok<T, X>) result).value();
+			return ((Ok<T, X>) result).value();
+		}
 		Err<T, X> err = (Err<T, X>) result;
 		throw new RuntimeException(err.error());
 	}

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -325,7 +325,8 @@ public class TypeScriptStubsTest {
         }
 
         writeSource(javaRoot, "test/A.java",
-                "package test;\npublic class A { int foo(){ int x=1; bar(); return x; } void bar(){} }\n");
+                "package test;\n" +
+                "public class A { int foo(){ int x=1; if(x>0){ bar(); } else { baz(); } return x; } void bar(){} void baz(){} }\n");
 
         Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
         result.ifPresent(e -> { throw new RuntimeException(e); });
@@ -337,5 +338,20 @@ public class TypeScriptStubsTest {
         PathLike tsRoot = generateSegmentStubs();
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
         assertTrue(a.contains("let x: number = 1;"));
+    }
+
+    @Test
+    public void splitsStatementsAcrossLines() {
+        PathLike tsRoot = generateSegmentStubs();
+        String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
+        String expected = "let x: number = 1;" + System.lineSeparator()
+                + "\t\tif(x>0){" + System.lineSeparator()
+                + "\t\t\tbar();" + System.lineSeparator()
+                + "\t\t}" + System.lineSeparator()
+                + "\t\telse {" + System.lineSeparator()
+                + "\t\t\tbaz();" + System.lineSeparator()
+                + "\t\t}" + System.lineSeparator()
+                + "\t\treturn x;";
+        assertTrue(a.contains(expected));
     }
 }


### PR DESCRIPTION
## Summary
- break up Java statements when generating TypeScript stubs
- indent generated blocks based on braces
- handle `else` blocks when splitting statements
- test that multi-statement bodies are split into separate lines
- regenerate TypeScript

## Testing
- `./test.sh`
- `./run.sh` *(fails: `Cannot run program "/opt/local/bin/dot"`)*

------
https://chatgpt.com/codex/tasks/task_e_6841dc5d7ff48321bd40bc6e8e2187db