### PR TITLE
Introduce Result type and propagate Err from compiler

### DIFF
--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 
 import magma.ast.*;
 import magma.util.*;
+import magma.util.result.*;
 import magma.compile.*;
 
 // New utility classes providing parsing and generation helpers
@@ -38,7 +39,10 @@ public class Main {
             Files.createDirectories(target.getParent());
 
             final var input = Files.readString(source);
-            final var output = compile(input);
+            final var outputResult = compile(input);
+            final var output = outputResult.isOk()
+                    ? outputResult.unwrap()
+                    : Generator.generatePlaceholder(input);
             Files.writeString(target, output);
         } catch (IOException e) {
             //noinspection CallToPrintStackTrace
@@ -46,20 +50,47 @@ public class Main {
         }
     }
 
-    private static String compile(String input) {
+    private static Result<String, String> compile(String input) {
         return compileStatements(input, input1 -> compileRootSegment(input1, new CompileState()));
     }
 
-    private static String compileStatements(String input, Function<String, String> mapper) {
+    private static Result<String, String> compileStatements(String input, Function<String, Result<String, String>> mapper) {
         return compileAll(input, mapper, Main::foldStatements, Main::mergeStatements);
     }
 
-    private static String compileAll(String input, Function<String, String> mapper, BiFunction<DivideState, Character, DivideState> folder, BiFunction<StringBuilder, String, StringBuilder> merger) {
-        return Parser.divide(input, folder)
-                .iter()
-                .map(mapper)
-                .fold(new StringBuilder(), merger)
-                .toString();
+    private static Result<String, String> compileAll(
+            String input,
+            Function<String, Result<String, String>> mapper,
+            BiFunction<DivideState, Character, DivideState> folder,
+            BiFunction<StringBuilder, String, StringBuilder> merger) {
+        Result<StringBuilder, String> result = new Ok<>(new StringBuilder());
+
+        var iterator = Parser.divide(input, folder).iter();
+        while (true) {
+            var maybeElement = iterator.next();
+            if (maybeElement.isEmpty()) {
+                break;
+            }
+            String element = maybeElement.get();
+            if (result.isErr()) {
+                break;
+            }
+
+            var compiled = mapper.apply(element);
+            if (compiled.isErr()) {
+                result = new Err<StringBuilder, String>(compiled.unwrapErr());
+            } else {
+                StringBuilder current = result.unwrap();
+                String value = compiled.unwrap();
+                result = new Ok<>(merger.apply(current, value));
+            }
+        }
+
+        if (result.isOk()) {
+            return new Ok<>(result.unwrap().toString());
+        }
+
+        return new Err<String, String>(result.unwrapErr());
     }
 
     private static StringBuilder mergeStatements(StringBuilder output, String compiled) {
@@ -84,14 +115,17 @@ public class Main {
         return appended;
     }
 
-    private static String compileRootSegment(String input, CompileState state) {
+    private static Result<String, String> compileRootSegment(String input, CompileState state) {
         final var stripped = input.strip();
         if (stripped.startsWith("package ") || stripped.startsWith("import ")) {
-            return "";
+            return new Ok<>("");
         }
 
-        return compileRootStructure(input, state)
-                .orElseGet(() -> Generator.generatePlaceholder(input));
+        var maybe = compileRootStructure(input, state);
+        if (maybe.isPresent()) {
+            return new Ok<>(maybe.get());
+        }
+        return new Err<String, String>(input);
     }
 
     private static Option<String> compileRootStructure(String input, CompileState state) {
@@ -417,7 +451,11 @@ public class Main {
 
         final var content = inputAfterParams.substring(1, inputAfterParams.length() - 1);
         final CompileState defined = state.enter(new MethodFrame(new DefinitionSet(parameters)));
-        final String outputAfterParams = compileStatements(content, input1 -> compileFunctionSegments(input1, defined));
+        final var outputAfterParamsResult = compileStatements(content, input1 -> compileFunctionSegments(input1, defined));
+        if (outputAfterParamsResult.isErr()) {
+            return new None<>();
+        }
+        final String outputAfterParams = outputAfterParamsResult.unwrap();
         return assembleMethod(outputDefinition, outputParams, " {" + outputAfterParams + "\n\t}", state, paramTypes);
     }
 
@@ -438,10 +476,18 @@ public class Main {
         return new Some<>(new Tuple<>(generated, withLast));
     }
 
-    private static String compileFunctionSegments(String input, CompileState state) {
-        return compileWhitespace(input)
-                .or(() -> compileFunctionStatement(input, state))
-                .orElseGet(() -> Generator.generatePlaceholder(input));
+    private static Result<String, String> compileFunctionSegments(String input, CompileState state) {
+        var maybeWhitespace = compileWhitespace(input);
+        if (maybeWhitespace.isPresent()) {
+            return new Ok<>(maybeWhitespace.get());
+        }
+
+        var maybeStatement = compileFunctionStatement(input, state);
+        if (maybeStatement.isPresent()) {
+            return new Ok<>(maybeStatement.get());
+        }
+
+        return new Err<String, String>(input);
     }
 
     private static Option<String> compileFunctionStatement(String input, CompileState state) {

--- a/src/magma/util/result/Err.java
+++ b/src/magma/util/result/Err.java
@@ -1,0 +1,44 @@
+package magma.util.result;
+
+/** Result variant representing failure. */
+public final class Err<T, X> implements Result<T, X> {
+    private final X error;
+
+    public Err(X error) {
+        this.error = error;
+    }
+
+    public X error() {
+        return error;
+    }
+
+    @Override
+    public boolean isOk() {
+        return false;
+    }
+
+    @Override
+    public boolean isErr() {
+        return true;
+    }
+
+    @Override
+    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+        return new Err<>(error);
+    }
+
+    @Override
+    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+        return new Err<>(error);
+    }
+
+    @Override
+    public T unwrap() {
+        return null;
+    }
+
+    @Override
+    public X unwrapErr() {
+        return error;
+    }
+}

--- a/src/magma/util/result/Ok.java
+++ b/src/magma/util/result/Ok.java
@@ -1,0 +1,44 @@
+package magma.util.result;
+
+/** Result variant representing success. */
+public final class Ok<T, X> implements Result<T, X> {
+    private final T value;
+
+    public Ok(T value) {
+        this.value = value;
+    }
+
+    public T value() {
+        return value;
+    }
+
+    @Override
+    public boolean isOk() {
+        return true;
+    }
+
+    @Override
+    public boolean isErr() {
+        return false;
+    }
+
+    @Override
+    public <U> Result<U, X> mapValue(java.util.function.Function<? super T, ? extends U> mapper) {
+        return new Ok<>(mapper.apply(value));
+    }
+
+    @Override
+    public <U> Result<U, X> flatMapValue(java.util.function.Function<? super T, Result<U, X>> mapper) {
+        return mapper.apply(value);
+    }
+
+    @Override
+    public T unwrap() {
+        return value;
+    }
+
+    @Override
+    public X unwrapErr() {
+        return null;
+    }
+}

--- a/src/magma/util/result/Result.java
+++ b/src/magma/util/result/Result.java
@@ -1,0 +1,16 @@
+package magma.util.result;
+
+import java.util.function.Function;
+
+/** A simple result type representing success or failure. */
+public sealed interface Result<T, X> permits Ok, Err {
+    boolean isOk();
+    boolean isErr();
+
+    <U> Result<U, X> mapValue(Function<? super T, ? extends U> mapper);
+
+    <U> Result<U, X> flatMapValue(Function<? super T, Result<U, X>> mapper);
+
+    T unwrap();
+    X unwrapErr();
+}

--- a/src/magma/util/result/Results.java
+++ b/src/magma/util/result/Results.java
@@ -1,0 +1,15 @@
+package magma.util.result;
+
+/** Utility methods for working with {@link Result}. */
+public final class Results {
+    private Results() {}
+
+    @SuppressWarnings("unchecked")
+    public static <T, X> T unwrap(Result<T, X> result) {
+        if (result.isOk()) {
+            return ((Ok<T, X>) result).value();
+        }
+        Err<T, X> err = (Err<T, X>) result;
+        throw new RuntimeException(String.valueOf(err.error()));
+    }
+}


### PR DESCRIPTION
## Summary
- add `Result`, `Ok`, and `Err` types under `magma.util.result`
- expose helper `Results.unwrap`
- rewrite portions of `Main` to return `Err` instead of generating placeholders
- adjust `compileFile` to handle `Result` output

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6843b0012f888321be28d8c7ecf90bf7