### PR TITLE
Add primitive type support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ This document summarises which Java language features are currently handled by t
 - Converts fields and methods with their parameter and return types.
 - Supports generic type parameters on classes and methods.
 - Preserves the `static` modifier on methods.
-- Maps primitive types (`byte`, `short`, `int`, `long`, `float`, `double`) to `number`, `boolean` to `boolean` and `char`/`String` to `string`.
+- Maps primitive types (`byte`, `short`, `int`, `long`, `float`, `double`) to `number`, `boolean` to `boolean` and `char`/`String` to `string` via the `NumberType`, `BooleanType` and `StringType` nodes.
 - Converts Java functional interfaces (`Function`, `BiFunction`, `Supplier`) to arrow function types.
 - Resolves type parameters within record constructors and fields.
 - Compiles all Java files under `src/` to matching paths under `src-web/`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ This roadmap compares major Java features with their TypeScript counterparts as 
 | Fields and Methods | Fields and function members with parameter and return types | Implemented |
 | Generic Type Parameters | Generic parameters on classes and methods | Implemented |
 | `static` Methods | `static` methods in TypeScript | Implemented |
-| Primitive Types (`byte`, `short`, `int`, `long`, `float`, `double`) | `number` | Implemented |
+| Primitive Types (`byte`, `short`, `int`, `long`, `float`, `double`) | `number` | Complete |
 | `boolean` | `boolean` | Implemented |
 | `char`, `String` | `string` | Implemented |
 | Functional Interfaces (`Function`, `BiFunction`, `Supplier`) | Arrow function types | Implemented |

--- a/src/magma/Parser.java
+++ b/src/magma/Parser.java
@@ -276,8 +276,17 @@ public final class Parser {
             return maybeTypeParam.get();
         }
 
-        if (stripped.equals("String")) {
+        if (stripped.equals("String") || stripped.equals("char")) {
             return new StringType();
+        }
+
+        switch (stripped) {
+            case "byte", "short", "int", "long", "float", "double" -> {
+                return new NumberType();
+            }
+            case "boolean" -> {
+                return new BooleanType();
+            }
         }
 
         if (stripped.endsWith(">")) {

--- a/src/magma/ast/BooleanType.java
+++ b/src/magma/ast/BooleanType.java
@@ -1,0 +1,8 @@
+package magma.ast;
+
+public class BooleanType implements Type {
+    @Override
+    public String generate() {
+        return "boolean";
+    }
+}

--- a/src/magma/ast/NumberType.java
+++ b/src/magma/ast/NumberType.java
@@ -1,0 +1,8 @@
+package magma.ast;
+
+public class NumberType implements Type {
+    @Override
+    public String generate() {
+        return "number";
+    }
+}

--- a/test/magma/FunctionalInterfaceTypeTest.java
+++ b/test/magma/FunctionalInterfaceTypeTest.java
@@ -21,6 +21,6 @@ public class FunctionalInterfaceTypeTest {
     @Test
     void parsesBiFunction() {
         var type = Parser.parseType("BiFunction<int, int, String>", new CompileState());
-        assertEquals("(param0 : int, param1 : int) => string", type.generate());
+        assertEquals("(param0 : number, param1 : number) => string", type.generate());
     }
 }

--- a/test/magma/PrimitiveTypeTranspilationTest.java
+++ b/test/magma/PrimitiveTypeTranspilationTest.java
@@ -1,0 +1,33 @@
+package magma;
+
+import magma.compile.CompileState;
+import magma.ast.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PrimitiveTypeTranspilationTest {
+    @Test
+    void intMapsToNumber() {
+        Type type = Parser.parseType("int", new CompileState());
+        assertEquals("number", type.generate());
+    }
+
+    @Test
+    void doubleMapsToNumber() {
+        Type type = Parser.parseType("double", new CompileState());
+        assertEquals("number", type.generate());
+    }
+
+    @Test
+    void booleanMapsToBoolean() {
+        Type type = Parser.parseType("boolean", new CompileState());
+        assertEquals("boolean", type.generate());
+    }
+
+    @Test
+    void charMapsToString() {
+        Type type = Parser.parseType("char", new CompileState());
+        assertEquals("string", type.generate());
+    }
+}

--- a/test/magma/StructureCompilationTest.java
+++ b/test/magma/StructureCompilationTest.java
@@ -27,8 +27,8 @@ public class StructureCompilationTest {
     void compilesRecord() throws Exception {
         String output = compileStructure("public record R(int x) {}", "record ", "class");
         assertTrue(output.startsWith("export class R {"));
-        assertTrue(output.contains("x: int;"));
-        assertTrue(output.contains("constructor (x: int)"));
+        assertTrue(output.contains("x: number;"));
+        assertTrue(output.contains("constructor (x: number)"));
     }
 
     @Test
@@ -41,6 +41,6 @@ public class StructureCompilationTest {
     void implementsRelationshipPreserved() throws Exception {
         String output = compileStructure("public class A implements I { int x; }", "class ", "class");
         assertTrue(output.startsWith("export class A implements I {"));
-        assertTrue(output.contains("x: int;"));
+        assertTrue(output.contains("x: number;"));
     }
 }


### PR DESCRIPTION
## Summary
- parse primitive types into number/boolean/string AST nodes
- generate new `NumberType` and `BooleanType` classes
- test primitive type transpilation
- adjust existing tests for new type behaviour
- document primitive type nodes and mark roadmap item complete

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843bd488a148321a7fa8218f08fc3b3