### PR TITLE
Update design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 - `com.example.Main` – command line entry that runs the transpiler
 - Tests mirror the transpiler (`TranspilerTest`) and CLI (`MainTest`).
 
+Abstract classes are intentionally avoided. The project prefers composition of
+small classes over inheritance hierarchies.
+
 The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -3,3 +3,7 @@
 This project favors clear string manipulation over complex regular expressions.
 When parsing source text, prefer small, readable loops and `split` operations.
 Long or intricate regex patterns can be hard to maintain and are discouraged.
+
+Abstract classes tend to complicate the design and are avoided in this codebase.
+Favor composition of small collaborating objects over inheritance whenever
+possible.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -13,7 +13,8 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Arrays | Arrays | `int[]` → `number[]`, etc. | `TranspilerTest.mapsArrayTypes` |
 | Classes | Classes | Use `class` syntax. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Interfaces | Interfaces | Direct mapping. | |
-| Abstract classes | Abstract classes | Use the `abstract` keyword. | |
+| Abstract classes | Abstract classes | Use the `abstract` keyword. The project
+  itself avoids abstract base classes in favor of composition. | |
 | Enums | `enum` | TypeScript `enum` provides similar semantics. | |
 | Generics | Generics | Direct mapping of type parameters, e.g. `List<T>` → `List<T>`. | `TranspilerTest.mapsGenericTypes` |
 | Methods | Methods | Instance and static methods translate directly. Basic return types such as `int` or `void` become `number` or `void`. | `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes` |


### PR DESCRIPTION
## Summary
- discourage usage of abstract classes in README
- update coding standards to prefer composition over inheritance
- note this style in the Java-to-TypeScript feature roadmap

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d7db5d208321aa7bb0e3963403bb