### PR TITLE
Refactor CLI success handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
   to TypeScript files under `src/main/node`
 - `com.example.Result` – container for a successful value or an error
 - `com.example.Option` – optional value helper
+- `Main.run` now returns an `Option<String>` with an error message on failure
 - Tests mirror the transpiler (`TranspilerTest`) and CLI (`MainTest`).
 
 Abstract classes are intentionally avoided. The project prefers composition of
@@ -46,8 +47,8 @@ becomes `() => {}`.
 
 Error handling avoids Java exceptions. Do not use `throw`, `try`, or `catch`.
 Instead, functions should return a `Result` or `Option` object.
-`Main` now exposes a `run` method that returns a `Result` so callers can inspect
-errors without relying on exceptions.
+`Main` now exposes a `run` method that returns an `Option<String>` so callers
+can inspect errors without relying on exceptions.
 
 Annotations are currently skipped entirely, so no TypeScript decorators are
 generated.

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -11,28 +11,28 @@ import java.util.List;
  */
 public class Main {
     public static void main(String[] args) {
-        Result<Void> result = new Main().run();
-        if (result.error().isSome()) {
-            System.err.println(result.error().get());
+        Option<String> error = new Main().run();
+        if (error.isSome()) {
+            System.err.println(error.get());
         }
     }
 
-    private Result<Void> run() {
+    private Option<String> run() {
         Path srcRoot = Path.of("src/main/java");
         Path outRoot = Path.of("src/main/node");
 
         Result<List<Path>> files = listJavaFiles(srcRoot);
         if (!files.isOk()) {
-            return Result.error(files.error().get());
+            return Option.some(files.error().get());
         }
 
         for (Path file : files.value().get()) {
-            Result<Void> r = transpileFile(srcRoot, outRoot, file);
-            if (!r.isOk()) {
-                return r;
+            Option<String> err = transpileFile(srcRoot, outRoot, file);
+            if (err.isSome()) {
+                return err;
             }
         }
-        return Result.ok(null);
+        return Option.none();
     }
 
     private Result<List<Path>> listJavaFiles(Path srcRoot) {
@@ -49,7 +49,7 @@ public class Main {
         }
     }
 
-    private Result<Void> transpileFile(Path srcRoot, Path outRoot, Path javaFile) {
+    private Option<String> transpileFile(Path srcRoot, Path outRoot, Path javaFile) {
         try {
             String javaSrc = Files.readString(javaFile);
             String ts = new Transpiler().toTypeScript(javaSrc);
@@ -59,9 +59,9 @@ public class Main {
             Path outFile = outRoot.resolve(withoutExt + ".ts");
             Files.createDirectories(outFile.getParent());
             Files.writeString(outFile, ts + System.lineSeparator());
-            return Result.ok(null);
+            return Option.none();
         } catch (IOException e) {
-            return Result.error(e.getMessage());
+            return Option.some(e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- change `Main.run` to return `Option<String>` instead of `Result<Void>`
- update README for new return type

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6843e5be3bfc83218263989ceb55b536