### PR TITLE
Remove throws clause from example main method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Unlike Java, Magma does not use package declarations. Consequently the example
 `Main.java` and the generated `Main.mgs` start directly with their import
 statements.
 
+The example's `main` method no longer declares `throws Exception`.
+
 Magma classes are defined using the `class def` syntax. For example
 `class def MyType() => {}` defines a class named `MyType` with an empty body.
 

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -1,3 +1,4 @@
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -5,26 +6,30 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Main {
-    public static void main() throws Exception {
-        Path source = Paths.get("src/magma/Main.java");
-        Path target = Paths.get("src/magma/Main.mgs");
+    public static void main() {
+        try {
+            Path source = Paths.get("src/magma/Main.java");
+            Path target = Paths.get("src/magma/Main.mgs");
 
-        String content = Files.readString(source);
-        Pattern pattern = Pattern.compile("import\\s+([\\w\\.]+);", Pattern.MULTILINE);
-        Matcher matcher = pattern.matcher(content);
-        StringBuffer sb = new StringBuffer();
-        while (matcher.find()) {
-            String full = matcher.group(1);
-            int last = full.lastIndexOf('.');
-            String cls = full.substring(last + 1);
-            String replacement = "import " + cls + " from " + full + ";";
-            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            String content = Files.readString(source);
+            Pattern pattern = Pattern.compile("import\\s+([\\w\\.]+);", Pattern.MULTILINE);
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer sb = new StringBuffer();
+            while (matcher.find()) {
+                String full = matcher.group(1);
+                int last = full.lastIndexOf('.');
+                String cls = full.substring(last + 1);
+                String replacement = "import " + cls + " from " + full + ";";
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(sb);
+
+            String replaced = sb.toString()
+                    .replaceFirst("public\\s+class\\s+(\\w+)\\s*\\{", "class def $1() => {");
+
+            Files.writeString(target, replaced);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-        matcher.appendTail(sb);
-
-        String replaced = sb.toString()
-                .replaceFirst("public\\s+class\\s+(\\w+)\\s*\\{", "class def $1() => {");
-
-        Files.writeString(target, replaced);
     }
 }

--- a/src/magma/Main.mgs
+++ b/src/magma/Main.mgs
@@ -5,23 +5,27 @@ import Matcher from java.util.regex.Matcher.
 import Pattern from java.util.regex.Pattern.
 
 class def Main() => {
-    public static void main() throws Exception {
-        Path source = Paths.get("src/magma/Main.java");
-        Path target = Paths.get("src/magma/Main.mgs");
+    public static void main() {
+        try {
+            Path source = Paths.get("src/magma/Main.java");
+            Path target = Paths.get("src/magma/Main.mgs");
 
-        String content = Files.readString(source);
-        Pattern pattern = Pattern.compile("import\\s+([\\w\\.]+);", Pattern.MULTILINE);
-        Matcher matcher = pattern.matcher(content);
-        StringBuffer sb = new StringBuffer();
-        while (matcher.find()) {
-            String full = matcher.group(1);
-            int last = full.lastIndexOf('.');
-            String cls = full.substring(last + 1);
-            String replacement = "import " + cls + " from " + full + ";";
-            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            String content = Files.readString(source);
+            Pattern pattern = Pattern.compile("import\\s+([\\w\\.]+);", Pattern.MULTILINE);
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer sb = new StringBuffer();
+            while (matcher.find()) {
+                String full = matcher.group(1);
+                int last = full.lastIndexOf('.');
+                String cls = full.substring(last + 1);
+                String replacement = "import " + cls + " from " + full + ";";
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(sb);
+
+            Files.writeString(target, sb.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        matcher.appendTail(sb);
-
-        Files.writeString(target, sb.toString());
     }
 }


### PR DESCRIPTION
## Summary
- drop `throws Exception` from the example `main` method
- wrap file operations in `try/catch`
- update generated Magma file accordingly
- mention the change in README

## Testing
- `javac src/magma/Main.java`

------
https://chatgpt.com/codex/tasks/task_e_68425e2aaa9883219c2c23fb0f8388dd