### PR TITLE
Remove obsolete package declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ The repository includes a small demonstration of a Java → Magma compiler. The 
 `src/magma/Main.java` reads its own source, rewrites Java-style import statements into the
 Magma form `import Child from parent.Child.`, and writes the result to `src/magma/Main.mgs`.
 
+Unlike Java, Magma does not use package declarations. Consequently the example
+`Main.java` and the generated `Main.mgs` start directly with their import
+statements.
+

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -1,5 +1,3 @@
-package magma;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/magma/Main.mgs
+++ b/src/magma/Main.mgs
@@ -1,5 +1,3 @@
-package magma;
-
 import Files from java.nio.file.Files.
 import Path from java.nio.file.Path.
 import Paths from java.nio.file.Paths.


### PR DESCRIPTION
## Summary
- drop `package magma` lines in example source and generated Magma code
- note lack of package statements in README

## Testing
- `javac src/magma/Main.java`

------
https://chatgpt.com/codex/tasks/task_e_68425beed77c832191a8636079ff3a3a