### PR TITLE
Add return type parsing to stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
-preserving each method's name and indentation. Future tests will drive
-the full implementation.
+preserving each method's name and indentation. Basic parameter and
+return types are converted to their TypeScript equivalents. Future
+tests will drive the full implementation.
 
 ## Documentation
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -1,6 +1,6 @@
 # Java to TypeScript Feature Roadmap
 
-This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript while method signatures are preserved.
+This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript while method signatures are preserved, including basic return type mappings.
 
 | Java Feature | TypeScript Equivalent | Notes |
 | ------------ | -------------------- | ----- |
@@ -15,7 +15,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Abstract classes | Abstract classes | Use the `abstract` keyword. |
 | Enums | `enum` | TypeScript `enum` provides similar semantics. |
 | Generics | Generics | `List<T>` → `Array<T>` or custom generic types. |
-| Methods | Methods | Instance and static methods translate directly. |
+| Methods | Methods | Instance and static methods translate directly. Basic return types such as `int` or `void` become `number` or `void`. |
 | Fields | Properties | Public/private modifiers apply. |
 | Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. |
 | Inheritance (`extends`) | `extends` | Works with classes and interfaces. |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -40,10 +40,12 @@ public class Transpiler {
         StringBuffer out = new StringBuffer();
         while (m.find()) {
             String indent = m.group(1);
+            String returnType = m.group(2);
             String name = m.group(3);
             String params = m.group(4).trim();
             String tsParams = toTsParams(params);
-            String replacement = indent + name + "(" + tsParams + ") {}";
+            String tsReturn = toTsType(returnType);
+            String replacement = indent + name + "(" + tsParams + ")" + (tsReturn.isBlank() ? "" : ": " + tsReturn) + " {}";
             m.appendReplacement(out, java.util.regex.Matcher.quoteReplacement(replacement));
         }
         m.appendTail(out);
@@ -72,6 +74,7 @@ public class Transpiler {
             case "int", "long", "float", "double" -> "number";
             case "boolean" -> "boolean";
             case "char", "String" -> "string";
+            case "void" -> "void";
             default -> "any";
         };
     }

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -33,7 +33,24 @@ class TranspilerTest {
 
         String expected = String.join("\n",
             "export default class Foo {",
-            "    bar(x: number) {}",
+            "    bar(x: number): number {}",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void stubsVoidReturnTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void baz() {",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    baz(): void {}",
             "}");
 
         String result = new Transpiler().toTypeScript(javaSrc);


### PR DESCRIPTION
## Summary
- parse method return types in the transpiler
- handle `void` in type conversions
- test stubbing of return types
- document that method parameter and return types are converted

## Testing
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `mkdir -p bin`
- `find src/main/java src/test/java -name "*.java" | xargs javac -cp junit-platform-console-standalone.jar -d bin`
- `java -jar junit-platform-console-standalone.jar -cp bin --scan-classpath`

------
https://chatgpt.com/codex/tasks/task_e_6843cfa0f47c8321968ac217fb50dd2a