### PR TITLE
Add stubbed method bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ their TypeScript equivalents. Numeric primitives (`byte`, `short`, `int`, `long`
 - `test/java` – JUnit tests
 - `docs/` – Documentation
 
+See `docs/overview.md` for a short list of the main modules.
+
 Additional notes on regex usage, coding style and CI can be found in the `docs/`
 directory.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,6 +16,7 @@
 - [x] Handles generic type arguments when converting return values
 - [x] Preserves method type parameters on generated methods
 - [x] Preserves the `static` modifier on generated methods
+- [x] Parses method bodies but only emits stubs in the generated TypeScript
 - [x] Preserves `extends` and `implements` on class declarations
 - [x] Includes an `npm` command to validate the TypeScript output
 - [x] Wraps file paths with `PathLike`/`JVMPath` so generated TypeScript does not

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,13 @@
+## Module Overview
+
+The project is organized around a few small modules:
+
+- `Main` – entry point orchestrating diagram and stub generation.
+- `GenerateDiagram` – creates PlantUML diagrams from the sources.
+- `TypeScriptStubs` – writes TypeScript stubs that mirror the Java classes.
+- `JavaFile` and `Sources` – helpers for parsing Java source files.
+- `PathLike`/`JVMPath` – thin wrappers around file system paths.
+- `Option` (`Some`/`None`) – optional value type.
+- `Result` (`Ok`/`Err`) – result type used for error handling.
+
+These modules keep the codebase small and easy to navigate.

--- a/src/java/magma/JavaFile.java
+++ b/src/java/magma/JavaFile.java
@@ -296,14 +296,7 @@ public record JavaFile(PathLike file) {
         if (segRes.isErr()) {
             return new Err<>(((Err<List<String>, IOException>) segRes).error());
         }
-        List<String> segs = ((Ok<List<String>, IOException>) segRes).value();
-        if (segs.isEmpty()) {
-            list.add("\t\treturn 0;");
-        } else {
-            for (String seg : segs) {
-                list.add("\t\t" + seg);
-            }
-        }
+        list.add("\t\treturn 0;");
         list.add("\t}");
         return new Ok<>(null);
     }

--- a/test/java/magma/TypeScriptStubsTest.java
+++ b/test/java/magma/TypeScriptStubsTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import static magma.TestUtil.writeSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TypeScriptStubsTest {
 
@@ -303,21 +304,15 @@ public class TypeScriptStubsTest {
     public void copiesAssignmentSegment() {
         PathLike tsRoot = generateSegmentStubs();
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
-        assertTrue(a.contains("let x: number = 1;"));
+        assertFalse(a.contains("let x: number = 1;"));
+        assertTrue(a.contains("return 0;"));
     }
 
     @Test
     public void splitsStatementsAcrossLines() {
         PathLike tsRoot = generateSegmentStubs();
         String a = Results.unwrap(tsRoot.resolve("test/A.ts").readString());
-        String expected = "let x: number = 1;" + System.lineSeparator()
-                + "\t\tif(x>0){" + System.lineSeparator()
-                + "\t\t\tbar();" + System.lineSeparator()
-                + "\t\t}" + System.lineSeparator()
-                + "\t\telse {" + System.lineSeparator()
-                + "\t\t\tbaz();" + System.lineSeparator()
-                + "\t\t}" + System.lineSeparator()
-                + "\t\treturn x;";
-        assertTrue(a.contains(expected));
+        assertFalse(a.contains("baz();"));
+        assertTrue(a.contains("return 0;"));
     }
 }


### PR DESCRIPTION
## Summary
- keep only stub `return` statements in generated TypeScript
- adjust tests for stubbed bodies
- document module list and note that bodies are stubbed

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843bf218de88321bddd2488334748c8