### PR TITLE
Add statement stubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
-preserving each method's name and indentation. Future tests will drive
+preserving each method's name and indentation. Each statement inside a
+method becomes a `// TODO` placeholder so structure is retained. Future tests will drive
 the full implementation.
 
 ## Documentation

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -1,6 +1,6 @@
 # Java to TypeScript Feature Roadmap
 
-This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript while method signatures are preserved.
+This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript while method signatures are preserved. Statements within those methods become `// TODO` placeholders.
 
 | Java Feature | TypeScript Equivalent | Notes |
 | ------------ | -------------------- | ----- |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -35,15 +35,27 @@ public class Transpiler {
 
     private String stubMethods(String source) {
         String pattern = "(?ms)^([ \t]*)(?:public|private|protected|static|final|abstract|synchronized|native|strictfp\\s+)*" +
-                "([a-zA-Z_][a-zA-Z0-9_<>\\[\\]]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)\\s*\\{[^}]*\\}";
+                "([a-zA-Z_][a-zA-Z0-9_<>\\[\\]]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)\\s*\\{([^}]*)\\}";
         java.util.regex.Matcher m = java.util.regex.Pattern.compile(pattern).matcher(source);
         StringBuffer out = new StringBuffer();
         while (m.find()) {
             String indent = m.group(1);
             String name = m.group(3);
             String params = m.group(4).trim();
+            String body = m.group(5);
             String tsParams = toTsParams(params);
-            String replacement = indent + name + "(" + tsParams + ") {}";
+
+            StringBuilder stubbedBody = new StringBuilder();
+            for (String line : body.split("\\R")) {
+                if (line.strip().isEmpty()) {
+                    continue;
+                }
+                stubbedBody.append(indent).append("    // TODO").append(System.lineSeparator());
+            }
+
+            String replacement = indent + name + "(" + tsParams + ") {" +
+                    (stubbedBody.length() > 0 ? System.lineSeparator() + stubbedBody.toString() + indent : "") +
+                    "}";
             m.appendReplacement(out, java.util.regex.Matcher.quoteReplacement(replacement));
         }
         m.appendTail(out);

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -33,7 +33,31 @@ class TranspilerTest {
 
         String expected = String.join("\n",
             "export default class Foo {",
-            "    bar(x: number) {}",
+            "    bar(x: number) {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void stubsStatementsInsideMethods() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void bar() {",
+            "        int x = 1;",
+            "        System.out.println(x);",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    bar() {",
+            "        // TODO",
+            "        // TODO",
+            "    }",
             "}");
 
         String result = new Transpiler().toTypeScript(javaSrc);


### PR DESCRIPTION
## Summary
- stub out statements in transpiled methods with `// TODO`
- update tests for new statement stubs
- document statement stubbing in README and roadmap

## Testing
- `find src/main/java src/test/java -name "*.java" | xargs javac -cp junit-platform-console-standalone.jar -d bin`
- `java -jar junit-platform-console-standalone.jar -cp bin --scan-classpath`

------
https://chatgpt.com/codex/tasks/task_e_6843cfab69748321a9f424906daac12d