### PR TITLE
Add return stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
 bodies are replaced with stubs in the generated TypeScript while
 preserving each method's name and indentation. Stubs insert one
-`// TODO` comment for every statement in the original method. Basic parameter and
+`// TODO` comment for every statement in the original method. Return statements
+retain the `return` keyword with `/* TODO */` as a placeholder value. Basic parameter and
 return types are converted to their TypeScript equivalents. Array types
 map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -25,7 +25,8 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Generics** preserve type parameters, e.g. `List<T>` → `List<T>`.
   - Tests: `TranspilerTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
-  - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`.
+  - Return statements are emitted as `return /* TODO */;` while other statements become `// TODO` comments.
+  - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`, `TranspilerTest.stubsOneTodoPerStatement`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -49,8 +49,7 @@ public class Transpiler {
             String trimmed = line.trim();
             if (trimmed.endsWith("{") && trimmed.contains("(") && !trimmed.startsWith("export")) {
                 int end = skipBody(lines, i);
-                int count = countStatements(lines, i + 1, end - 1);
-                String stub = buildMethodStub(line, trimmed, Math.max(1, count));
+                String stub = buildMethodStub(line, trimmed, lines, i + 1, end - 1);
                 if (stub == null) {
                     for (int j = i; j < end; j++) {
                         out.append(lines[j]).append(System.lineSeparator());
@@ -67,7 +66,7 @@ public class Transpiler {
         return out.toString().trim();
     }
 
-    private String buildMethodStub(String line, String trimmed, int todoCount) {
+    private String buildMethodStub(String line, String trimmed, String[] lines, int start, int end) {
         String indent = line.substring(0, line.indexOf(trimmed));
         String beforeBrace = trimmed.substring(0, trimmed.length() - 1).trim();
         int parenStart = beforeBrace.indexOf('(');
@@ -91,7 +90,28 @@ public class Transpiler {
             stub.append(": ").append(tsReturn);
         }
         stub.append(" {").append(System.lineSeparator());
-        for (int i = 0; i < todoCount; i++) {
+        boolean wrote = false;
+        for (int i = start; i < end; i++) {
+            String body = lines[i].trim();
+            if (body.isEmpty()) {
+                continue;
+            }
+            wrote = true;
+            if (body.startsWith("return")) {
+                stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+            } else {
+                String[] parts = body.split(";");
+                for (String part : parts) {
+                    if (part.trim().isEmpty()) continue;
+                    if (part.trim().startsWith("return")) {
+                        stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                    } else {
+                        stub.append(indent).append("    // TODO").append(System.lineSeparator());
+                    }
+                }
+            }
+        }
+        if (!wrote) {
             stub.append(indent).append("    // TODO").append(System.lineSeparator());
         }
         stub.append(indent).append("}").append(System.lineSeparator());
@@ -110,25 +130,12 @@ public class Transpiler {
         return i;
     }
 
-    private int countStatements(String[] lines, int start, int end) {
-        int count = 0;
-        for (int i = start; i <= end && i < lines.length; i++) {
-            String body = lines[i];
-            for (int j = 0; j < body.length(); j++) {
-                if (body.charAt(j) == ';') {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
     private String transpileFields(String source) {
         String[] lines = source.split("\\R");
         StringBuilder out = new StringBuilder();
         for (String line : lines) {
             String trimmed = line.trim();
-            if (!trimmed.endsWith(";") || trimmed.contains("(") || trimmed.startsWith("import")) {
+            if (!trimmed.endsWith(";") || trimmed.contains("(") || trimmed.startsWith("import") || trimmed.startsWith("return")) {
                 out.append(line).append(System.lineSeparator());
                 continue;
             }

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -34,7 +34,7 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    bar(x: number): number {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 
@@ -79,13 +79,13 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    fromChar(c: string): string {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "    fromWrapper(c: string): string {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "    fromString(s: string): string {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 
@@ -105,7 +105,7 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    bar(words: string[]): number[] {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 
@@ -125,7 +125,7 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    flag(a: boolean, b: boolean): boolean {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 
@@ -145,7 +145,7 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    names(in: List<string>): List<string> {",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 
@@ -281,7 +281,7 @@ class TranspilerTest {
             "    multi(): number {",
             "        // TODO",
             "        // TODO",
-            "        // TODO",
+            "        return /* TODO */;",
             "    }",
             "}");
 


### PR DESCRIPTION
## Summary
- stub out `return` statements in transpiled methods
- document return stubbing behaviour
- update unit tests for new return statement output

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843e962fdfc83219e79dd86bc0ca221