### PR TITLE
Implement simple import resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders.
+Import statements are rewritten to relative paths that mirror the Java package
+structure.
 
 Generic type parameters are preserved, so `List<String>` becomes
 `List<string>` in the transpiled output.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -75,5 +75,6 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.
 9. Parse invokable expressions and stub out the caller and arguments.
+10. Translate `import` statements to relative paths reflecting the package hierarchy.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/com/example/Transpiler.java
+++ b/src/main/java/com/example/Transpiler.java
@@ -15,9 +15,11 @@ public class Transpiler {
      * @return transpiled TypeScript
      */
     public String toTypeScript(String javaSource) {
+        String pkg = extractPackage(javaSource);
         String withoutPackage = removePackage(javaSource);
+        String withImports = translateImports(withoutPackage, pkg);
 
-        String[] lines = withoutPackage.split("\\R");
+        String[] lines = withImports.split("\\R");
         StringBuilder ts = new StringBuilder();
         for (String line : lines) {
             int classIdx = line.indexOf("class");
@@ -344,6 +346,65 @@ public class Transpiler {
             mapped.add(toTsType(p.trim()));
         }
         return base + "<" + String.join(", ", mapped) + ">";
+    }
+
+    private String extractPackage(String source) {
+        for (String line : source.split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("package ") && trimmed.endsWith(";")) {
+                String pkg = trimmed.substring(8, trimmed.length() - 1).trim();
+                return pkg;
+            }
+        }
+        return "";
+    }
+
+    private String translateImports(String source, String currentPkg) {
+        String[] lines = source.split("\\R");
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            String trimmed = line.trim();
+            if (trimmed.startsWith("import ") && trimmed.endsWith(";") &&
+                    !trimmed.contains("*") && !trimmed.startsWith("import static")) {
+                String imp = trimmed.substring(7, trimmed.length() - 1).trim();
+                String replacement = buildImport(imp, currentPkg);
+                out.append("import ").append(replacement).append(";").append(System.lineSeparator());
+                // skip blank lines following the import
+                int j = i + 1;
+                while (j < lines.length && lines[j].trim().isEmpty()) {
+                    i = j;
+                    j++;
+                }
+                continue;
+            }
+            out.append(line).append(System.lineSeparator());
+        }
+        return out.toString().trim();
+    }
+
+    private String buildImport(String imp, String currentPkg) {
+        String[] parts = imp.split("\\.");
+        if (parts.length == 0) return imp;
+        String className = parts[parts.length - 1];
+        String[] importPkgParts = java.util.Arrays.copyOf(parts, parts.length - 1);
+        String[] currentParts = currentPkg.isBlank() ? new String[0] : currentPkg.split("\\.");
+        int i = 0;
+        while (i < currentParts.length && i < importPkgParts.length && currentParts[i].equals(importPkgParts[i])) {
+            i++;
+        }
+        StringBuilder path = new StringBuilder();
+        for (int j = i; j < currentParts.length; j++) {
+            path.append("../");
+        }
+        for (int j = i; j < importPkgParts.length; j++) {
+            path.append(importPkgParts[j]).append('/');
+        }
+        path.append(className);
+        if (!path.toString().startsWith("../")) {
+            path.insert(0, "./");
+        }
+        return className + " from \"" + path.toString() + "\"";
     }
 
     private String removePackage(String source) {

--- a/src/test/java/com/example/TranspilerImportTest.java
+++ b/src/test/java/com/example/TranspilerImportTest.java
@@ -1,0 +1,46 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TranspilerImportTest {
+
+    @Test
+    void translatesImportsRelativeToPackage() {
+        String javaSrc = String.join("\n",
+            "package com.example.util;",
+            "",
+            "import com.example.data.Model;",
+            "",
+            "public class Util {}"
+        );
+
+        String expected = String.join("\n",
+            "import Model from \"../data/Model\";",
+            "export default class Util {}"
+        );
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void importsFromSamePackageUseDotSlash() {
+        String javaSrc = String.join("\n",
+            "package com.example;",
+            "",
+            "import com.example.Helper;",
+            "",
+            "public class Foo {}"
+        );
+
+        String expected = String.join("\n",
+            "import Helper from \"./Helper\";",
+            "export default class Foo {}"
+        );
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add simple relative import rewriting to Transpiler
- test import path calculation across packages
- document new import translation feature
- note roadmap task for import handling

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684479bb399083219877d53420f8f69a