### PR TITLE
Add tests for extends and implements mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ syntax with the appropriate type mappings.
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.
 
+Inheritance via the `extends` keyword and interface implementation with
+`implements` are copied directly to the TypeScript output.
+
 The primitive `boolean` and its wrapper `Boolean` both become TypeScript
 `boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -20,8 +20,8 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Methods | Methods | Instance and static methods translate directly. Basic return types such as `int` or `void` become `number` or `void`. | `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes` |
 | Fields | Properties | Public/private modifiers apply. | `TranspilerTest.transpilesFieldDeclarations` |
 | Access modifiers (`public`, `private`, `protected`) | `public`, `private`, `protected` | `package‑private` becomes `public` or internal module export. | `TranspilerTest.transpilesClassDefinitionWithModifier` |
-| Inheritance (`extends`) | `extends` | Works with classes and interfaces. | |
-| Implementing interfaces (`implements`) | `implements` | Direct mapping. | |
+| Inheritance (`extends`) | `extends` | Works with classes and interfaces. | `TranspilerTest.preservesExtendsClause` |
+| Implementing interfaces (`implements`) | `implements` | Direct mapping. | `TranspilerTest.preservesImplementsClause` |
 | Exceptions (`throw`, `try`/`catch`) | `Result`/`Option` types | Prefer returning a `Result` or `Option` object instead of using exceptions. | |
 | Annotations | *(not supported)* | Decorators are not used in this project. | |
 | Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. | |

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -170,4 +170,32 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void preservesExtendsClause() {
+        String javaSrc = String.join("\n",
+            "public class Child extends Parent {",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Child extends Parent {",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void preservesImplementsClause() {
+        String javaSrc = String.join("\n",
+            "public class Service implements Runnable {",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Service implements Runnable {",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- verify `extends` and `implements` are preserved in TypeScript output
- document the feature in the README and roadmap

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843d9790e308321a9624a7ded255fe5