### PR TITLE
Fix and expand type mapping tests

### DIFF
--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -10,9 +10,6 @@ This page outlines how Java language features map to their TypeScript counterpar
 | `char` | `string` | Primitive character becomes a string. | `TranspilerTest.mapsCharCharacterAndStringToString` |
 | `Character` | `string` | Wrapper character type. | `TranspilerTest.mapsCharCharacterAndStringToString` |
 | `String` | `string` | Direct mapping. | `TranspilerTest.mapsCharCharacterAndStringToString` |
-| Arrays | Arrays | `int[]` → `number[]`, etc. | |
-| `char` | `string` (1‑character) or `number` | Depends on intended representation. | |
-| `String` | `string` | Direct mapping. | |
 | Arrays | Arrays | `int[]` → `number[]`, etc. | `TranspilerTest.mapsArrayTypes` |
 | Classes | Classes | Use `class` syntax. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Interfaces | Interfaces | Direct mapping. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -109,9 +109,8 @@ public class Transpiler {
 
         return switch (javaType) {
             case "int", "long", "float", "double" -> "number";
-            case "boolean" -> "boolean";
-            case "char", "Character", "String" -> "string";
             case "boolean", "Boolean" -> "boolean";
+            case "char", "Character", "String" -> "string";
             case "void" -> "void";
             default -> "any";
         };

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -16,9 +16,9 @@ class TranspilerTest {
 
     @Test
     void transpilesClassDefinitionWithModifier() {
-        String javaSrc = "public final class Bar {}"; 
-        String expected = "export default class Bar {}"; 
-        String result = new Transpiler().toTypeScript(javaSrc); 
+        String javaSrc = "public final class Bar {}";
+        String expected = "export default class Bar {}";
+        String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
 
@@ -73,16 +73,6 @@ class TranspilerTest {
             "    }",
             "    String fromString(String s) {",
             "        return s;",
-    void mapsArrayTypes() {
-        String javaSrc = String.join("\n",
-            "public class Foo {",
-            "    int[] bar(String[] words) {",
-            "        return null;",
-    void mapsBooleanTypes() {
-        String javaSrc = String.join("\n",
-            "public class Foo {",
-            "    Boolean flag(Boolean a, boolean b) {",
-            "        return a;",
             "    }",
             "}");
 
@@ -95,7 +85,45 @@ class TranspilerTest {
             "        // TODO",
             "    }",
             "    fromString(s: string): string {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void mapsArrayTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    int[] bar(String[] words) {",
+            "        return null;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
             "    bar(words: string[]): number[] {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void mapsBooleanTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    Boolean flag(Boolean a, boolean b) {",
+            "        return a;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
             "    flag(a: boolean, b: boolean): boolean {",
             "        // TODO",
             "    }",


### PR DESCRIPTION
## Summary
- split mapping checks into dedicated tests for char/String, arrays, and boolean types
- deduplicate roadmap entries and note the array mapping test
- remove duplicate switch case in `Transpiler` type map

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d5d6eac88321a0ac2a252a3a622f