### PR TITLE
Update transpiler to emit readonly for final fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ tests will drive the full implementation.
 
 Field declarations inside classes are converted to TypeScript property
 syntax with the appropriate type mappings.
+`final` fields become `readonly` properties in the generated TypeScript.
 
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -26,8 +26,9 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`.
-- **Fields** become class properties.
-  - Tests: `TranspilerTest.transpilesFieldDeclarations`.
+  - **Fields** become class properties.
+    - `final` fields are emitted with the `readonly` modifier.
+    - Tests: `TranspilerTest.transpilesFieldDeclarations`, `TranspilerTest.finalFieldsBecomeReadonly`.
 - **Access modifiers** (`public`, `private`, `protected`) map directly. `package‑private` is emitted as a public or internal export.
   - Tests: `TranspilerTest.transpilesClassDefinitionWithModifier`.
 - **Inheritance** via `extends` is preserved.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -142,7 +142,8 @@ public class Transpiler {
 
             String name = tokens[tokens.length - 1];
             String type = tokens[tokens.length - 2];
-            String modifiers = String.join(" ", java.util.Arrays.copyOf(tokens, tokens.length - 2));
+            String[] modArray = java.util.Arrays.copyOf(tokens, tokens.length - 2);
+            String modifiers = replaceFinalWithReadonly(modArray);
             String tsType = toTsType(type);
             out.append(indent);
             if (!modifiers.isBlank()) {
@@ -151,6 +152,15 @@ public class Transpiler {
             out.append(name).append(": ").append(tsType).append(";").append(System.lineSeparator());
         }
         return out.toString().trim();
+    }
+
+    private String replaceFinalWithReadonly(String[] mods) {
+        for (int i = 0; i < mods.length; i++) {
+            if (mods[i].equals("final")) {
+                mods[i] = "readonly";
+            }
+        }
+        return String.join(" ", mods).trim();
     }
 
     private String convertArrowFunctions(String source) {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -172,6 +172,24 @@ class TranspilerTest {
     }
 
     @Test
+    void finalFieldsBecomeReadonly() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    public final int count;",
+            "    private final String name;",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    public readonly count: number;",
+            "    private readonly name: string;",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void preservesExtendsClause() {
         String javaSrc = String.join("\n",
             "public class Child extends Parent {",


### PR DESCRIPTION
## Summary
- add conversion of `final` to `readonly` in field transpilation
- document readonly field handling
- note readonly behavior in the roadmap
- test final fields -> readonly

## Testing
- `bash -x build.sh >/tmp/build.log && tail -n 20 /tmp/build.log`
- `./test.sh >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6843e5ef4c34832198ac1e16ccdbc843