### PR TITLE
Add Boolean mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ preserving each method's name and indentation. Each stub contains a
 return types are converted to their TypeScript equivalents. Future
 tests will drive the full implementation.
 
+The primitive `boolean` and its wrapper `Boolean` both become TypeScript
+`boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
+
 ## Documentation
 
 Additional notes and a feature mapping between Java and TypeScript live in

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -6,7 +6,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | ------------ | -------------------- | ----- | ----- |
 | `package` declarations | `module` or ES module system | Use directory structure to mirror packages. | `TranspilerTest.removesPackageDeclaration`, `MainTest.printsTranspiledSource` |
 | Primitive types (`int`, `float`, `double`, `long`) | `number` | TypeScript uses a single `number` type. | `TranspilerTest.stubsMethodBodiesPreservingNames` |
-| `boolean` | `boolean` | Direct mapping. | |
+| `boolean` / `Boolean` | `boolean` | Direct mapping. | `TranspilerTest.mapsBooleanTypes` |
 | `char` | `string` (1‑character) or `number` | Depends on intended representation. | |
 | `String` | `string` | Direct mapping. | |
 | Arrays | Arrays | `int[]` → `number[]`, etc. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -104,7 +104,7 @@ public class Transpiler {
     private String toTsType(String javaType) {
         return switch (javaType) {
             case "int", "long", "float", "double" -> "number";
-            case "boolean" -> "boolean";
+            case "boolean", "Boolean" -> "boolean";
             case "char", "String" -> "string";
             case "void" -> "void";
             default -> "any";

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -60,4 +60,24 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void mapsBooleanTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    Boolean flag(Boolean a, boolean b) {",
+            "        return a;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    flag(a: boolean, b: boolean): boolean {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- handle Java `Boolean` in `Transpiler`
- test boolean mappings
- document boolean mapping in the roadmap and README

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d3eff3a48321b437aa7a05594b18