### PR TITLE
Add symbol validation in parser

### DIFF
--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.regex.Pattern;
 
 /**
@@ -181,9 +183,17 @@ public record JavaFile(PathLike file) {
             String kind = cMatcher.group(1);
             String name = cMatcher.group(2);
             int start = cMatcher.end();
-            String body = extractClassBody(source, start);
+            var bodyRes = extractClassBody(source, start);
+            if (bodyRes.isErr()) {
+                return new Err<>(((Err<String, IOException>) bodyRes).error());
+            }
+            String body = ((Ok<String, IOException>) bodyRes).value();
             boolean isInterface = "interface".equals(kind);
-            List<String> list = parseMethods(body, name, isInterface);
+            var methodsRes = parseMethods(body, name, isInterface);
+            if (methodsRes.isErr()) {
+                return new Err<>(((Err<List<String>, IOException>) methodsRes).error());
+            }
+            List<String> list = ((Ok<List<String>, IOException>) methodsRes).value();
 
             if ("record".equals(kind)) {
                 String header = source.substring(cMatcher.start(), start - 1);
@@ -213,7 +223,7 @@ public record JavaFile(PathLike file) {
         return new Ok<>(map);
     }
 
-    private static String extractClassBody(String source, int start) {
+    private static Result<String, IOException> extractClassBody(String source, int start) {
         int level = 1;
         int i = start;
         while (i < source.length() && level > 0) {
@@ -226,10 +236,13 @@ public record JavaFile(PathLike file) {
             }
             i++;
         }
-        return source.substring(start, i - 1);
+        if (level != 0) {
+            return new Err<>(new ParseException("missing '}'"));
+        }
+        return new Ok<>(source.substring(start, i - 1));
     }
 
-    private static List<String> parseMethods(String body, String className, boolean isInterface) {
+    private static Result<List<String>, IOException> parseMethods(String body, String className, boolean isInterface) {
         var methodPat = Pattern.compile(
                 "(?:public\\s+|protected\\s+|private\\s+)?(static\\s+)?(?:final\\s+)?(<[^>]+>\\s+)?([\\w.]+(?:<[^>]+>)?(?:\\[\\])*)\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*(\\{|;)");
         var mMatcher = methodPat.matcher(body);
@@ -243,9 +256,13 @@ public record JavaFile(PathLike file) {
             String methodBody = "";
             if ("{".equals(delim)) {
                 int start = mMatcher.end();
-                methodBody = extractBlock(body, start);
+                var blockRes = extractBlock(body, start);
+                if (blockRes.isErr()) {
+                    return new Err<>(((Err<String, IOException>) blockRes).error());
+                }
+                methodBody = ((Ok<String, IOException>) blockRes).value();
             }
-            addMethod(list,
+            var addRes = addMethod(list,
                     mMatcher.group(1),
                     mMatcher.group(2),
                     mMatcher.group(3),
@@ -254,11 +271,14 @@ public record JavaFile(PathLike file) {
                     delim,
                     isInterface,
                     methodBody);
+            if (addRes.isErr()) {
+                return new Err<>(((Err<Void, IOException>) addRes).error());
+            }
         }
-        return list;
+        return new Ok<>(list);
     }
 
-    private static void addMethod(List<String> list, String staticKw, String generics,
+    private static Result<Void, IOException> addMethod(List<String> list, String staticKw, String generics,
                                   String returnType, String name, String params,
                                   String delim, boolean isInterface,
                                   String body) {
@@ -267,10 +287,16 @@ public record JavaFile(PathLike file) {
         String paramList = tsParams(params);
         if (isInterface || ";".equals(delim)) {
             list.add("\t" + prefix + name + typeParams + "(" + paramList + "): " + tsType(returnType) + ";");
-            return;
+            return new Ok<>(null);
         }
         list.add("\t" + prefix + name + typeParams + "(" + paramList + "): " + tsType(returnType) + " {");
-        List<String> segs = MethodBodyParser.parseSegments(body);
+        Set<String> defined = new HashSet<>(paramNames(params));
+        defined.add("this");
+        var segRes = MethodBodyParser.parseSegments(body, defined);
+        if (segRes.isErr()) {
+            return new Err<>(((Err<List<String>, IOException>) segRes).error());
+        }
+        List<String> segs = ((Ok<List<String>, IOException>) segRes).value();
         if (segs.isEmpty()) {
             list.add("\t\treturn 0;");
         } else {
@@ -279,6 +305,7 @@ public record JavaFile(PathLike file) {
             }
         }
         list.add("\t}");
+        return new Ok<>(null);
     }
 
     private static String tsParams(String javaParams) {
@@ -321,6 +348,36 @@ public record JavaFile(PathLike file) {
         }
         out.append(name).append(": ").append(tsType(type));
         return false;
+    }
+
+    private static List<String> paramNames(String javaParams) {
+        javaParams = javaParams.trim();
+        List<String> names = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i <= javaParams.length(); i++) {
+            boolean atEnd = i == javaParams.length();
+            boolean atComma = !atEnd && javaParams.charAt(i) == ',' && depth == 0;
+            if (atEnd || atComma) {
+                String part = javaParams.substring(start, i).trim();
+                if (!part.isEmpty()) {
+                    int last = part.lastIndexOf(' ');
+                    if (last != -1) {
+                        String name = part.substring(last + 1).trim();
+                        names.add(name);
+                    }
+                }
+                start = i + 1;
+                continue;
+            }
+            if (javaParams.charAt(i) == '<') {
+                depth++;
+            }
+            else if (javaParams.charAt(i) == '>') {
+                depth--;
+            }
+        }
+        return names;
     }
 
     private static List<Param> parseRecordParams(String javaParams) {
@@ -430,7 +487,7 @@ public record JavaFile(PathLike file) {
     }
 
 
-    private static String extractBlock(String source, int start) {
+    private static Result<String, IOException> extractBlock(String source, int start) {
         int level = 1;
         int i = start;
         while (i < source.length() && level > 0) {
@@ -443,7 +500,10 @@ public record JavaFile(PathLike file) {
             }
             i++;
         }
-        return source.substring(start, i - 1);
+        if (level != 0) {
+            return new Err<>(new ParseException("missing '}'"));
+        }
+        return new Ok<>(source.substring(start, i - 1));
     }
 
     private static String sanitizeWildcard(String type) {

--- a/src/java/magma/MethodBodyParser.java
+++ b/src/java/magma/MethodBodyParser.java
@@ -3,12 +3,19 @@ package magma;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.io.IOException;
+
+import magma.result.Err;
+import magma.result.Ok;
+import magma.result.Result;
+
+import java.util.Set;
 
 final class MethodBodyParser {
     private MethodBodyParser() {
     }
 
-    static List<String> parseSegments(String body) {
+    static Result<List<String>, IOException> parseSegments(String body, Set<String> defined) {
         List<String> segments = new ArrayList<>();
         int indent = 0;
         for (String token : tokens(body)) {
@@ -24,7 +31,11 @@ final class MethodBodyParser {
                     continue;
                 }
             }
-            String seg = matchSegment(stripped);
+            var segRes = matchSegment(stripped, defined);
+            if (segRes.isErr()) {
+                return new Err<>(((Err<String, IOException>) segRes).error());
+            }
+            String seg = ((Ok<String, IOException>) segRes).value();
             if (seg != null) {
                 segments.add("\t".repeat(indent) + seg);
             }
@@ -32,7 +43,7 @@ final class MethodBodyParser {
                 indent++;
             }
         }
-        return segments;
+        return new Ok<>(segments);
     }
 
     private static List<String> tokens(String body) {
@@ -51,16 +62,16 @@ final class MethodBodyParser {
         return parts;
     }
 
-    private static String matchSegment(String stripped) {
+    private static Result<String, IOException> matchSegment(String stripped, Set<String> defined) {
         for (Pattern pat : SEGMENT_PATTERNS) {
             if (pat.matcher(stripped).find()) {
-                return processSegment(stripped);
+                return processSegment(stripped, defined);
             }
         }
-        return null;
+        return new Ok<>(null);
     }
 
-    private static String processSegment(String segment) {
+    private static Result<String, IOException> processSegment(String segment, Set<String> defined) {
         String result = segment;
         if (ASSIGNMENT_PATTERN.matcher(segment).find()) {
             int eq = segment.indexOf('=');
@@ -71,8 +82,6 @@ final class MethodBodyParser {
                 if (semi) {
                     after = after.substring(0, after.length() - 1).trim();
                 }
-                String value = parseValue(after);
-
                 var declPat = Pattern.compile("^(?:final\\s+)?([\\w.<>\\[\\]]+)\\s+(\\w+)$");
                 var declMatch = declPat.matcher(before);
                 if (declMatch.find()) {
@@ -80,11 +89,22 @@ final class MethodBodyParser {
                     String name = declMatch.group(2);
                     boolean isConst = before.startsWith("final ");
                     String kw = isConst ? "const" : "let";
+                    defined.add(name);
+                    var valRes = parseValue(after, defined);
+                    if (valRes.isErr()) {
+                        return new Err<>(((Err<String, IOException>) valRes).error());
+                    }
+                    String value = ((Ok<String, IOException>) valRes).value();
                     result = kw + " " + name + ": " + type + " = " + value + (semi ? ";" : "");
                 } else {
+                    var valRes = parseValue(after, defined);
+                    if (valRes.isErr()) {
+                        return new Err<>(((Err<String, IOException>) valRes).error());
+                    }
+                    String value = ((Ok<String, IOException>) valRes).value();
                     result = before + " = " + value + (semi ? ";" : "");
                 }
-                return result.replace("->", "=>");
+                return new Ok<>(result.replace("->", "=>"));
             }
         }
         if (RETURN_PATTERN.matcher(segment).find()) {
@@ -94,11 +114,15 @@ final class MethodBodyParser {
                 rest = rest.substring(0, rest.length() - 1).trim();
             }
             if (rest.isEmpty()) {
-                return segment.replace("->", "=>");
+                return new Ok<>(segment.replace("->", "=>"));
             }
-            String value = parseValue(rest);
+            var valRes = parseValue(rest, defined);
+            if (valRes.isErr()) {
+                return new Err<>(((Err<String, IOException>) valRes).error());
+            }
+            String value = ((Ok<String, IOException>) valRes).value();
             result = "return " + value + (semi ? ";" : "");
-            return result.replace("->", "=>");
+            return new Ok<>(result.replace("->", "=>"));
         }
         if (IF_PATTERN.matcher(segment).find() || WHILE_PATTERN.matcher(segment).find() || FOR_PATTERN.matcher(segment).find()) {
             int open = segment.indexOf('(');
@@ -107,15 +131,19 @@ final class MethodBodyParser {
                 String prefix = segment.substring(0, open + 1);
                 String inner = segment.substring(open + 1, close);
                 String suffix = segment.substring(close);
-                String value = parseValue(inner);
+                var valRes = parseValue(inner, defined);
+                if (valRes.isErr()) {
+                    return new Err<>(((Err<String, IOException>) valRes).error());
+                }
+                String value = ((Ok<String, IOException>) valRes).value();
                 result = prefix + value + suffix;
-                return result.replace("->", "=>");
+                return new Ok<>(result.replace("->", "=>"));
             }
         }
-        return result.replace("->", "=>");
+        return new Ok<>(result.replace("->", "=>"));
     }
 
-    private static String parseValue(String value) {
+    private static Result<String, IOException> parseValue(String value, Set<String> defined) {
         value = value.replace("->", "=>");
         StringBuilder out = new StringBuilder();
         int i = 0;
@@ -140,13 +168,17 @@ final class MethodBodyParser {
                 continue;
             }
             if (Character.isJavaIdentifierStart(ch)) {
-                i = scanIdentifier(value, i, out);
+                var idxRes = scanIdentifier(value, i, out, defined);
+                if (idxRes.isErr()) {
+                    return new Err<>(((Err<Integer, IOException>) idxRes).error());
+                }
+                i = ((Ok<Integer, IOException>) idxRes).value();
                 continue;
             }
             out.append(ch);
             i++;
         }
-        return out.toString().trim();
+        return new Ok<>(out.toString().trim());
     }
 
     private static int scanStringLiteral(String value, int start, StringBuilder out) {
@@ -204,7 +236,7 @@ final class MethodBodyParser {
         return i;
     }
 
-    private static int scanIdentifier(String value, int start, StringBuilder out) {
+    private static Result<Integer, IOException> scanIdentifier(String value, int start, StringBuilder out, Set<String> defined) {
         int i = start + 1;
         while (i < value.length() && Character.isJavaIdentifierPart(value.charAt(i))) {
             i++;
@@ -212,11 +244,27 @@ final class MethodBodyParser {
         String id = value.substring(start, i);
         if ("instanceof".equals(id)) {
             out.append("/* FIXME: instanceof */ instanceof");
-        } else {
-            out.append(id);
+            return new Ok<>(i);
         }
-        return i;
+        out.append(id);
+        if (!KEYWORDS.contains(id) && !defined.contains(id)) {
+            int prev = start - 1;
+            while (prev >= 0 && Character.isWhitespace(value.charAt(prev))) {
+                prev--;
+            }
+            char prevCh = prev >= 0 ? value.charAt(prev) : '\0';
+            char nextCh = i < value.length() ? value.charAt(i) : '\0';
+            if (prevCh != '.' && nextCh != '(') {
+                return new Err<>(new ParseException("undefined symbol: " + id));
+            }
+        }
+        return new Ok<>(i);
     }
+
+    private static final Set<String> KEYWORDS = Set.of(
+            "return", "if", "else", "for", "while", "do", "switch", "case",
+            "break", "continue", "new", "null", "true", "false", "this", "super"
+    );
 
     private static final Pattern[] SEGMENT_PATTERNS = new Pattern[]{
         Pattern.compile("\\b(class|interface|record)\\b"),

--- a/src/java/magma/ParseException.java
+++ b/src/java/magma/ParseException.java
@@ -1,0 +1,10 @@
+package magma;
+
+import java.io.IOException;
+
+/** Exception representing parsing errors. */
+public class ParseException extends IOException {
+    public ParseException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- return Result from `MethodBodyParser.parseSegments`
- check identifiers against a defined-symbol table
- propagate parsing errors in `JavaFile`

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841f22b0008832196fe6ad9549c86ac