### PR TITLE
Add arrow function conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Enum declarations are also converted so that `public enum Foo` becomes
 The primitive `boolean` and its wrapper `Boolean` both become TypeScript
 `boolean`, as verified by `TranspilerTest.mapsBooleanTypes`.
 
+Lambda expressions use TypeScript arrow function syntax, so `() -> {}`
+becomes `() => {}`.
+
 Error handling avoids Java exceptions. Do not use `throw`, `try`, or `catch`.
 Instead, functions should return a `Result` or `Option` object.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -23,7 +23,7 @@ This page outlines how Java language features map to their TypeScript counterpar
 | Implementing interfaces (`implements`) | `implements` | Direct mapping. | `TranspilerTest.preservesImplementsClause` |
 | Exceptions (`throw`, `try`/`catch`) | `Result`/`Option` types | Prefer returning a `Result` or `Option` object instead of using exceptions. | |
 | Annotations | *(not supported)* | Decorators are not used in this project. | |
-| Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. | |
+| Lambda expressions | Arrow functions | `() -> {}` → `() => {}`. | `TranspilerTest.convertsLambdasToArrowFunctions` |
 | Streams | Array methods / custom helpers | Use `map`, `filter`, `reduce`. | |
 | Standard library (`java.util`, etc.) | TypeScript/JS standard APIs or polyfills | Replace with equivalent utilities. | |
 | Reflection | Limited or custom metadata | TypeScript has limited runtime type information. | |

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -35,7 +35,8 @@ public class Transpiler {
         }
 
         String withMethods = stubMethods(ts.toString().trim());
-        return transpileFields(withMethods);
+        String withFields = transpileFields(withMethods);
+        return convertArrowFunctions(withFields);
     }
 
     private String stubMethods(String source) {
@@ -130,6 +131,19 @@ public class Transpiler {
                 out.append(modifiers).append(" ");
             }
             out.append(name).append(": ").append(tsType).append(";").append(System.lineSeparator());
+        }
+        return out.toString().trim();
+    }
+
+    private String convertArrowFunctions(String source) {
+        String[] lines = source.split("\\R");
+        StringBuilder out = new StringBuilder();
+        for (String line : lines) {
+            if (line.contains("->")) {
+                out.append(line.replace("->", "=>")).append(System.lineSeparator());
+            } else {
+                out.append(line).append(System.lineSeparator());
+            }
         }
         return out.toString().trim();
     }

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -207,4 +207,13 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void convertsLambdasToArrowFunctions() {
+        String javaSrc = "Runnable r = () -> {};";
+        String expected = "Runnable r = () => {};";
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- convert Java lambdas `->` to TypeScript `=>`
- document arrow function support
- test lambda conversion
- list test in roadmap

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843df45e7a8832199c685eac05d0a8b