### PR TITLE
Implement multi-file compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Magma is an experimental programming language with an implementation in Java.
 
 Further documentation about building or testing the project will be added in the future.
-Magma is an experimental compiler that reads a subset of Java and emits TypeScript code. The current proof of concept focuses on translating `src/magma/Main.java` into `src/magma/Main.ts`.
+Magma is an experimental compiler that reads Java sources under the `src/` directory and emits TypeScript under `src-web/` while preserving the package directory structure.
 
 ## Building
 

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -2,6 +2,7 @@ package magma;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -15,8 +16,26 @@ import magma.compile.*;
 public class Main {
     public static void main(String[] args) {
         try {
-            final var source = Paths.get(".", "src", "magma", "Main.java");
-            final var target = source.resolveSibling("Main.ts");
+            final var root = Paths.get(".", "src");
+            final var targetRoot = Paths.get(".", "src-web");
+
+            Files.walk(root)
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .forEach(source -> compileFile(root, targetRoot, source));
+        } catch (IOException e) {
+            //noinspection CallToPrintStackTrace
+            e.printStackTrace();
+        }
+    }
+
+    private static void compileFile(Path root, Path targetRoot, Path source) {
+        try {
+            final var relative = root.relativize(source);
+            Path target = targetRoot.resolve(relative);
+            target = target.resolveSibling(
+                    target.getFileName().toString().replaceFirst("\\.java$", ".ts"));
+
+            Files.createDirectories(target.getParent());
 
             final var input = Files.readString(source);
             final var output = compile(input);

--- a/test/magma/MultiFileCompilationTest.java
+++ b/test/magma/MultiFileCompilationTest.java
@@ -1,0 +1,53 @@
+package magma;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MultiFileCompilationTest {
+    private static void invokeCompileFile(Path root, Path targetRoot, Path source) throws Exception {
+        Method m = Main.class.getDeclaredMethod("compileFile", Path.class, Path.class, Path.class);
+        m.setAccessible(true);
+        m.invoke(null, root, targetRoot, source);
+    }
+
+    @Test
+    void compileFileGeneratesMatchingPath() throws Exception {
+        Path srcRoot = Files.createTempDirectory("srcRoot");
+        Path targetRoot = Files.createTempDirectory("targetRoot");
+        Path packageDir = srcRoot.resolve("magma/ast");
+        Files.createDirectories(packageDir);
+        Path javaFile = packageDir.resolve("Caller.java");
+        String content = "package magma.ast; public class Caller {}";
+        Files.writeString(javaFile, content);
+
+        invokeCompileFile(srcRoot, targetRoot, javaFile);
+
+        Path tsFile = targetRoot.resolve("magma/ast/Caller.ts");
+        assertTrue(Files.exists(tsFile), "expected generated TypeScript file");
+    }
+
+    @Test
+    void compileMultipleFiles() throws Exception {
+        Path srcRoot = Files.createTempDirectory("srcRoot");
+        Path targetRoot = Files.createTempDirectory("targetRoot");
+        Path dirA = srcRoot.resolve("pkgA");
+        Path dirB = srcRoot.resolve("pkgB");
+        Files.createDirectories(dirA);
+        Files.createDirectories(dirB);
+        Path fileA = dirA.resolve("A.java");
+        Path fileB = dirB.resolve("B.java");
+        Files.writeString(fileA, "package pkgA; public class A {}");
+        Files.writeString(fileB, "package pkgB; public class B {}");
+
+        invokeCompileFile(srcRoot, targetRoot, fileA);
+        invokeCompileFile(srcRoot, targetRoot, fileB);
+
+        assertTrue(Files.exists(targetRoot.resolve("pkgA/A.ts")));
+        assertTrue(Files.exists(targetRoot.resolve("pkgB/B.ts")));
+    }
+}


### PR DESCRIPTION
## Summary
- compile all Java files under `src/` preserving package layout
- write generated code to matching paths under `src-web/`
- document the new behaviour in the README

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843ad0413348321b42fb5bb92ea5c7f