### PR TITLE
Add roadmap for Java to TypeScript features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 - `com.example.SelfReplicator` – logic to copy the running class file and a small `main` method.
 - `com.example.SelfReplicatorTest` – JUnit test verifying the copy operation.
 
+## Documentation
+
+Additional notes and a feature mapping between Java and TypeScript live in
+[`docs/java-to-typescript-roadmap.md`](docs/java-to-typescript-roadmap.md).
+
 To run the tests:
 
 ```bash

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -1,0 +1,39 @@
+# Java to TypeScript Feature Roadmap
+
+This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication.
+
+| Java Feature | TypeScript Equivalent | Notes |
+| ------------ | -------------------- | ----- |
+| `package` declarations | `module` or ES module system | Use directory structure to mirror packages. |
+| Primitive types (`int`, `float`, `double`, `long`) | `number` | TypeScript uses a single `number` type. |
+| `boolean` | `boolean` | Direct mapping. |
+| `char` | `string` (1‑character) or `number` | Depends on intended representation. |
+| `String` | `string` | Direct mapping. |
+| Arrays | Arrays | `int[]` → `number[]`, etc. |
+| Classes | Classes | Use `class` syntax. |
+| Interfaces | Interfaces | Direct mapping. |
+| Abstract classes | Abstract classes | Use the `abstract` keyword. |
+| Enums | `enum` | TypeScript `enum` provides similar semantics. |
+| Generics | Generics | `List<T>` → `Array<T>` or custom generic types. |
+| Methods | Methods | Instance and static methods translate directly. |
+| Fields | Properties | Public/private modifiers apply. |
+| Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. |
+| Inheritance (`extends`) | `extends` | Works with classes and interfaces. |
+| Implementing interfaces (`implements`) | `implements` | Direct mapping. |
+| Exceptions (`throw`, `try`/`catch`) | `throw`, `try`/`catch` | No checked exceptions in TypeScript. |
+| Annotations | Decorators | Requires enabling experimental decorators. |
+| Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. |
+| Streams | Array methods / custom helpers | Use `map`, `filter`, `reduce`. |
+| Standard library (`java.util`, etc.) | TypeScript/JS standard APIs or polyfills | Replace with equivalent utilities. |
+| Reflection | Limited or custom metadata | TypeScript has limited runtime type information. |
+| `synchronized` | Not applicable | Use higher‑level concurrency primitives if needed. |
+| Threads | Web Workers or async/await | Depends on target platform. |
+
+Further tasks:
+1. Implement translation of basic class structure and type mappings.
+2. Add support for generics and inheritance.
+3. Handle exceptions and control flow constructs.
+4. Map annotations to decorators.
+5. Gradually cover advanced features like reflection or concurrency.
+
+Each step should begin with a test describing the expected TypeScript output for a Java input example.


### PR DESCRIPTION
## Summary
- add a documentation page that maps Java features to TypeScript
- link the documentation from the README

## Testing
- `mvn -q test` *(fails: could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6843c685431c832183f76a1833fecaa8