### PR TITLE
Update docs to note decorators won't be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Generic type parameters are preserved, so `List<String>` becomes
 The primitive `boolean` and its wrapper `Boolean` both become TypeScript
 `boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
 
+Annotations are currently skipped entirely, so no TypeScript decorators are
+generated.
+
 ## Documentation
 
 Additional notes and a feature mapping between Java and TypeScript live in

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -22,7 +22,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Inheritance (`extends`) | `extends` | Works with classes and interfaces. | |
 | Implementing interfaces (`implements`) | `implements` | Direct mapping. | |
 | Exceptions (`throw`, `try`/`catch`) | `throw`, `try`/`catch` | No checked exceptions in TypeScript. | |
-| Annotations | Decorators | Requires enabling experimental decorators. | |
+| Annotations | *(not supported)* | Decorators are not used in this project. | |
 | Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. | |
 | Streams | Array methods / custom helpers | Use `map`, `filter`, `reduce`. | |
 | Standard library (`java.util`, etc.) | TypeScript/JS standard APIs or polyfills | Replace with equivalent utilities. | |
@@ -35,7 +35,7 @@ Further tasks:
    Basic class definitions now output `export default class`.
 2. ~~Add support for generics~~ and inheritance.
 3. Handle exceptions and control flow constructs.
-4. Map annotations to decorators.
+4. ~~Map annotations to decorators.~~ Decorators will not be used.
 5. Gradually cover advanced features like reflection or concurrency.
 
 6. Record the related test names in the "Tests" column whenever a feature is completed.


### PR DESCRIPTION
## Summary
- clarify that annotations/decorators are not supported in README
- update the roadmap to indicate decorators will not be used

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d8300f0883219a2436ae6644edfe