### PR TITLE
Handle assignments in methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ syntax with the appropriate type mappings.
 `final` fields become `readonly` properties in the generated TypeScript.
 Field assignments are removed so initial values are not emitted.
 Assignments inside arrow function bodies are replaced with `// TODO` comments.
+Assignments that define new variables inside methods become `let` declarations
+with `/* TODO */` as the initializer.
 
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -43,6 +43,10 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Lambda expressions** become arrow functions.
   - Assignment statements inside arrow function bodies are replaced with `// TODO`.
   - Tests: `TranspilerTest.stubsAssignmentsInArrowFunctions`.
+  - Variable definitions within method bodies are emitted as `let` declarations
+    with `/* TODO */` for the assigned value.
+  - Tests: `TranspilerTest.stubsOneTodoPerStatement`,
+    `TranspilerTest.leavesValueAssignmentsAsTodo`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -123,9 +123,12 @@ public class Transpiler {
             } else {
                 String[] parts = body.split(";");
                 for (String part : parts) {
-                    if (part.trim().isEmpty()) continue;
-                    if (part.trim().startsWith("return")) {
+                    String trimmedPart = part.trim();
+                    if (trimmedPart.isEmpty()) continue;
+                    if (trimmedPart.startsWith("return")) {
                         stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                    } else if (trimmedPart.contains("=")) {
+                        stub.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
                     } else {
                         stub.append(indent).append("    // TODO").append(System.lineSeparator());
                     }
@@ -156,7 +159,7 @@ public class Transpiler {
         StringBuilder out = new StringBuilder();
         for (String line : lines) {
             String trimmed = line.trim();
-            if (!trimmed.endsWith(";") || trimmed.contains("(") || trimmed.startsWith("import") || trimmed.startsWith("return")) {
+            if (!trimmed.endsWith(";") || trimmed.contains("(") || trimmed.startsWith("import") || trimmed.startsWith("return") || trimmed.startsWith("let ")) {
                 out.append(line).append(System.lineSeparator());
                 continue;
             }
@@ -223,8 +226,13 @@ public class Transpiler {
                 if (body.contains("=") && body.contains(";")) {
                     out.append(header).append(System.lineSeparator());
                     for (String part : body.split(";")) {
-                        if (part.trim().isEmpty()) continue;
-                        out.append(indent).append("    // TODO").append(System.lineSeparator());
+                        String trimmedPart = part.trim();
+                        if (trimmedPart.isEmpty()) continue;
+                        if (trimmedPart.contains("=")) {
+                            out.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
+                        } else {
+                            out.append(indent).append("    // TODO").append(System.lineSeparator());
+                        }
                     }
                     out.append(indent).append("};").append(System.lineSeparator());
                     continue;
@@ -233,6 +241,21 @@ public class Transpiler {
             out.append(line).append(System.lineSeparator());
         }
         return out.toString().trim();
+    }
+
+    private String parseAssignment(String stmt, String indent) {
+        int eq = stmt.indexOf('=');
+        if (eq == -1) {
+            return indent + "    // TODO";
+        }
+        String dest = stmt.substring(0, eq).trim();
+        String[] tokens = dest.split("\\s+");
+        if (tokens.length >= 2) {
+            String name = tokens[tokens.length - 1];
+            String type = tokens[tokens.length - 2];
+            return indent + "    let " + name + ": " + toTsType(type) + " = /* TODO */;";
+        }
+        return indent + "    // TODO";
     }
 
     private String toTsParams(String params) {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -15,6 +15,26 @@ class TranspilerTest {
     }
 
     @Test
+    void leavesValueAssignmentsAsTodo() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void set() {",
+            "        x = 1;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    set(): void {",
+            "        // TODO",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void transpilesClassDefinitionWithModifier() {
         String javaSrc = "public final class Bar {}";
         String expected = "export default class Bar {}";
@@ -266,7 +286,7 @@ class TranspilerTest {
 
         String expected = String.join("\n",
             "Runnable r = () => {",
-            "    // TODO",
+            "    let x: number = /* TODO */;",
             "    // TODO",
             "};");
 
@@ -288,7 +308,7 @@ class TranspilerTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    multi(): number {",
-            "        // TODO",
+            "        let y: number = /* TODO */;",
             "        // TODO",
             "        return /* TODO */;",
             "    }",


### PR DESCRIPTION
## Summary
- parse variable declarations in assignments
- ignore `let` statements when processing fields
- stub assignment definitions in arrow functions and methods
- leave value assignments as TODOs
- document assignment handling in README and roadmap
- add tests for new behavior

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684475f1a4448321a03bf7c075945c92