### PR TITLE
Map char and Character to string

### DIFF
--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -7,8 +7,9 @@ This page outlines how Java language features map to their TypeScript counterpar
 | `package` declarations | `module` or ES module system | Use directory structure to mirror packages. | `TranspilerTest.removesPackageDeclaration`, `MainTest.printsTranspiledSource` |
 | Primitive types (`int`, `float`, `double`, `long`) | `number` | TypeScript uses a single `number` type. | `TranspilerTest.stubsMethodBodiesPreservingNames` |
 | `boolean` | `boolean` | Direct mapping. | |
-| `char` | `string` (1‑character) or `number` | Depends on intended representation. | |
-| `String` | `string` | Direct mapping. | |
+| `char` | `string` | Primitive character becomes a string. | `TranspilerTest.mapsCharCharacterAndStringToString` |
+| `Character` | `string` | Wrapper character type. | `TranspilerTest.mapsCharCharacterAndStringToString` |
+| `String` | `string` | Direct mapping. | `TranspilerTest.mapsCharCharacterAndStringToString` |
 | Arrays | Arrays | `int[]` → `number[]`, etc. | |
 | Classes | Classes | Use `class` syntax. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Interfaces | Interfaces | Direct mapping. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -105,7 +105,7 @@ public class Transpiler {
         return switch (javaType) {
             case "int", "long", "float", "double" -> "number";
             case "boolean" -> "boolean";
-            case "char", "String" -> "string";
+            case "char", "Character", "String" -> "string";
             case "void" -> "void";
             default -> "any";
         };

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -60,4 +60,36 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void mapsCharCharacterAndStringToString() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    char fromChar(char c) {",
+            "        return c;",
+            "    }",
+            "    char fromWrapper(Character c) {",
+            "        return c;",
+            "    }",
+            "    String fromString(String s) {",
+            "        return s;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    fromChar(c: string): string {",
+            "        // TODO",
+            "    }",
+            "    fromWrapper(c: string): string {",
+            "        // TODO",
+            "    }",
+            "    fromString(s: string): string {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- map `char`, `Character` and `String` to `string`
- test that all three convert to the TypeScript `string` type
- document mapping for primitive `char`, wrapper `Character` and `String`

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d3f9666c8321b995bb6a70be73df