### PR TITLE
Implement TODO per statement stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
-preserving each method's name and indentation. Each stub contains a
-`// TODO` comment. Basic parameter and
+preserving each method's name and indentation. Stubs insert one
+`// TODO` comment for every statement in the original method. Basic parameter and
 return types are converted to their TypeScript equivalents. Array types
 map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -1,6 +1,6 @@
 # Java to TypeScript Feature Roadmap
 
-This page outlines how Java language features map to their TypeScript counterparts. Development is test-driven and favors a simple design. The current prototype stubs out Java method bodies with a `// TODO` comment while preserving method signatures and basic type mappings.
+This page outlines how Java language features map to their TypeScript counterparts. Development is test-driven and favors a simple design. The current prototype stubs out Java method bodies with `// TODO` comments—one for each statement—while preserving method signatures and basic type mappings.
 
 Only the features listed below are supported. Anything not mentioned here is considered unsupported.
 ## Supported Features

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -47,14 +47,17 @@ public class Transpiler {
             String line = lines[i];
             String trimmed = line.trim();
             if (trimmed.endsWith("{") && trimmed.contains("(") && !trimmed.startsWith("export")) {
-                String stub = buildMethodStub(line, trimmed);
+                int end = skipBody(lines, i);
+                int count = countStatements(lines, i + 1, end - 1);
+                String stub = buildMethodStub(line, trimmed, Math.max(1, count));
                 if (stub == null) {
-                    out.append(line).append(System.lineSeparator());
-                    i++;
-                    continue;
+                    for (int j = i; j < end; j++) {
+                        out.append(lines[j]).append(System.lineSeparator());
+                    }
+                } else {
+                    out.append(stub);
                 }
-                out.append(stub);
-                i = skipBody(lines, i);
+                i = end;
                 continue;
             }
             out.append(line).append(System.lineSeparator());
@@ -63,7 +66,7 @@ public class Transpiler {
         return out.toString().trim();
     }
 
-    private String buildMethodStub(String line, String trimmed) {
+    private String buildMethodStub(String line, String trimmed, int todoCount) {
         String indent = line.substring(0, line.indexOf(trimmed));
         String beforeBrace = trimmed.substring(0, trimmed.length() - 1).trim();
         int parenStart = beforeBrace.indexOf('(');
@@ -87,7 +90,9 @@ public class Transpiler {
             stub.append(": ").append(tsReturn);
         }
         stub.append(" {").append(System.lineSeparator());
-        stub.append(indent).append("    // TODO").append(System.lineSeparator());
+        for (int i = 0; i < todoCount; i++) {
+            stub.append(indent).append("    // TODO").append(System.lineSeparator());
+        }
         stub.append(indent).append("}").append(System.lineSeparator());
         return stub.toString();
     }
@@ -102,6 +107,19 @@ public class Transpiler {
             i++;
         }
         return i;
+    }
+
+    private int countStatements(String[] lines, int start, int end) {
+        int count = 0;
+        for (int i = start; i <= end && i < lines.length; i++) {
+            String body = lines[i];
+            for (int j = 0; j < body.length(); j++) {
+                if (body.charAt(j) == ';') {
+                    count++;
+                }
+            }
+        }
+        return count;
     }
 
     private String transpileFields(String source) {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -216,4 +216,28 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void stubsOneTodoPerStatement() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    int multi() {",
+            "        int y = 0;",
+            "        y++;",
+            "        return y;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    multi(): number {",
+            "        // TODO",
+            "        // TODO",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- generate a TODO comment for each Java statement
- test that multi-statement methods produce multiple TODOs
- document updated stubbing behavior

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843e313ae1883218216eabb4f105c30