### PR TITLE
Parse invokables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Field assignments are removed so initial values are not emitted.
 Assignments inside arrow function bodies are replaced with `// TODO` comments.
 Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
+Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
+the caller and arguments are emitted as `/* TODO */` placeholders.
 
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -74,5 +74,6 @@ Only the features listed below are supported. Anything not mentioned here is con
 7. Explore concurrency patterns for future features.
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.
+9. Parse invokable expressions and stub out the caller and arguments.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -131,6 +131,8 @@ public class Transpiler {
                         stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
                     } else if (trimmedPart.contains("=")) {
                         stub.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
+                    } else if (isInvokable(trimmedPart)) {
+                        stub.append(parseInvokable(trimmedPart, indent)).append(System.lineSeparator());
                     } else {
                         stub.append(indent).append("    // TODO").append(System.lineSeparator());
                     }
@@ -268,6 +270,32 @@ public class Transpiler {
             return indent + "    let " + name + ": " + toTsType(type) + " = /* TODO */;";
         }
         return indent + "    // TODO";
+    }
+
+    private boolean isInvokable(String stmt) {
+        int open = stmt.indexOf('(');
+        int close = stmt.lastIndexOf(')');
+        if (open == -1 || close == -1 || close <= open) {
+            return false;
+        }
+        String head = stmt.substring(0, open).trim();
+        return !head.startsWith("if") && !head.startsWith("while") && !head.startsWith("for");
+    }
+
+    private String parseInvokable(String stmt, String indent) {
+        int open = stmt.indexOf('(');
+        int close = stmt.lastIndexOf(')');
+        if (open == -1 || close == -1 || close <= open) {
+            return indent + "    // TODO";
+        }
+        String args = stmt.substring(open + 1, close).trim();
+        int count = args.isBlank() ? 0 : args.split(",").length;
+        java.util.List<String> parts = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            parts.add("/* TODO */");
+        }
+        String joined = String.join(", ", parts);
+        return indent + "    /* TODO */(" + joined + ");";
     }
 
     private String toTsParams(String params) {

--- a/src/test/java/com/example/TranspilerTest.java
+++ b/src/test/java/com/example/TranspilerTest.java
@@ -365,4 +365,24 @@ class TranspilerTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void stubsInvokables() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void run() {",
+            "        doThing(a, new Some<>(1));",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    run(): void {",
+            "        /* TODO */(/* TODO */, /* TODO */);",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- support stubbing of method calls and `new` expressions
- document invokable placeholders in README and roadmap
- test invokable parsing

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844781f08d883218547c4b29c4570a7