### PR TITLE
Add generic type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future
 tests will drive the full implementation.
 
+Generic type parameters are preserved, so `List<String>` becomes
+`List<string>` in the transpiled output.
+
 The primitive `boolean` and its wrapper `Boolean` both become TypeScript
 `boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -15,7 +15,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Interfaces | Interfaces | Direct mapping. | |
 | Abstract classes | Abstract classes | Use the `abstract` keyword. | |
 | Enums | `enum` | TypeScript `enum` provides similar semantics. | |
-| Generics | Generics | `List<T>` → `Array<T>` or custom generic types. | |
+| Generics | Generics | Direct mapping of type parameters, e.g. `List<T>` → `List<T>`. | `TranspilerTest.mapsGenericTypes` |
 | Methods | Methods | Instance and static methods translate directly. Basic return types such as `int` or `void` become `number` or `void`. | `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes` |
 | Fields | Properties | Public/private modifiers apply. | |
 | Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
@@ -33,7 +33,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 Further tasks:
 1. ~~Implement translation of basic class structure and type mappings.~~
    Basic class definitions now output `export default class`.
-2. Add support for generics and inheritance.
+2. ~~Add support for generics~~ and inheritance.
 3. Handle exceptions and control flow constructs.
 4. Map annotations to decorators.
 5. Gradually cover advanced features like reflection or concurrency.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -102,6 +102,18 @@ public class Transpiler {
     }
 
     private String toTsType(String javaType) {
+        int genericStart = javaType.indexOf('<');
+        int genericEnd = javaType.lastIndexOf('>');
+        if (genericStart != -1 && genericEnd != -1 && genericEnd > genericStart) {
+            String base = javaType.substring(0, genericStart).trim();
+            String params = javaType.substring(genericStart + 1, genericEnd);
+            java.util.List<String> mapped = new java.util.ArrayList<>();
+            for (String p : params.split(",")) {
+                mapped.add(toTsType(p.trim()));
+            }
+            return base + "<" + String.join(", ", mapped) + ">";
+        }
+
         if (javaType.endsWith("[]")) {
             String element = javaType.substring(0, javaType.length() - 2);
             return toTsType(element) + "[]";

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -132,4 +132,24 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void mapsGenericTypes() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    List<String> names(List<String> in) {",
+            "        return in;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    names(in: List<string>): List<string> {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- map generic Java types directly to TypeScript generics
- document generic mapping and update feature roadmap
- test generic support

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d6c0f5f88321ada7fc581715d3dd