### PR TITLE
Handle invokables in let statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Assignments inside arrow function bodies are replaced with `// TODO` comments.
 Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
-the caller and arguments are emitted as `/* TODO */` placeholders.
+the caller and arguments are emitted as `/* TODO */` placeholders. This also
+applies to variable definitions like `int x = run();`, which become
+`let x: number = /* TODO */();`.
 
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -47,6 +47,11 @@ Only the features listed below are supported. Anything not mentioned here is con
     with `/* TODO */` for the assigned value.
   - Tests: `TranspilerStatementTest.stubsOneTodoPerStatement`,
     `TranspilerStatementTest.leavesValueAssignmentsAsTodo`.
+- **Invokable expressions** like method or constructor calls are stubbed with
+  `/* TODO */` placeholders for the callee and each argument. This includes
+  assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
+  - Tests: `TranspilerStatementTest.stubsInvokables`,
+    `TranspilerStatementTest.stubsInvokablesInLetStatements`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 
@@ -74,6 +79,8 @@ Only the features listed below are supported. Anything not mentioned here is con
 7. Explore concurrency patterns for future features.
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.
-9. Parse invokable expressions and stub out the caller and arguments.
+9. ~~Parse invokable expressions and stub out the caller and arguments.~~
+   Tests ensure calls are stubbed in both standalone statements and in `let`
+   declarations.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -263,11 +263,13 @@ public class Transpiler {
             return indent + "    // TODO";
         }
         String dest = stmt.substring(0, eq).trim();
+        String rhs = stmt.substring(eq + 1).trim();
         String[] tokens = dest.split("\\s+");
         if (tokens.length >= 2) {
             String name = tokens[tokens.length - 1];
             String type = tokens[tokens.length - 2];
-            return indent + "    let " + name + ": " + toTsType(type) + " = /* TODO */;";
+            String value = isInvokable(rhs) ? stubInvokableExpr(rhs) : "/* TODO */";
+            return indent + "    let " + name + ": " + toTsType(type) + " = " + value + ";";
         }
         return indent + "    // TODO";
     }
@@ -283,10 +285,14 @@ public class Transpiler {
     }
 
     private String parseInvokable(String stmt, String indent) {
+        return indent + "    " + stubInvokableExpr(stmt) + ";";
+    }
+
+    private String stubInvokableExpr(String stmt) {
         int open = stmt.indexOf('(');
         int close = stmt.lastIndexOf(')');
         if (open == -1 || close == -1 || close <= open) {
-            return indent + "    // TODO";
+            return "/* TODO */";
         }
         String args = stmt.substring(open + 1, close).trim();
         int count = args.isBlank() ? 0 : args.split(",").length;
@@ -295,7 +301,7 @@ public class Transpiler {
             parts.add("/* TODO */");
         }
         String joined = String.join(", ", parts);
-        return indent + "    /* TODO */(" + joined + ");";
+        return "/* TODO */(" + joined + ")";
     }
 
     private String toTsParams(String params) {

--- a/src/test/java/com/example/TranspilerStatementTest.java
+++ b/src/test/java/com/example/TranspilerStatementTest.java
@@ -27,6 +27,26 @@ class TranspilerStatementTest {
     }
 
     @Test
+    void stubsInvokablesInLetStatements() {
+        String javaSrc = String.join("\n",
+                "public class Foo {",
+                "    void run() {",
+                "        int x = doThing(a, new Some<>(1));",
+                "    }",
+                "}");
+
+        String expected = String.join("\n",
+                "export default class Foo {",
+                "    run(): void {",
+                "        let x: number = /* TODO */(/* TODO */, /* TODO */);",
+                "    }",
+                "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void leavesValueAssignmentsAsTodo() {
         String javaSrc = String.join("\n",
             "public class Foo {",


### PR DESCRIPTION
## Summary
- handle invokable expressions as let initializers
- document invokable handling for variable declarations
- mark invokable parsing task complete on the roadmap
- test invokable calls assigned to variables

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68447985b2ec83218fb17a18e4ad647c