### PR TITLE
Fix boxed primitive ts conversion

### DIFF
--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -332,9 +332,13 @@ public record JavaFile(PathLike file) {
             return base + "<" + String.join(", ", converted) + ">";
         }
         return switch (javaType) {
-            case "byte", "short", "int", "long", "float", "double" -> "number";
-            case "boolean" -> "boolean";
-            case "char", "String" -> "string";
+            case "byte", "short", "int", "long", "float", "double",
+                    "Byte", "Short", "Integer", "Long", "Float", "Double",
+                    "java.lang.Byte", "java.lang.Short", "java.lang.Integer",
+                    "java.lang.Long", "java.lang.Float", "java.lang.Double" -> "number";
+            case "boolean", "Boolean", "java.lang.Boolean" -> "boolean";
+            case "char", "Character", "java.lang.Character",
+                    "String", "java.lang.String" -> "string";
             default -> javaType;
         };
     }

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -204,6 +204,22 @@ public class TypeScriptStubsTest {
     }
 
     @Test
+    public void convertsBoxedPrimitives() {
+        PathLike javaRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("java")));
+        PathLike tsRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("ts")));
+
+        writeSource(javaRoot, "test/A.java",
+                "package test;\n" +
+                "public class A { Integer add(Integer x, Boolean flag){return 0;} }\n");
+
+        Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
+        result.ifPresent(e -> fail(e));
+
+        String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
+        assertTrue(a.contains("add(x: number, flag: boolean): number {"));
+    }
+
+    @Test
     public void preservesParameterTypes() {
         PathLike javaRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("java")));
         PathLike tsRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("ts")));


### PR DESCRIPTION
## Summary
- update tsType to treat boxed Java primitives like their primitive forms
- add test verifying boxed Integer/Boolean conversion

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841e12cb9bc8321ababe3f232f823cf