### PR TITLE
Implement TODO stubs for if statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ method contains at most one loop and braces never nest more than two levels.
 The transpiler removes the `package` declaration since TypeScript does
 not use Java-style packages. It also rewrites simple class definitions
 so that Java modifiers like `public` become `export default`. Method
-bodies are replaced with stubs in the generated TypeScript while
+body text is replaced with stubs in the generated TypeScript while
 preserving each method's name and indentation. Stubs insert one
 `// TODO` comment for every statement in the original method. Return statements
-retain the `return` keyword with `/* TODO */` as a placeholder value. Basic parameter and
+retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks are rewritten as skeletons where the condition becomes `/* TODO */` and the body contains a single `// TODO` comment. Basic parameter and
 return types are converted to their TypeScript equivalents. Array types
 map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -26,7 +26,8 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Return statements are emitted as `return /* TODO */;` while other statements become `// TODO` comments.
-  - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`, `TranspilerTest.stubsOneTodoPerStatement`.
+  - `if` statements output `if (/* TODO */) {` with a single `// TODO` in the body.
+  - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`, `TranspilerTest.stubsOneTodoPerStatement`, `TranspilerTest.stubsIfStatements`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -97,6 +97,23 @@ public class Transpiler {
                 continue;
             }
             wrote = true;
+
+            if ((body.startsWith("if") || body.startsWith("else if")) && body.endsWith("{")) {
+                stub.append(indent).append("    if (/* TODO */) {").append(System.lineSeparator());
+                stub.append(indent).append("        // TODO").append(System.lineSeparator());
+                stub.append(indent).append("    }").append(System.lineSeparator());
+                i = skipBody(lines, i) - 1;
+                continue;
+            }
+
+            if (body.startsWith("else") && body.endsWith("{")) {
+                stub.append(indent).append("    else {").append(System.lineSeparator());
+                stub.append(indent).append("        // TODO").append(System.lineSeparator());
+                stub.append(indent).append("    }").append(System.lineSeparator());
+                i = skipBody(lines, i) - 1;
+                continue;
+            }
+
             if (body.startsWith("return")) {
                 stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
             } else {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -288,4 +288,28 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void stubsIfStatements() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void check(int x) {",
+            "        if (x > 0) {",
+            "            System.out.println(x);",
+            "        }",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    check(x: number): void {",
+            "        if (/* TODO */) {",
+            "            // TODO",
+            "        }",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- stub out if blocks when transpiling Java to TypeScript
- document the new behaviour in README and roadmap
- add tests for stubbing if statements

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684474959bdc832190b06f2731564a49