### PR TITLE
Document Result/Option error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Generic type parameters are preserved, so `List<String>` becomes
 The primitive `boolean` and its wrapper `Boolean` both become TypeScript
 `boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
 
+Error handling avoids Java exceptions. Do not use `throw`, `try`, or `catch`.
+Instead, functions should return a `Result` or `Option` object.
+
 ## Documentation
 
 Additional notes and a feature mapping between Java and TypeScript live in

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -3,3 +3,6 @@
 This project favors clear string manipulation over complex regular expressions.
 When parsing source text, prefer small, readable loops and `split` operations.
 Long or intricate regex patterns can be hard to maintain and are discouraged.
+
+Avoid Java-style exception handling. Do not use `throw`, `try`, or `catch`.
+Instead, represent failure or missing values with a `Result` or `Option` object.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -21,7 +21,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
 | Inheritance (`extends`) | `extends` | Works with classes and interfaces. | |
 | Implementing interfaces (`implements`) | `implements` | Direct mapping. | |
-| Exceptions (`throw`, `try`/`catch`) | `throw`, `try`/`catch` | No checked exceptions in TypeScript. | |
+| Exceptions (`throw`, `try`/`catch`) | `Result`/`Option` types | Prefer returning a `Result` or `Option` object instead of using exceptions. | |
 | Annotations | Decorators | Requires enabling experimental decorators. | |
 | Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. | |
 | Streams | Array methods / custom helpers | Use `map`, `filter`, `reduce`. | |
@@ -34,7 +34,7 @@ Further tasks:
 1. ~~Implement translation of basic class structure and type mappings.~~
    Basic class definitions now output `export default class`.
 2. ~~Add support for generics~~ and inheritance.
-3. Handle exceptions and control flow constructs.
+3. Replace exceptions with `Result`/`Option` constructs and update control flow accordingly.
 4. Map annotations to decorators.
 5. Gradually cover advanced features like reflection or concurrency.
 


### PR DESCRIPTION
## Summary
- add Result/Option guidance to coding standards and README
- note Result/Option policy in roadmap table
- update roadmap task about error handling

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d83443008321b3f2e8ec8056065b