### PR TITLE
Implement array type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
 preserving each method's name and indentation. Each stub contains a
 `// TODO` comment. Basic parameter and
-return types are converted to their TypeScript equivalents. Future
+return types are converted to their TypeScript equivalents. Array types
+map directly as well, so `int[]` becomes `number[]` and `String[]`
+becomes `string[]`. Future
 tests will drive the full implementation.
 
 ## Documentation

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -9,7 +9,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | `boolean` | `boolean` | Direct mapping. | |
 | `char` | `string` (1‑character) or `number` | Depends on intended representation. | |
 | `String` | `string` | Direct mapping. | |
-| Arrays | Arrays | `int[]` → `number[]`, etc. | |
+| Arrays | Arrays | `int[]` → `number[]`, etc. | `TranspilerTest.mapsArrayTypes` |
 | Classes | Classes | Use `class` syntax. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Interfaces | Interfaces | Direct mapping. | |
 | Abstract classes | Abstract classes | Use the `abstract` keyword. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -102,6 +102,11 @@ public class Transpiler {
     }
 
     private String toTsType(String javaType) {
+        if (javaType.endsWith("[]")) {
+            String element = javaType.substring(0, javaType.length() - 2);
+            return toTsType(element) + "[]";
+        }
+
         return switch (javaType) {
             case "int", "long", "float", "double" -> "number";
             case "boolean" -> "boolean";

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -60,4 +60,24 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void mapsArrayTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    int[] bar(String[] words) {",
+            "        return null;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    bar(words: string[]): number[] {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- map Java array types to the appropriate TypeScript arrays
- describe array mapping in README
- record new coverage in the Java→TypeScript roadmap
- test array type mapping

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d4166b948321a5b7d76113923f4b