### PR TITLE
Add class definition translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 - Tests mirror each class (`SelfReplicatorTest`, `TranspilerTest`).
 
 The transpiler currently removes the `package` declaration since
-TypeScript does not use Java-style packages.
+TypeScript does not use Java-style packages. It also rewrites simple
+class definitions so that Java modifiers like `public` are replaced with
+`export default`.
 
 ## Documentation
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -30,7 +30,8 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Threads | Web Workers or async/await | Depends on target platform. |
 
 Further tasks:
-1. Implement translation of basic class structure and type mappings.
+1. ~~Implement translation of basic class structure and type mappings.~~
+   Basic class definitions now output `export default class`.
 2. Add support for generics and inheritance.
 3. Handle exceptions and control flow constructs.
 4. Map annotations to decorators.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -7,7 +7,9 @@ public class Transpiler {
 
     /**
      * Transpiles the given Java source code to TypeScript.
-     * Currently only removes the package declaration.
+     * Currently removes the package declaration and rewrites simple class
+     * definitions. Modifiers before the {@code class} keyword are replaced with
+     * {@code export default}.
      *
      * @param javaSource the Java source text
      * @return transpiled TypeScript
@@ -20,6 +22,16 @@ public class Transpiler {
             if (trimmed.startsWith("package ")) {
                 continue; // skip package declarations entirely
             }
+
+            int brace = line.indexOf('{');
+            int classIdx = line.indexOf("class");
+            if (brace != -1 && classIdx != -1 && classIdx < brace) {
+                String afterClass = line.substring(classIdx, line.length());
+                ts.append("export default ").append(afterClass)
+                        .append(System.lineSeparator());
+                continue;
+            }
+
             ts.append(line).append(System.lineSeparator());
         }
         return ts.toString().trim();

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -9,7 +9,15 @@ class TranspilerTest {
     @Test
     void removesPackageDeclaration() {
         String javaSrc = "package com.example;\n\npublic class Foo {}";
-        String expected = "public class Foo {}";
+        String expected = "export default class Foo {}";
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void transpilesClassDefinitionWithModifier() {
+        String javaSrc = "public final class Bar {}";
+        String expected = "export default class Bar {}";
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }


### PR DESCRIPTION
## Summary
- extend `Transpiler` to rewrite simple class definitions
- update tests for new behaviour
- document class translation in README and roadmap

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843caa945ac83218af6c0063be1c95e