### PR TITLE
Add TODO stubs for TypeScript methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
-preserving each method's name and indentation. Basic parameter and
+preserving each method's name and indentation. Each stub contains a
+`// TODO` comment. Basic parameter and
 return types are converted to their TypeScript equivalents. Future
 tests will drive the full implementation.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -1,6 +1,6 @@
 # Java to TypeScript Feature Roadmap
 
-This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript while method signatures are preserved, including basic return type mappings.
+This page outlines how Java language features map to their TypeScript counterparts. The project follows a test‑driven approach and Kent Beck's rules for simple design. Each feature should be supported by failing tests before implementation and refactored to remove duplication. The current prototype stubs out Java method bodies in the generated TypeScript with a `// TODO` comment while method signatures are preserved, including basic return type mappings.
 
 | Java Feature | TypeScript Equivalent | Notes |
 | ------------ | -------------------- | ----- |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -45,7 +45,11 @@ public class Transpiler {
             String params = m.group(4).trim();
             String tsParams = toTsParams(params);
             String tsReturn = toTsType(returnType);
-            String replacement = indent + name + "(" + tsParams + ")" + (tsReturn.isBlank() ? "" : ": " + tsReturn) + " {}";
+            String replacement = indent + name + "(" + tsParams + ")" +
+                    (tsReturn.isBlank() ? "" : ": " + tsReturn) + " {" +
+                    System.lineSeparator() +
+                    indent + "    // TODO" + System.lineSeparator() +
+                    indent + "}";
             m.appendReplacement(out, java.util.regex.Matcher.quoteReplacement(replacement));
         }
         m.appendTail(out);

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -33,7 +33,9 @@ class TranspilerTest {
 
         String expected = String.join("\n",
             "export default class Foo {",
-            "    bar(x: number): number {}",
+            "    bar(x: number): number {",
+            "        // TODO",
+            "    }",
             "}");
 
         String result = new Transpiler().toTypeScript(javaSrc);
@@ -50,7 +52,9 @@ class TranspilerTest {
 
         String expected = String.join("\n",
             "export default class Foo {",
-            "    baz(): void {}",
+            "    baz(): void {",
+            "        // TODO",
+            "    }",
             "}");
 
         String result = new Transpiler().toTypeScript(javaSrc);


### PR DESCRIPTION
## Summary
- emit TODO comment inside stubbed TypeScript method bodies
- update tests for TODO comment
- document TODO method stubs in README and roadmap

## Testing
- `curl -L -o junit-platform-console-standalone.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.10.1/junit-platform-console-standalone-1.10.1.jar`
- `mkdir -p bin && find src/main/java src/test/java -name "*.java" | xargs javac -cp junit-platform-console-standalone.jar -d bin`
- `java -jar junit-platform-console-standalone.jar -cp bin --scan-classpath`

------
https://chatgpt.com/codex/tasks/task_e_6843d095035c83219b928d1d8a1f9eab