### PR TITLE
Add roadmap comparing Java and TypeScript features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Magma is an experimental programming language with an implementation in Java.
 Further documentation about building or testing the project will be added in the future.
 Magma is an experimental compiler that reads Java sources under the `src/` directory and emits TypeScript under `src-web/` while preserving the package directory structure.
 The current translation capabilities are summarised in [docs/features.md](docs/features.md).
+For a comparison of supported Java features with their TypeScript equivalents, see the [roadmap](docs/roadmap.md).
 
 ## Building
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,37 @@
+# Java to TypeScript Roadmap
+
+This roadmap compares major Java features with their TypeScript counterparts as implemented by the Magma compiler. It enumerates what is currently converted and what remains unimplemented.
+
+## Conversion Overview
+
+| Java Feature | TypeScript Conversion | Status |
+|--------------|----------------------|--------|
+| Classes, Interfaces, Records | `class` and `interface` definitions with preserved `extends`/`implements` hierarchy | Implemented |
+| Fields and Methods | Fields and function members with parameter and return types | Implemented |
+| Generic Type Parameters | Generic parameters on classes and methods | Implemented |
+| `static` Methods | `static` methods in TypeScript | Implemented |
+| Primitive Types (`byte`, `short`, `int`, `long`, `float`, `double`) | `number` | Implemented |
+| `boolean` | `boolean` | Implemented |
+| `char`, `String` | `string` | Implemented |
+| Functional Interfaces (`Function`, `BiFunction`, `Supplier`) | Arrow function types | Implemented |
+| Type Parameters in Records | Type parameters resolved for record constructors and fields | Implemented |
+| Lambda Expressions | Currently emitted as `0` | Missing |
+| `switch` Statements | Emitted as `0` with `case` blocks ignored | Missing |
+| `instanceof` Checks | Emitted as `0` | Missing |
+| `if`, `for`, `while` Headers | Always generate `if (true)` | Missing |
+| Variadic Type Arguments & Complex Types | Replaced with `?` | Missing |
+
+The [features document](features.md) provides additional details and will be updated as the compiler evolves.
+
+## Module Overview
+
+The compiler is organised into a few main packages:
+
+- **`magma.ast`** – abstract syntax tree structures.
+- **`magma.compile`** – compilation state and frames for generating TypeScript.
+- **`magma.util`** – small collection-like utilities and result types.
+- **`magma.Parser`** – parses Java source files.
+- **`magma.Generator`** – generates TypeScript output from the AST.
+- **`magma.Main`** – entry point used by `build.sh`.
+
+These modules provide a high-level map when navigating the source tree.


### PR DESCRIPTION
## Summary
- document how Java features map to TypeScript in a new roadmap
- mention the roadmap from the README

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843ba8715688321b1812f77cb890425