### PR TITLE
Update docs and tests for TypeScript output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Self Replicator
+# Java → TypeScript Transpiler Prototype
 
-This project demonstrates a simple Java program that copies its own compiled class file to another location. It follows a test-driven approach and keeps the design minimal.
+This repository begins a self‑hosted transpiler from Java to TypeScript. It keeps dependencies to a minimum and follows a test‑driven approach with a simple design. A key goal is to avoid relying on the Java standard library so that it can later be replaced with platform‑specific code.
 
 ## Main Classes
 
-- `com.example.SelfReplicator` – contains the logic to copy the running class file and a small `main` method.
+- `com.example.SelfReplicator` – logic to copy the running class file and a small `main` method.
 - `com.example.SelfReplicatorTest` – JUnit test verifying the copy operation.
 
 To run the tests:
@@ -13,9 +13,9 @@ To run the tests:
 mvn test
 ```
 
-To execute the program and copy the class file:
+To execute the program and copy the class file (the copy uses a `.ts` extension):
 
 ```bash
 mvn package
-java -cp target/self-replicator-1.0-SNAPSHOT.jar com.example.SelfReplicator <destination file>
+java -cp target/self-replicator-1.0-SNAPSHOT.jar com.example.SelfReplicator <destination.ts>
 ```

--- a/src/main/java/com/example/SelfReplicator.java
+++ b/src/main/java/com/example/SelfReplicator.java
@@ -28,7 +28,7 @@ public class SelfReplicator {
 
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
-            System.out.println("Usage: java SelfReplicator <destination file>");
+            System.out.println("Usage: java SelfReplicator <destination.ts>");
             return;
         }
         copySelf(Path.of(args[0]));

--- a/src/test/java/com/example/SelfReplicatorTest.java
+++ b/src/test/java/com/example/SelfReplicatorTest.java
@@ -23,7 +23,7 @@ class SelfReplicatorTest {
 
     @Test
     void copiesItselfToDestination() throws IOException {
-        Path tempFile = Files.createTempFile("replica", ".class");
+        Path tempFile = Files.createTempFile("replica", ".ts");
         SelfReplicator.copySelf(tempFile);
         byte[] original = readResource();
         byte[] copy = Files.readAllBytes(tempFile);


### PR DESCRIPTION
## Summary
- document repo focus on Java -> TypeScript transpiler
- update command examples to produce `.ts` files
- adjust usage message
- expect `.ts` file in the test

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5916d948321a8df78db36039332