### PR TITLE
Handle record components as fields in stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The project is an early experiment for a future Magma compiler pipeline.
   orthogonal line routing
 - Renders `diagram.puml` to `diagram.png` using PlantUML
 - Produces TypeScript stubs mirroring the Java hierarchy
+- Record components become fields in the generated class constructor
 - Provides build, run and test helper scripts
 - Includes a simple `Result` type for functional-style error handling
 - Provides a minimal `Option` type (`Some`/`None`) instead of relying on

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,8 @@
 ## Features
 
 - Parses Java sources to find classes, interfaces and records
+- Treats records as classes and converts record components into fields with a
+  generated constructor
 - Detects inheritance and dependency relationships
 - Generates a PlantUML diagram summarizing the relations with
   orthogonal line routing

--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -19,6 +19,9 @@ import java.util.regex.Pattern;
  */
 public record JavaFile(PathLike file) {
 
+    /** Simple container for a record component. */
+    private static record Param(String name, String tsType) {}
+
     public Result<List<String>, IOException> imports() {
         var sourceRes = file.readString();
         if (sourceRes.isErr()) {
@@ -181,6 +184,30 @@ public record JavaFile(PathLike file) {
             String body = extractClassBody(source, start);
             boolean isInterface = "interface".equals(kind);
             List<String> list = parseMethods(body, name, isInterface);
+
+            if ("record".equals(kind)) {
+                String header = source.substring(cMatcher.start(), start - 1);
+                int lp = header.indexOf('(');
+                int rp = header.indexOf(')', lp);
+                if (lp != -1 && rp != -1 && rp > lp + 1) {
+                    String params = header.substring(lp + 1, rp).trim();
+                    if (!params.isEmpty()) {
+                        List<Param> fields = parseRecordParams(params);
+                        List<String> all = new ArrayList<>();
+                        for (Param p : fields) {
+                            all.add("\t" + p.name + ": " + p.tsType + ";");
+                        }
+                        all.add("\tconstructor(" + tsParams(params) + ") {");
+                        for (Param p : fields) {
+                            all.add("\t\tthis." + p.name + " = " + p.name + ";");
+                        }
+                        all.add("\t}");
+                        all.addAll(list);
+                        list = all;
+                    }
+                }
+            }
+
             map.put(name, list);
         }
         return new Ok<>(map);
@@ -294,6 +321,36 @@ public record JavaFile(PathLike file) {
         }
         out.append(name).append(": ").append(tsType(type));
         return false;
+    }
+
+    private static List<Param> parseRecordParams(String javaParams) {
+        javaParams = javaParams.trim();
+        List<Param> list = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i <= javaParams.length(); i++) {
+            boolean atEnd = i == javaParams.length();
+            boolean atComma = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+            if (atEnd || atComma) {
+                String part = javaParams.substring(start, i).trim();
+                if (!part.isEmpty()) {
+                    int last = part.lastIndexOf(' ');
+                    if (last != -1) {
+                        String type = part.substring(0, last).trim();
+                        String name = part.substring(last + 1).trim();
+                        list.add(new Param(name, tsType(type)));
+                    }
+                }
+                start = i + 1;
+                continue;
+            }
+            if (javaParams.charAt(i) == '<') {
+                depth++;
+            } else if (javaParams.charAt(i) == '>') {
+                depth--;
+            }
+        }
+        return list;
     }
 
     static String tsType(String javaType) {

--- a/src/node/magma/JVMPath.ts
+++ b/src/node/magma/JVMPath.ts
@@ -7,6 +7,10 @@ import { Ok } from "./result/Ok";
 import { Result } from "./result/Result";
 import { PathLike } from "./PathLike";
 export class JVMPath implements PathLike {
+	path: Path;
+	constructor(path: Path) {
+		this.path = path;
+	}
 	static of(first: string, more: String...): PathLike {
 		return new JVMPath(Path.of(first, more));
 	}

--- a/src/node/magma/JavaFile.ts
+++ b/src/node/magma/JavaFile.ts
@@ -3,6 +3,13 @@ import { Err } from "./result/Err";
 import { Ok } from "./result/Ok";
 import { Result } from "./result/Result";
 export class JavaFile {
+	file: PathLike;
+	constructor(file: PathLike) {
+		this.file = file;
+	}
+	static Param(name: string, tsType: string): record {
+		return 0;
+	}
 	packageName(): Result<string, IOException> {
 		return file.readString().mapValue(source => {
 			let pattern: var = Pattern.compile("^package\\s+([\\w.]+);
@@ -113,6 +120,34 @@ export class JavaFile {
 					}
 					out.append(name).append(": ").append(tsType(type));
 					return false;
+				}
+				private static List<Param> parseRecordParams(String javaParams) {
+					javaParams = javaParams.trim();
+					let list: List<Param> = new ArrayList<>();
+					let depth: number = 0;
+					let start: number = 0;
+					for (int i = 0;
+					i <= javaParams.length();
+						let atEnd: boolean = i == javaParams.length();
+						let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+						if (atEnd || atComma) {
+							let part: string = javaParams.substring(start, i).trim();
+							if (!part.isEmpty()) {
+								let last: number = part.lastIndexOf(' ');
+								if (last != -1) {
+									let type: string = part.substring(0, last).trim();
+									let name: string = part.substring(last + 1).trim();
+									list.add(new Param(name, tsType(type)));
+								}
+							}
+							start = i + 1;
+						}
+						if (javaParams.charAt(i) == '<') {
+						}
+						else if (javaParams.charAt(i) == '>') {
+						}
+					}
+					return list;
 				}
 				static String tsType(String javaType) {
 					javaType = javaType.trim();
@@ -258,6 +293,34 @@ export class JavaFile {
 		}
 		out.append(name).append(": ").append(tsType(type));
 		return false;
+	}
+	static parseRecordParams(javaParams: string): List<Param> {
+		javaParams = javaParams.trim();
+		let list: List<Param> = new ArrayList<>();
+		let depth: number = 0;
+		let start: number = 0;
+		for (int i = 0;
+		i <= javaParams.length();
+			let atEnd: boolean = i == javaParams.length();
+			let atComma: boolean = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+			if (atEnd || atComma) {
+				let part: string = javaParams.substring(start, i).trim();
+				if (!part.isEmpty()) {
+					let last: number = part.lastIndexOf(' ');
+					if (last != -1) {
+						let type: string = part.substring(0, last).trim();
+						let name: string = part.substring(last + 1).trim();
+						list.add(new Param(name, tsType(type)));
+					}
+				}
+				start = i + 1;
+			}
+			if (javaParams.charAt(i) == '<') {
+			}
+			else if (javaParams.charAt(i) == '>') {
+			}
+		}
+		return list;
 	}
 	static tsType(javaType: string): string {
 		javaType = javaType.trim();

--- a/src/node/magma/Relation.ts
+++ b/src/node/magma/Relation.ts
@@ -1,2 +1,11 @@
 // Auto-generated from magma/Relation.java
-export class Relation {}
+export class Relation {
+	from: string;
+	arrow: string;
+	to: string;
+	constructor(from: string, arrow: string, to: string) {
+		this.from = from;
+		this.arrow = arrow;
+		this.to = to;
+	}
+}

--- a/src/node/magma/Sources.ts
+++ b/src/node/magma/Sources.ts
@@ -4,6 +4,10 @@ import { Ok } from "./result/Ok";
 import { Result } from "./result/Result";
 import { PathLike } from "./PathLike";
 export class Sources {
+	list: List<string>;
+	constructor(list: List<string>) {
+		this.list = list;
+	}
 	findClasses(): List<string> {
 		let pattern: Pattern = Pattern.compile(
 		"(?:class|interface|record)\\s+(\\w+)",

--- a/src/node/magma/Tuple.ts
+++ b/src/node/magma/Tuple.ts
@@ -1,2 +1,9 @@
 // Auto-generated from magma/Tuple.java
-export class Tuple<L, R> {}
+export class Tuple<L, R> {
+	left: L;
+	right: R;
+	constructor(left: L, right: R) {
+		this.left = left;
+		this.right = right;
+	}
+}

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -114,7 +114,27 @@ public class TypeScriptStubsTest {
     public void copiesRecordDeclaration() {
         PathLike tsRoot = generateGenericStubs();
         String r = Results.unwrap(tsRoot.resolve("test/R.ts").readString());
-        assertTrue(r.contains("export class R<T> {}"));
+        assertTrue(r.contains("export class R<T> {"));
+        assertTrue(r.contains("x: T;"));
+        assertTrue(r.contains("constructor(x: T)"));
+    }
+
+    @Test
+    public void processesRecordParameters() {
+        PathLike javaRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("java")));
+        PathLike tsRoot = new JVMPath(assertDoesNotThrow(() -> Files.createTempDirectory("ts")));
+
+        writeSource(javaRoot, "test/R.java",
+                "package test;\npublic record R(int id, String name) {}\n");
+
+        Option<IOException> result = TypeScriptStubs.write(javaRoot, tsRoot);
+        result.ifPresent(e -> fail(e));
+
+        String r = Results.unwrap(tsRoot.resolve("test/R.ts").readString());
+        assertTrue(r.contains("id: number;"), "R.ts missing id field");
+        assertTrue(r.contains("name: string;"), "R.ts missing name field");
+        assertTrue(r.contains("constructor(id: number, name: string)"), "R.ts missing constructor");
+        assertTrue(r.contains("this.id = id"), "R.ts missing id assignment");
     }
 
     private PathLike generateMethodStubs() {


### PR DESCRIPTION
## Summary
- generate constructor and fields for record components
- clarify record handling in docs
- add unit test for record parameters
- regenerate node stubs for updated logic

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841e6f0cdc883219a87be94a5aa4904