### PR TITLE
Add while statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ so that Java modifiers like `public` become `export default`. Method
 body text is replaced with stubs in the generated TypeScript while
 preserving each method's name and indentation. Stubs insert one
 `// TODO` comment for every statement in the original method. Return statements
-retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks are rewritten as skeletons where the condition becomes `/* TODO */` and the body contains a single `// TODO` comment. Basic parameter and
+retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks and `while` loops are rewritten as skeletons where the condition becomes `/* TODO */` and the body contains a single `// TODO` comment. Basic parameter and
 return types are converted to their TypeScript equivalents. Array types
 map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -27,8 +27,8 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Return statements are emitted as `return /* TODO */;` while other statements become `// TODO` comments.
-  - `if` statements output `if (/* TODO */) {` with a single `// TODO` in the body.
-  - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`, `TranspilerTest.stubsOneTodoPerStatement`, `TranspilerTest.stubsIfStatements`.
+    - `if` and `while` statements output `<keyword> (/* TODO */) {` with a single `// TODO` in the body.
+    - Tests: `TranspilerTest.stubsMethodBodiesPreservingNames`, `TranspilerTest.stubsVoidReturnTypes`, `TranspilerTest.stubsOneTodoPerStatement`, `TranspilerTest.stubsIfStatements`, `TranspilerTest.stubsWhileStatements`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -103,17 +103,19 @@ public class Transpiler {
             wrote = true;
 
             if ((body.startsWith("if") || body.startsWith("else if")) && body.endsWith("{")) {
-                stub.append(indent).append("    if (/* TODO */) {").append(System.lineSeparator());
-                stub.append(indent).append("        // TODO").append(System.lineSeparator());
-                stub.append(indent).append("    }").append(System.lineSeparator());
+                appendBlockStub(stub, indent, "if", true);
                 i = skipBody(lines, i) - 1;
                 continue;
             }
 
             if (body.startsWith("else") && body.endsWith("{")) {
-                stub.append(indent).append("    else {").append(System.lineSeparator());
-                stub.append(indent).append("        // TODO").append(System.lineSeparator());
-                stub.append(indent).append("    }").append(System.lineSeparator());
+                appendBlockStub(stub, indent, "else", false);
+                i = skipBody(lines, i) - 1;
+                continue;
+            }
+
+            if (body.startsWith("while") && body.endsWith("{")) {
+                appendBlockStub(stub, indent, "while", true);
                 i = skipBody(lines, i) - 1;
                 continue;
             }
@@ -149,6 +151,16 @@ public class Transpiler {
             i++;
         }
         return i;
+    }
+
+    private void appendBlockStub(StringBuilder stub, String indent, String keyword, boolean withCondition) {
+        stub.append(indent).append("    ").append(keyword);
+        if (withCondition) {
+            stub.append(" (/* TODO */)");
+        }
+        stub.append(" {").append(System.lineSeparator());
+        stub.append(indent).append("        // TODO").append(System.lineSeparator());
+        stub.append(indent).append("    }").append(System.lineSeparator());
     }
 
     private String transpileFields(String source) {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -321,4 +321,28 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void stubsWhileStatements() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void loop() {",
+            "        while (true) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    loop(): void {",
+            "        while (/* TODO */) {",
+            "            // TODO",
+            "        }",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- refactor stub generation to reuse a helper
- support `while` loops when stubbing method bodies
- document the new feature
- test while loop stubbing

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684475a6633c8321b3ad3feb56c84860