### PR TITLE
Implement minimal transpiler removing package statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 
 ## Main Classes
 
-- `com.example.SelfReplicator` – logic to copy the running class file and a small `main` method.
-- `com.example.SelfReplicatorTest` – JUnit test verifying the copy operation.
+- `com.example.SelfReplicator` – copies the running class file.
+- `com.example.Transpiler` – prototype Java → TypeScript converter.
+- Tests mirror each class (`SelfReplicatorTest`, `TranspilerTest`).
+
+The transpiler currently removes the `package` declaration since
+TypeScript does not use Java-style packages.
 
 To run the tests:
 

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -1,0 +1,27 @@
+package com.example;
+
+/**
+ * Very small prototype that converts a fragment of Java to TypeScript.
+ */
+public class Transpiler {
+
+    /**
+     * Transpiles the given Java source code to TypeScript.
+     * Currently only removes the package declaration.
+     *
+     * @param javaSource the Java source text
+     * @return transpiled TypeScript
+     */
+    public String toTypeScript(String javaSource) {
+        String[] lines = javaSource.split("\\R");
+        StringBuilder ts = new StringBuilder();
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("package ")) {
+                continue; // skip package declarations entirely
+            }
+            ts.append(line).append(System.lineSeparator());
+        }
+        return ts.toString().trim();
+    }
+}

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TranspilerTest {
+
+    @Test
+    void removesPackageDeclaration() {
+        String javaSrc = "package com.example;\n\npublic class Foo {}";
+        String expected = "public class Foo {}";
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Transpiler` prototype with `toTypeScript` method
- test that the transpiler strips Java `package` lines
- document new module and its behaviour

## Testing
- `mvn -q test` *(fails: Could not download Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6843c67350648321b075315b88efdcec