### PR TITLE
Add field parsing to transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future
 tests will drive the full implementation.
 
+Field declarations inside classes are converted to TypeScript property
+syntax with the appropriate type mappings.
+
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -17,7 +17,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Enums | `enum` | TypeScript `enum` provides similar semantics. | |
 | Generics | Generics | Direct mapping of type parameters, e.g. `List<T>` → `List<T>`. | `TranspilerTest.mapsGenericTypes` |
 | Methods | Methods | Instance and static methods translate directly. Basic return types such as `int` or `void` become `number` or `void`. | `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes` |
-| Fields | Properties | Public/private modifiers apply. | |
+| Fields | Properties | Public/private modifiers apply. | `TranspilerTest.transpilesFieldDeclarations` |
 | Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Inheritance (`extends`) | `extends` | Works with classes and interfaces. | |
 | Implementing interfaces (`implements`) | `implements` | Direct mapping. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -30,7 +30,8 @@ public class Transpiler {
             }
         }
 
-        return stubMethods(ts.toString().trim());
+        String withMethods = stubMethods(ts.toString().trim());
+        return transpileFields(withMethods);
     }
 
     private String stubMethods(String source) {
@@ -80,6 +81,33 @@ public class Transpiler {
             } else {
                 out.append(line).append(System.lineSeparator());
             }
+        }
+        return out.toString().trim();
+    }
+
+    private String transpileFields(String source) {
+        String[] lines = source.split("\\R");
+        StringBuilder out = new StringBuilder();
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.endsWith(";") && !trimmed.contains("(") && !trimmed.startsWith("import")) {
+                String indent = line.substring(0, line.indexOf(trimmed));
+                String withoutSemi = trimmed.substring(0, trimmed.length() - 1).trim();
+                String[] tokens = withoutSemi.split("\\s+");
+                if (tokens.length >= 2) {
+                    String name = tokens[tokens.length - 1];
+                    String type = tokens[tokens.length - 2];
+                    String modifiers = String.join(" ", java.util.Arrays.copyOf(tokens, tokens.length - 2));
+                    String tsType = toTsType(type);
+                    out.append(indent);
+                    if (!modifiers.isBlank()) {
+                        out.append(modifiers).append(" ");
+                    }
+                    out.append(name).append(": ").append(tsType).append(";").append(System.lineSeparator());
+                    continue;
+                }
+            }
+            out.append(line).append(System.lineSeparator());
         }
         return out.toString().trim();
     }

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -152,4 +152,22 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void transpilesFieldDeclarations() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    public int count;",
+            "    private String name;",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    public count: number;",
+            "    private name: string;",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- parse Java field declarations and emit TypeScript properties
- document field support in README
- record the new test in the roadmap
- test `transpilesFieldDeclarations`

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d804862483219a48b24a461158bc