### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For convenience there are helper scripts at the repository root:
 ./build.sh   # compile the Java sources
 ./run.sh     # run the program (builds automatically if needed)
 ./test.sh    # execute the JUnit test suite
+./render-diagram.sh  # regenerate diagram.png from diagram.puml
 ```
 
 Running the program creates a `diagram.puml` file in the repository root and

--- a/docs/build.md
+++ b/docs/build.md
@@ -9,8 +9,9 @@ compiles all `*.java` files under the `src` directory:
 
 The script simply compiles the Java sources into the `out` directory. After
 building you can manually run `Main` to create the TypeScript stubs
-and update `diagram.puml`. If you want to check that the generated TypeScript
-files compile, execute:
+and update `diagram.puml`. If you modify the diagram manually, run
+`./render-diagram.sh` to regenerate the image. If you want to check that the
+generated TypeScript files compile, execute:
 
 ```bash
 npm run check-ts

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,13 @@ Run the program using the provided helper script:
 `magma.Main`. After execution it converts `diagram.puml` to `diagram.png`
 using PlantUML.
 
+To re-render `diagram.png` without running the whole program again,
+use the helper script:
+
+```bash
+./render-diagram.sh
+```
+
 Executing the program creates a file named `diagram.puml` in the repository
 root. The file contains a PlantUML diagram describing the discovered classes and
 their relationships. The diagram uses `skinparam linetype ortho` for clearer


### PR DESCRIPTION
## Summary
- mention render-diagram.sh in README helper scripts
- document how to re-render the PlantUML diagram in usage and build docs

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841e3d36588832183c0d8d25542158c