### PR TITLE
Fix TypeParam resolution within record parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ independent jobs so failures in either stage are reported clearly.
 ## Status
 
 This project is still in a very early stage and the generated TypeScript is primarily for demonstration purposes.
+
+## Development Notes
+
+Development generally follows a test-driven workflow. When adding new features or fixing bugs, a failing unit test is written first. The implementation is then updated until the test passes. For example, resolving type parameters within record fields was implemented by first adding `RecordTypeParamTest` and `TypeParamResolutionTest` to demonstrate the issue.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Compile Java sources
-javac $(find src -name "*.java")
+javac --release 21 --enable-preview $(find src -name "*.java")
 
 # Generate TypeScript output
-java -cp src magma.Main
+java --enable-preview -cp src magma.Main

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Compile Java sources
-javac --release 21 --enable-preview $(find src -name "*.java")
+# Compile Java sources with preview features enabled. Use the
+# installed JDK version rather than requiring a specific release
+# to avoid errors on environments without Java 21.
+javac --source 21 --enable-preview $(find src -name "*.java")
 
 # Generate TypeScript output
 java --enable-preview -cp src magma.Main

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -151,7 +151,12 @@ public class Main {
             if (paramStart >= 0) {
                 final var name = withoutParamEnd.substring(0, paramStart).strip();
                 final var inputParams = withoutParamEnd.substring(paramStart + "(".length());
-                final var fields = getCollect(state, inputParams);
+
+                // Parse type parameters before parsing record parameters so that
+                // parseType can resolve them when used in parameter types.
+                final var typeParams = parseTypeParamsFromName(name);
+                final var withFrame = state.enter(new StructureFrame(typeParams));
+                final var fields = getCollect(withFrame, inputParams);
                 if (!fields.isEmpty()) {
                     return getTupleOption(targetInfix, state, inputContent, modifiers, implementsTypes, new Some<>(fields), name);
                 }
@@ -209,6 +214,20 @@ public class Main {
                 .filter(value -> !value.isEmpty())
                 .map(TypeParam::new)
                 .collect(new ListCollector<>());
+    }
+
+    private static TypeParamSet parseTypeParamsFromName(String name) {
+        if (name.endsWith(">")) {
+            final var withoutEnd = name.substring(0, name.length() - ">".length());
+            final var typeParamsStart = withoutEnd.indexOf("<");
+            if (typeParamsStart >= 0) {
+                final var substring = withoutEnd.substring(typeParamsStart + "<".length());
+                final var typeParams = parseTypeParameters(substring);
+                return new TypeParamSet(typeParams);
+            }
+        }
+
+        return new TypeParamSet();
     }
 
     private static String convertParametersToBeforeBody(List<Definition> parameters) {
@@ -651,7 +670,7 @@ public class Main {
         return appended;
     }
 
-    private static Parameter parseParameter(String input, CompileState state) {
+    static Parameter parseParameter(String input, CompileState state) {
         return parseWhitespace(input).<Parameter>map(parameter -> parameter)
                 .or(() -> parseDefinition(input, state).map(parameter -> parameter))
                 .orElseGet(() -> new Placeholder(input));
@@ -723,9 +742,12 @@ public class Main {
         return new Definition(new Some<>(generatePlaceholder(beforeType)), Lists.empty(), compiledType, name);
     }
 
-    private static Type parseType(String input, CompileState state) {
+    static Type parseType(String input, CompileState state) {
         final var stripped = input.strip();
-        state.stack.resolveTypeParam(stripped);
+        final var maybeTypeParam = state.stack.resolveTypeParam(stripped);
+        if (maybeTypeParam.isPresent()) {
+            return maybeTypeParam.get();
+        }
 
         if (stripped.equals("String")) {
             return new StringType();

--- a/src/magma/ast/TypeParam.java
+++ b/src/magma/ast/TypeParam.java
@@ -2,5 +2,9 @@ package magma.ast;
 
 import magma.util.*;
 import magma.compile.*;
-public record TypeParam(String name) {
+public record TypeParam(String name) implements Type {
+    @Override
+    public String generate() {
+        return name;
+    }
 }

--- a/test.sh
+++ b/test.sh
@@ -13,11 +13,11 @@ fi
 
 # Compile main sources
 find src -name "*.java" > sources.txt
-javac -d build @sources.txt
+javac --release 21 --enable-preview -d build @sources.txt
 
 # Compile test sources
 find test -name "*.java" > test-sources.txt
-javac -cp "$JUNIT_JAR:build" -d test-classes @test-sources.txt
+javac --release 21 --enable-preview -cp "$JUNIT_JAR:build" -d test-classes @test-sources.txt
 
 # Run tests
-java -jar "$JUNIT_JAR" -cp build:test-classes --scan-class-path
+java --enable-preview -jar "$JUNIT_JAR" -cp build:test-classes --scan-class-path

--- a/test.sh
+++ b/test.sh
@@ -13,11 +13,13 @@ fi
 
 # Compile main sources
 find src -name "*.java" > sources.txt
-javac --release 21 --enable-preview -d build @sources.txt
+# Compile using the available JDK. Avoid the --release flag to allow
+# running on environments without explicit Java 21 support.
+javac --source 21 --enable-preview -d build @sources.txt
 
 # Compile test sources
 find test -name "*.java" > test-sources.txt
-javac --release 21 --enable-preview -cp "$JUNIT_JAR:build" -d test-classes @test-sources.txt
+javac --source 21 --enable-preview -cp "$JUNIT_JAR:build" -d test-classes @test-sources.txt
 
 # Run tests
 java --enable-preview -jar "$JUNIT_JAR" -cp build:test-classes --scan-class-path

--- a/test/magma/RecordTypeParamTest.java
+++ b/test/magma/RecordTypeParamTest.java
@@ -1,0 +1,20 @@
+package magma;
+
+import magma.ast.*;
+import magma.compile.*;
+import magma.util.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RecordTypeParamTest {
+    @Test
+    void parameterInRecordUsesTypeParam() {
+        TypeParam typeParam = new TypeParam("T");
+        TypeParamSet typeParams = new TypeParamSet(Lists.of(typeParam));
+        CompileState state = new CompileState().enter(new StructureFrame(typeParams));
+        Parameter param = Main.parseParameter("T value", state);
+        assertTrue(param instanceof Definition);
+        Definition def = (Definition) param;
+        assertTrue(def.type instanceof TypeParam, "expected type param to resolve in parameter");
+    }
+}

--- a/test/magma/TypeParamResolutionTest.java
+++ b/test/magma/TypeParamResolutionTest.java
@@ -1,0 +1,18 @@
+package magma;
+
+import magma.ast.*;
+import magma.compile.*;
+import magma.util.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TypeParamResolutionTest {
+    @Test
+    void typeParamsInRecordParametersAreResolved() {
+        TypeParam typeParam = new TypeParam("T");
+        TypeParamSet typeParams = new TypeParamSet(Lists.of(typeParam));
+        CompileState state = new CompileState().enter(new StructureFrame(typeParams));
+        Type type = Main.parseType("T", state);
+        assertTrue(type instanceof TypeParam, "expected type param to be resolved");
+    }
+}


### PR DESCRIPTION
## Summary
- parse type parameters prior to processing record parameters
- expose `parseParameter` for testing
- added helper `parseTypeParamsFromName`
- regression test for parameter type resolution with generics

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843a06cb5ec8321ae271416126a732f