### PR TITLE
Refactor Main into helper classes

### DIFF
--- a/src/magma/Generator.java
+++ b/src/magma/Generator.java
@@ -1,0 +1,23 @@
+package magma;
+
+import magma.ast.*;
+import magma.util.*;
+
+/** Utility methods for generating source code from AST nodes. */
+public final class Generator {
+    private Generator() {}
+
+    public static <T extends Generating> String generateNodes(List<T> arguments) {
+        return arguments.iter()
+                .map(Generating::generate)
+                .collect(new Joiner(", "))
+                .orElse("");
+    }
+
+    public static String generatePlaceholder(String input) {
+        final var replaced = input
+                .replace("/*", "start")
+                .replace("*/", "end");
+        return "/*" + replaced + "*/";
+    }
+}

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -9,6 +9,10 @@ import java.util.function.Function;
 import magma.ast.*;
 import magma.util.*;
 import magma.compile.*;
+
+// New utility classes providing parsing and generation helpers
+import magma.Parser;
+import magma.Generator;
 public class Main {
     public static void main(String[] args) {
         try {
@@ -89,7 +93,7 @@ public class Main {
         }
 
         return compileRootStructure(input, state)
-                .orElseGet(() -> generatePlaceholder(input));
+                .orElseGet(() -> Generator.generatePlaceholder(input));
     }
 
     private static Option<String> compileRootStructure(String input, CompileState state) {
@@ -135,7 +139,7 @@ public class Main {
         if (implementsIndex >= 0) {
             final var beforeImplements = beforeContent.substring(0, implementsIndex);
             final var implementsString = beforeContent.substring(implementsIndex + " implements ".length());
-            final var implementsTypes = parseValuesString(implementsString, input -> parseType(input, state));
+            final var implementsTypes = Parser.parseValuesString(implementsString, input -> Parser.parseType(input, state));
 
             return assembleStructureWithParameters(targetInfix, state, inputContent, modifiers, beforeImplements, implementsTypes);
         }
@@ -167,9 +171,9 @@ public class Main {
     }
 
     private static List<Definition> getCollect(CompileState state, String inputParams) {
-        return divide(inputParams, Main::foldValues)
+        return divide(inputParams, Parser::foldValues)
                 .iter()
-                .map(input -> parseParameter(input, state))
+                .map(input -> Parser.parseParameter(input, state))
                 .map(Main::retainDefinition)
                 .flatMap(Iterators::fromOptional)
                 .collect(new ListCollector<>());
@@ -208,7 +212,7 @@ public class Main {
     }
 
     private static List<TypeParam> parseTypeParameters(String substring) {
-        return divide(substring, Main::foldValues)
+        return divide(substring, Parser::foldValues)
                 .iter()
                 .map(String::strip)
                 .filter(value -> !value.isEmpty())
@@ -241,8 +245,8 @@ public class Main {
     private static String joinParameters(List<Definition> fields) {
         return fields.iter()
                 .map(Definition::generate)
-                .fold(new StringBuilder(), Main::mergeValues)
-                .toString();
+                .collect(new Joiner(", "))
+                .orElse("");
     }
 
     private static String convertParametersToFields(List<Definition> fields) {
@@ -257,7 +261,7 @@ public class Main {
             String targetInfix,
             CompileState state, StructurePrototype structurePrototype) {
         final var strippedName = structurePrototype.name().strip();
-        if (!isSymbol(strippedName)) {
+        if (!Parser.isSymbol(strippedName)) {
             return new None<>();
         }
 
@@ -287,7 +291,7 @@ public class Main {
             });
 
             final var outputContent = structurePrototype.beforeBody() + classSegmentsOutput;
-            final var joinedImplements = structurePrototype.implementsTypes().isEmpty() ? "" : " implements " + generateNodes(structurePrototype.implementsTypes());
+            final var joinedImplements = structurePrototype.implementsTypes().isEmpty() ? "" : " implements " + Generator.generateNodes(structurePrototype.implementsTypes());
             var generated = structurePrototype.modifiers() + targetInfix + " " + strippedName + joinedImplements + " {" + outputContent + "\n}\n";
 
             return new Some<>(new Tuple<>("", defined.addStructure(generated)));
@@ -352,7 +356,7 @@ public class Main {
                 .or(() -> compileStructure(input, "interface ", "interface", state))
                 .or(() -> compileField(input, state))
                 .or(() -> compileMethod(input, state))
-                .orElseGet(() -> new Tuple<>(generatePlaceholder(input), state));
+                .orElseGet(() -> new Tuple<>(Generator.generatePlaceholder(input), state));
     }
 
     private static Option<Tuple<String, CompileState>> compileField(String input, CompileState state) {
@@ -366,7 +370,7 @@ public class Main {
     }
 
     private static Option<String> compileSimpleDefinition(String content, CompileState state) {
-        return parseDefinition(content, state).map(Definition::generate);
+        return Parser.parseDefinition(content, state).map(Definition::generate);
     }
 
     private static Option<Tuple<String, CompileState>> compileWhitespaceWithState(String input, CompileState state) {
@@ -374,16 +378,7 @@ public class Main {
     }
 
     private static Option<String> compileWhitespace(String input) {
-        return parseWhitespace(input).map(Whitespace::generate);
-    }
-
-    private static Option<Whitespace> parseWhitespace(String input) {
-        if (input.isBlank()) {
-            return new Some<>(new Whitespace());
-        }
-        else {
-            return new None<>();
-        }
+        return Parser.parseWhitespace(input).map(Whitespace::generate);
     }
 
     private static Option<Tuple<String, CompileState>> compileMethod(String input, CompileState state) {
@@ -402,13 +397,13 @@ public class Main {
         final var inputParams = withParams.substring(0, paramEnd);
         final var inputAfterParams = withParams.substring(paramEnd + ")".length()).strip();
 
-        final var maybeOutputDefinition = parseDefinition(inputDefinition, state);
+        final var maybeOutputDefinition = Parser.parseDefinition(inputDefinition, state);
         if (!maybeOutputDefinition.isPresent()) {
             return new None<>();
         }
 
         final var outputDefinition = maybeOutputDefinition.get();
-        final var parameters = parseAll(inputParams, Main::foldValues, input2 -> parseParameter(input2, state))
+        final var parameters = parseAll(inputParams, Parser::foldValues, input2 -> Parser.parseParameter(input2, state))
                 .iter()
                 .map(Main::retainDefinition)
                 .flatMap(Iterators::fromOptional)
@@ -418,7 +413,7 @@ public class Main {
                 .map(Definition::type)
                 .collect(new ListCollector<>());
 
-        final var outputParams = generateNodes(parameters);
+        final var outputParams = Generator.generateNodes(parameters);
         if (inputAfterParams.equals(";")) {
             return assembleMethod(outputDefinition, outputParams, ";", state, paramTypes);
         }
@@ -455,7 +450,7 @@ public class Main {
     private static String compileFunctionSegments(String input, CompileState state) {
         return compileWhitespace(input)
                 .or(() -> compileFunctionStatement(input, state))
-                .orElseGet(() -> generatePlaceholder(input));
+                .orElseGet(() -> Generator.generatePlaceholder(input));
     }
 
     private static Option<String> compileFunctionStatement(String input, CompileState state) {
@@ -471,209 +466,12 @@ public class Main {
     private static Option<String> compileFunctionStatementValue(String withoutEnd, CompileState state) {
         if (withoutEnd.startsWith("return ")) {
             final var value = withoutEnd.substring("return ".length());
-            final var generated = parseValue(value, state);
+            final var generated = Parser.parseValue(value, state);
             return new Some<>("return " + generated.generate());
         }
         else {
             return new None<>();
         }
-    }
-
-    private static Value parseValue(String input, CompileState state) {
-        return parseInvocation(input, state).<Value>map(value -> value)
-                .or(() -> parseAccess(input, state).map(value -> value))
-                .or(() -> parseSymbol(input).map(value -> value))
-                .orElseGet(() -> new Placeholder(input));
-    }
-
-    private static Option<FieldAccess> parseAccess(String input, CompileState state) {
-        var stripped = input.strip();
-        final var separator = stripped.lastIndexOf(".");
-        if (separator >= 0) {
-            final var parentString = stripped.substring(0, separator);
-            final var property = stripped.substring(separator + ".".length());
-            final var parent = parseValue(parentString, state);
-            return new Some<>(new FieldAccess(parent, property));
-        }
-
-        return new None<>();
-    }
-
-    private static Option<Invocation> parseInvocation(String input, CompileState state) {
-        var stripped = input.strip();
-        if (stripped.endsWith(")")) {
-            final var withoutEnd = stripped.substring(0, stripped.length() - ")".length());
-            final var argumentsStart = withoutEnd.indexOf("(");
-            if (argumentsStart >= 0) {
-                final var callerString = withoutEnd.substring(0, argumentsStart).strip();
-                final var argumentsString = withoutEnd.substring(argumentsStart + "(".length());
-                final var arguments = parseValuesString(argumentsString, input1 -> parseArgument(input1, state))
-                        .iter()
-                        .map(Main::retainValue)
-                        .flatMap(Iterators::fromOptional)
-                        .collect(new ListCollector<>());
-
-                final var caller = mapCaller(state, callerString);
-                return new Some<>(parseAfterInvocation(state, caller, arguments));
-            }
-        }
-
-        return new None<>();
-    }
-
-    private static Invocation parseAfterInvocation(CompileState state, Caller caller, List<Value> arguments) {
-        if (caller instanceof Construction(var type)) {
-            if (type instanceof TemplateType(String base, List<Type> templateArgumentTypes)) {
-                if (templateArgumentTypes.isEmpty()) {
-                    final var maybeStructureType = state.stack.resolveType(base);
-                    if (maybeStructureType.isPresent()) {
-                        final var structureType = maybeStructureType.get();
-                        final var maybeConstructorDefinition = structureType.find("new");
-                        if (maybeConstructorDefinition.isPresent()) {
-                            final var constructorDefinition = maybeConstructorDefinition.get();
-                            final var constructorDefinitionType = constructorDefinition.type;
-                            if (constructorDefinitionType instanceof FunctionType functionalConstructorDefinition) {
-                                final var constructorArgumentTypes = functionalConstructorDefinition.parameterTypes;
-
-                                final var argumentTypes = arguments.iter()
-                                        .map(argument -> resolveValue(argument, state))
-                                        .flatMap(Iterators::fromOptional)
-                                        .collect(new ListCollector<>());
-
-                                final var resolved = constructorArgumentTypes.iter()
-                                        .zip(argumentTypes.iter())
-                                        .map(pair -> pair.left.extract(pair.right))
-                                        .fold(Maps.<String, Type>empty(), Map::putAll);
-
-                                final var actualArgumentTypes = argumentTypes.iter()
-                                        .map(argument -> argument.resolve(resolved))
-                                        .collect(new ListCollector<>());
-
-                                final var actualTemplateType = new TemplateType(base, actualArgumentTypes);
-                                return new Invocation(new Construction(actualTemplateType), arguments);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return new Invocation(caller, arguments);
-    }
-
-    private static Option<Type> resolveValue(Value argument, CompileState state) {
-        return switch (argument) {
-            case FieldAccess fieldAccess -> new None<>();
-            case Invocation invocation -> resolveInvocation(invocation, state);
-            case Placeholder placeholder -> new None<>();
-            case Symbol symbol -> state.stack.resolveValue(symbol.value());
-        };
-    }
-
-    private static Option<Type> resolveInvocation(Invocation invocation, CompileState state) {
-        final var maybeCallerType = resolveCaller(invocation.caller(), state);
-        if (maybeCallerType.isPresent()) {
-            final var callerType = maybeCallerType.get();
-            if (callerType instanceof FunctionType type) {
-                return new Some<>(type.returnType);
-            }
-        }
-
-        return new None<>();
-    }
-
-    private static Option<Type> resolveCaller(Caller caller, CompileState state) {
-        return switch (caller) {
-            case Construction construction -> new None<>();
-            case Value value -> resolveValue(value, state);
-        };
-    }
-
-    private static Option<Value> retainValue(ValueArgument argument) {
-        if (argument instanceof Value value) {
-            return new Some<>(value);
-        }
-        else {
-            return new None<>();
-        }
-    }
-
-    private static ValueArgument parseArgument(String input, CompileState state) {
-        return parseWhitespace(input).<ValueArgument>map(value -> value)
-                .orElseGet(() -> parseValue(input, state));
-    }
-
-    private static Option<Symbol> parseSymbol(String input) {
-        final var stripped = input.strip();
-        if (isSymbol(stripped)) {
-            return new Some<>(new Symbol(stripped));
-        }
-        return new None<>();
-    }
-
-    private static Caller mapCaller(CompileState state, String callerString) {
-        final var caller = parseCaller(callerString, state);
-
-        if (caller instanceof FieldAccess access) {
-            final var parent = access.parent();
-            if (parent instanceof Symbol(String value)) {
-                final var maybeType = state.stack.resolveValue(value);
-                if (maybeType.isPresent()) {
-                    final var type = maybeType.get();
-                    if (type instanceof FunctionType) {
-                        return parent;
-                    }
-                }
-            }
-        }
-
-        return caller;
-    }
-
-    public static <T extends Generating> String generateNodes(List<T> arguments) {
-        final var generated = arguments.iter()
-                .map(Generating::generate)
-                .collect(new ListCollector<>());
-
-        return mergeAll(generated, Main::mergeValues);
-    }
-
-    private static Caller parseCaller(String input, CompileState state) {
-        final var stripped = input.strip();
-        if (stripped.startsWith("new ")) {
-            final var afterNew = stripped.substring("new ".length());
-            final var type = parseType(afterNew, state);
-            return new Construction(type);
-        }
-
-        return parseValue(stripped, state);
-    }
-
-    private static StringBuilder mergeValues(StringBuilder cache, String element) {
-        if (!cache.isEmpty()) {
-            cache.append(", ");
-        }
-        return cache.append(element);
-    }
-
-    private static DivideState foldValues(DivideState state, char c) {
-        if (c == ',' && state.isLevel()) {
-            return state.advance();
-        }
-
-        final var appended = state.append(c);
-        if (c == '<') {
-            return appended.enter();
-        }
-        if (c == '>') {
-            return appended.exit();
-        }
-        return appended;
-    }
-
-    static Parameter parseParameter(String input, CompileState state) {
-        return parseWhitespace(input).<Parameter>map(parameter -> parameter)
-                .or(() -> parseDefinition(input, state).map(parameter -> parameter))
-                .orElseGet(() -> new Placeholder(input));
     }
 
     private static Option<Definition> parseDefinition(String input, CompileState state) {
@@ -685,23 +483,23 @@ public class Main {
 
         final var beforeName = stripped.substring(0, nameSeparator).strip();
         final var name = stripped.substring(nameSeparator + " ".length()).strip();
-        if (!isSymbol(name)) {
+        if (!Parser.isSymbol(name)) {
             return new None<>();
         }
 
         final var divisions = divide(beforeName, Main::foldTypeSeparator);
         final var maybePopped = divisions.popLast();
         if (maybePopped.isEmpty()) {
-            return new Some<>(new Definition(new None<>(), Lists.empty(), parseType(beforeName, state), name));
+            return new Some<>(new Definition(new None<>(), Lists.empty(), Parser.parseType(beforeName, state), name));
         }
 
         final var popped = maybePopped.get();
         final var beforeTypeDivisions = popped.left;
         final var type = popped.right;
-        final var compiledType = parseType(type, state);
+        final var compiledType = Parser.parseType(type, state);
 
         if (beforeTypeDivisions.isEmpty()) {
-            return new Some<>(new Definition(new None<>(), Lists.empty(), parseType(type, state), name));
+            return new Some<>(new Definition(new None<>(), Lists.empty(), Parser.parseType(type, state), name));
         }
 
         final var beforeType = joinWithDelimiter(beforeTypeDivisions, " ");
@@ -730,103 +528,16 @@ public class Main {
             if (typeParamStart >= 0) {
                 final var beforeTypeParams = withoutEnd.substring(0, typeParamStart);
                 final var typeParamsString = withoutEnd.substring(typeParamStart + "<".length());
-                final var typeParams = parseValuesString(typeParamsString, String::strip);
+                final var typeParams = Parser.parseValuesString(typeParamsString, String::strip);
 
                 final Option<String> beforeTypeOptional;
-                beforeTypeOptional = beforeTypeParams.isEmpty() ? new None<>() : new Some<>(generatePlaceholder(beforeTypeParams));
+                beforeTypeOptional = beforeTypeParams.isEmpty() ? new None<>() : new Some<>(Generator.generatePlaceholder(beforeTypeParams));
 
                 return new Definition(beforeTypeOptional, typeParams, compiledType, name);
             }
         }
 
-        return new Definition(new Some<>(generatePlaceholder(beforeType)), Lists.empty(), compiledType, name);
+        return new Definition(new Some<>(Generator.generatePlaceholder(beforeType)), Lists.empty(), compiledType, name);
     }
 
-    static Type parseType(String input, CompileState state) {
-        final var stripped = input.strip();
-        final var maybeTypeParam = state.stack.resolveTypeParam(stripped);
-        if (maybeTypeParam.isPresent()) {
-            return maybeTypeParam.get();
-        }
-
-        if (stripped.equals("String")) {
-            return new StringType();
-        }
-
-        if (stripped.endsWith(">")) {
-            final var withoutEnd = stripped.substring(0, stripped.length() - ">".length());
-            final var argumentsStart = withoutEnd.indexOf("<");
-            if (argumentsStart >= 0) {
-                final var base = withoutEnd.substring(0, argumentsStart).strip();
-                final var inputArguments = withoutEnd.substring(argumentsStart + 1);
-                final var elements = parseValuesString(inputArguments, input1 -> parseTypeArgument(input1, state))
-                        .iter()
-                        .map(Main::retainType)
-                        .flatMap(Iterators::fromOptional)
-                        .collect(new ListCollector<>());
-
-                if (base.equals("Supplier")) {
-                    List<Type> parameterTypes = Lists.empty();
-                    return new FunctionType(parameterTypes, elements.get(0));
-                }
-
-                if (base.equals("Function")) {
-                    List<Type> parameterTypes = Lists.of(elements.get(0));
-                    return new FunctionType(parameterTypes, elements.get(1));
-                }
-
-                if (base.equals("BiFunction")) {
-                    List<Type> parameterTypes = Lists.of(elements.get(0), elements.get(1));
-                    return new FunctionType(parameterTypes, elements.get(2));
-                }
-
-                return new TemplateType(base, elements);
-            }
-        }
-
-        return parseSymbol(stripped).<Type>map(value -> value)
-                .orElseGet(() -> new Placeholder(input));
-    }
-
-    private static Option<Type> retainType(TypeArgument argument) {
-        if (argument instanceof Type type) {
-            return new Some<>(type);
-        }
-        else {
-            return new None<>();
-        }
-    }
-
-    private static TypeArgument parseTypeArgument(String input, CompileState state) {
-        return parseWhitespace(input)
-                .<TypeArgument>map(whitespace -> whitespace)
-                .orElseGet(() -> parseType(input, state));
-    }
-
-    private static <T> List<T> parseValuesString(String input, Function<String, T> mapper) {
-        return parseAll(input, Main::foldValues, mapper);
-    }
-
-    private static boolean isSymbol(String input) {
-        final var length = input.length();
-        if (length == 0) {
-            return false;
-        }
-
-        for (var i = 0; i < length; i++) {
-            final var c = input.charAt(i);
-            if (!Character.isLetter(c)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public static String generatePlaceholder(String input) {
-        final var replaced = input
-                .replace("/*", "start")
-                .replace("*/", "end");
-
-        return "/*" + replaced + "*/";
-    }
 }

--- a/src/magma/Parser.java
+++ b/src/magma/Parser.java
@@ -1,0 +1,374 @@
+package magma;
+
+import java.util.function.Function;
+import java.util.function.BiFunction;
+import magma.ast.*;
+import magma.compile.*;
+import magma.util.*;
+
+/**
+ * Utility class for parsing source code into AST nodes.
+ */
+public final class Parser {
+    private Parser() {}
+
+    public static Option<Whitespace> parseWhitespace(String input) {
+        if (input.isBlank()) {
+            return new Some<>(new Whitespace());
+        }
+        else {
+            return new None<>();
+        }
+    }
+
+    public static Value parseValue(String input, CompileState state) {
+        return parseInvocation(input, state).<Value>map(value -> value)
+                .or(() -> parseAccess(input, state).map(value -> value))
+                .or(() -> parseSymbol(input).map(value -> value))
+                .orElseGet(() -> new Placeholder(input));
+    }
+
+    public static Option<FieldAccess> parseAccess(String input, CompileState state) {
+        var stripped = input.strip();
+        final var separator = stripped.lastIndexOf(".");
+        if (separator >= 0) {
+            final var parentString = stripped.substring(0, separator);
+            final var property = stripped.substring(separator + ".".length());
+            final var parent = parseValue(parentString, state);
+            return new Some<>(new FieldAccess(parent, property));
+        }
+
+        return new None<>();
+    }
+
+    public static Option<Invocation> parseInvocation(String input, CompileState state) {
+        var stripped = input.strip();
+        if (stripped.endsWith(")")) {
+            final var withoutEnd = stripped.substring(0, stripped.length() - ")".length());
+            final var argumentsStart = withoutEnd.indexOf("(");
+            if (argumentsStart >= 0) {
+                final var callerString = withoutEnd.substring(0, argumentsStart).strip();
+                final var argumentsString = withoutEnd.substring(argumentsStart + "(".length());
+                final var arguments = parseValuesString(argumentsString, arg -> parseArgument(arg, state))
+                        .iter()
+                        .map(Parser::retainValue)
+                        .flatMap(Iterators::fromOptional)
+                        .collect(new ListCollector<>());
+
+                final var caller = mapCaller(state, callerString);
+                return new Some<>(parseAfterInvocation(state, caller, arguments));
+            }
+        }
+
+        return new None<>();
+    }
+
+    private static Invocation parseAfterInvocation(CompileState state, Caller caller, List<Value> arguments) {
+        if (caller instanceof Construction(var type)) {
+            if (type instanceof TemplateType(String base, List<Type> templateArgumentTypes)) {
+                if (templateArgumentTypes.isEmpty()) {
+                    final var maybeStructureType = state.stack.resolveType(base);
+                    if (maybeStructureType.isPresent()) {
+                        final var structureType = maybeStructureType.get();
+                        final var maybeConstructorDefinition = structureType.find("new");
+                        if (maybeConstructorDefinition.isPresent()) {
+                            final var constructorDefinition = maybeConstructorDefinition.get();
+                            final var constructorDefinitionType = constructorDefinition.type;
+                            if (constructorDefinitionType instanceof FunctionType functionalConstructorDefinition) {
+                                final var constructorArgumentTypes = functionalConstructorDefinition.parameterTypes;
+
+                                final var argumentTypes = arguments.iter()
+                                        .map(argument -> resolveValue(argument, state))
+                                        .flatMap(Iterators::fromOptional)
+                                        .collect(new ListCollector<>());
+
+                                final var resolved = constructorArgumentTypes.iter()
+                                        .zip(argumentTypes.iter())
+                                        .map(pair -> pair.left.extract(pair.right))
+                                        .fold(Maps.<String, Type>empty(), Map::putAll);
+
+                                final var actualArgumentTypes = argumentTypes.iter()
+                                        .map(argument -> argument.resolve(resolved))
+                                        .collect(new ListCollector<>());
+
+                                final var actualTemplateType = new TemplateType(base, actualArgumentTypes);
+                                return new Invocation(new Construction(actualTemplateType), arguments);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return new Invocation(caller, arguments);
+    }
+
+    private static Option<Type> resolveValue(Value argument, CompileState state) {
+        return switch (argument) {
+            case FieldAccess fieldAccess -> new None<>();
+            case Invocation invocation -> resolveInvocation(invocation, state);
+            case Placeholder placeholder -> new None<>();
+            case Symbol symbol -> state.stack.resolveValue(symbol.value());
+        };
+    }
+
+    private static Option<Type> resolveInvocation(Invocation invocation, CompileState state) {
+        final var maybeCallerType = resolveCaller(invocation.caller(), state);
+        if (maybeCallerType.isPresent()) {
+            final var callerType = maybeCallerType.get();
+            if (callerType instanceof FunctionType type) {
+                return new Some<>(type.returnType);
+            }
+        }
+
+        return new None<>();
+    }
+
+    private static Option<Type> resolveCaller(Caller caller, CompileState state) {
+        return switch (caller) {
+            case Construction construction -> new None<>();
+            case Value value -> resolveValue(value, state);
+        };
+    }
+
+    private static Option<Value> retainValue(ValueArgument argument) {
+        if (argument instanceof Value value) {
+            return new Some<>(value);
+        }
+        else {
+            return new None<>();
+        }
+    }
+
+    private static ValueArgument parseArgument(String input, CompileState state) {
+        return parseWhitespace(input).<ValueArgument>map(value -> value)
+                .orElseGet(() -> parseValue(input, state));
+    }
+
+    private static Option<Symbol> parseSymbol(String input) {
+        final var stripped = input.strip();
+        if (isSymbol(stripped)) {
+            return new Some<>(new Symbol(stripped));
+        }
+        return new None<>();
+    }
+
+    private static Caller mapCaller(CompileState state, String callerString) {
+        final var caller = parseCaller(callerString, state);
+
+        if (caller instanceof FieldAccess access) {
+            final var parent = access.parent();
+            if (parent instanceof Symbol(String value)) {
+                final var maybeType = state.stack.resolveValue(value);
+                if (maybeType.isPresent()) {
+                    final var type = maybeType.get();
+                    if (type instanceof FunctionType) {
+                        return parent;
+                    }
+                }
+            }
+        }
+
+        return caller;
+    }
+
+    private static Caller parseCaller(String input, CompileState state) {
+        final var stripped = input.strip();
+        if (stripped.startsWith("new ")) {
+            final var afterNew = stripped.substring("new ".length());
+            final var type = parseType(afterNew, state);
+            return new Construction(type);
+        }
+
+        return parseValue(stripped, state);
+    }
+
+    public static DivideState foldValues(DivideState state, char c) {
+        if (c == ',' && state.isLevel()) {
+            return state.advance();
+        }
+
+        final var appended = state.append(c);
+        if (c == '<') {
+            return appended.enter();
+        }
+        if (c == '>') {
+            return appended.exit();
+        }
+        return appended;
+    }
+
+    public static Parameter parseParameter(String input, CompileState state) {
+        return parseWhitespace(input).<Parameter>map(parameter -> parameter)
+                .or(() -> parseDefinition(input, state).map(parameter -> parameter))
+                .orElseGet(() -> new Placeholder(input));
+    }
+
+    public static Option<Definition> parseDefinition(String input, CompileState state) {
+        final var stripped = input.strip();
+        final var nameSeparator = stripped.lastIndexOf(" ");
+        if (nameSeparator < 0) {
+            return new None<>();
+        }
+
+        final var beforeName = stripped.substring(0, nameSeparator).strip();
+        final var name = stripped.substring(nameSeparator + " ".length()).strip();
+        if (!isSymbol(name)) {
+            return new None<>();
+        }
+
+        final var divisions = divide(beforeName, Parser::foldTypeSeparator);
+        final var maybePopped = divisions.popLast();
+        if (maybePopped.isEmpty()) {
+            return new Some<>(new Definition(new None<>(), Lists.empty(), parseType(beforeName, state), name));
+        }
+
+        final var popped = maybePopped.get();
+        final var beforeTypeDivisions = popped.left;
+        final var type = popped.right;
+        final var compiledType = parseType(type, state);
+
+        if (beforeTypeDivisions.isEmpty()) {
+            return new Some<>(new Definition(new None<>(), Lists.empty(), parseType(type, state), name));
+        }
+
+        final var beforeType = joinWithDelimiter(beforeTypeDivisions, " ");
+        return new Some<>(assembleDefinition(beforeType, compiledType, name));
+    }
+
+    private static DivideState foldTypeSeparator(DivideState state, char c) {
+        if (c == ' ' && state.isLevel()) {
+            return state.advance();
+        }
+
+        final var appended = state.append(c);
+        if (c == '<') {
+            return appended.enter();
+        }
+        if (c == '>') {
+            return appended.exit();
+        }
+        return appended;
+    }
+
+    private static Definition assembleDefinition(String beforeType, Type compiledType, String name) {
+        if (beforeType.endsWith(">")) {
+            final var withoutEnd = beforeType.substring(0, beforeType.length() - ">".length());
+            final var typeParamStart = withoutEnd.indexOf("<");
+            if (typeParamStart >= 0) {
+                final var beforeTypeParams = withoutEnd.substring(0, typeParamStart);
+                final var typeParamsString = withoutEnd.substring(typeParamStart + "<".length());
+                final var typeParams = parseValuesString(typeParamsString, String::strip);
+
+                final Option<String> beforeTypeOptional;
+                beforeTypeOptional = beforeTypeParams.isEmpty() ? new None<>() : new Some<>(Generator.generatePlaceholder(beforeTypeParams));
+
+                return new Definition(beforeTypeOptional, typeParams, compiledType, name);
+            }
+        }
+
+        return new Definition(new Some<>(Generator.generatePlaceholder(beforeType)), Lists.empty(), compiledType, name);
+    }
+
+    public static Type parseType(String input, CompileState state) {
+        final var stripped = input.strip();
+        final var maybeTypeParam = state.stack.resolveTypeParam(stripped);
+        if (maybeTypeParam.isPresent()) {
+            return maybeTypeParam.get();
+        }
+
+        if (stripped.equals("String")) {
+            return new StringType();
+        }
+
+        if (stripped.endsWith(">")) {
+            final var withoutEnd = stripped.substring(0, stripped.length() - ">".length());
+            final var argumentsStart = withoutEnd.indexOf("<");
+            if (argumentsStart >= 0) {
+                final var base = withoutEnd.substring(0, argumentsStart).strip();
+                final var inputArguments = withoutEnd.substring(argumentsStart + 1);
+                final var elements = parseValuesString(inputArguments, arg -> parseTypeArgument(arg, state))
+                        .iter()
+                        .map(Parser::retainType)
+                        .flatMap(Iterators::fromOptional)
+                        .collect(new ListCollector<>());
+
+                if (base.equals("Supplier")) {
+                    List<Type> parameterTypes = Lists.empty();
+                    return new FunctionType(parameterTypes, elements.get(0));
+                }
+
+                if (base.equals("Function")) {
+                    List<Type> parameterTypes = Lists.of(elements.get(0));
+                    return new FunctionType(parameterTypes, elements.get(1));
+                }
+
+                if (base.equals("BiFunction")) {
+                    List<Type> parameterTypes = Lists.of(elements.get(0), elements.get(1));
+                    return new FunctionType(parameterTypes, elements.get(2));
+                }
+
+                return new TemplateType(base, elements);
+            }
+        }
+
+        return parseSymbol(stripped).<Type>map(value -> value)
+                .orElseGet(() -> new Placeholder(input));
+    }
+
+    private static Option<Type> retainType(TypeArgument argument) {
+        if (argument instanceof Type type) {
+            return new Some<>(type);
+        }
+        else {
+            return new None<>();
+        }
+    }
+
+    private static TypeArgument parseTypeArgument(String input, CompileState state) {
+        return parseWhitespace(input)
+                .<TypeArgument>map(whitespace -> whitespace)
+                .orElseGet(() -> parseType(input, state));
+    }
+
+    public static <T> List<T> parseValuesString(String input, Function<String, T> mapper) {
+        return parseAll(input, Parser::foldValues, mapper);
+    }
+
+    public static boolean isSymbol(String input) {
+        final var length = input.length();
+        if (length == 0) {
+            return false;
+        }
+
+        for (var i = 0; i < length; i++) {
+            final var c = input.charAt(i);
+            if (!Character.isLetter(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static <T> List<T> parseAll(String input, BiFunction<DivideState, Character, DivideState> folder, Function<String, T> mapper) {
+        return divide(input, folder)
+                .iter()
+                .map(mapper)
+                .collect(new ListCollector<>());
+    }
+
+    private static List<String> divide(String input, BiFunction<DivideState, Character, DivideState> folder) {
+        DivideState state = new DivideState();
+        final var length = input.length();
+        var current = state;
+        for (var i = 0; i < length; i++) {
+            final var c = input.charAt(i);
+            current = folder.apply(current, c);
+        }
+
+        return current.advance().segments;
+    }
+
+    private static String joinWithDelimiter(List<String> list, String delimiter) {
+        return list.iter().collect(new Joiner(delimiter)).orElse("");
+    }
+}

--- a/src/magma/ast/Invocation.java
+++ b/src/magma/ast/Invocation.java
@@ -1,7 +1,7 @@
 package magma.ast;
 
 import magma.util.*;
-import magma.Main;
+import magma.Generator;
 import magma.compile.*;
 /**
  * Invocation of a {@link Caller} with a list of argument values.
@@ -9,6 +9,6 @@ import magma.compile.*;
 public record Invocation(Caller caller, List<Value> arguments) implements Value {
     @Override
     public String generate() {
-        return caller.generate() + "(" + Main.generateNodes(arguments) + ")";
+        return caller.generate() + "(" + Generator.generateNodes(arguments) + ")";
     }
 }

--- a/src/magma/ast/Placeholder.java
+++ b/src/magma/ast/Placeholder.java
@@ -1,7 +1,7 @@
 package magma.ast;
 
 import magma.util.*;
-import magma.Main;
+import magma.Generator;
 import magma.compile.*;
 /**
  * Value that will be substituted at generation time.
@@ -9,6 +9,6 @@ import magma.compile.*;
 public record Placeholder(String input) implements Parameter, Value, Type {
     @Override
     public String generate() {
-        return Main.generatePlaceholder(input);
+        return Generator.generatePlaceholder(input);
     }
 }

--- a/src/magma/ast/TemplateType.java
+++ b/src/magma/ast/TemplateType.java
@@ -1,12 +1,12 @@
 package magma.ast;
 
 import magma.util.*;
-import magma.Main;
+import magma.Generator;
 import magma.compile.*;
 public record TemplateType(String base, List<Type> arguments) implements Type {
     @Override
     public String generate() {
-        final var outputArguments = Main.generateNodes(arguments);
+        final var outputArguments = Generator.generateNodes(arguments);
         return base + "<" + outputArguments + ">";
     }
 }

--- a/test/magma/RecordTypeParamTest.java
+++ b/test/magma/RecordTypeParamTest.java
@@ -12,7 +12,7 @@ public class RecordTypeParamTest {
         TypeParam typeParam = new TypeParam("T");
         TypeParamSet typeParams = new TypeParamSet(Lists.of(typeParam));
         CompileState state = new CompileState().enter(new StructureFrame(typeParams));
-        Parameter param = Main.parseParameter("T value", state);
+        Parameter param = Parser.parseParameter("T value", state);
         assertTrue(param instanceof Definition);
         Definition def = (Definition) param;
         assertTrue(def.type instanceof TypeParam, "expected type param to resolve in parameter");

--- a/test/magma/TypeParamResolutionTest.java
+++ b/test/magma/TypeParamResolutionTest.java
@@ -12,7 +12,7 @@ public class TypeParamResolutionTest {
         TypeParam typeParam = new TypeParam("T");
         TypeParamSet typeParams = new TypeParamSet(Lists.of(typeParam));
         CompileState state = new CompileState().enter(new StructureFrame(typeParams));
-        Type type = Main.parseType("T", state);
+        Type type = Parser.parseType("T", state);
         assertTrue(type instanceof TypeParam, "expected type param to be resolved");
     }
 }


### PR DESCRIPTION
## Summary
- extract parsing logic into a new `Parser` utility class
- extract generation helpers into `Generator`
- update `Main` and AST classes to use the new utilities
- adjust tests to use `Parser`

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843a6dff22c83219a59805aac9a8a66