### PR TITLE
Add constructor call stubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Assignments inside arrow function bodies are replaced with `// TODO` comments.
 Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
-
-the caller and arguments are emitted as `/* TODO */` placeholders. This also
+the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
+calls keep the `new` keyword, producing `new /* TODO */()` when stubbed. This also
 applies to variable definitions like `int x = run();`, which become
 `let x: number = /* TODO */();`.
 Import statements are rewritten to relative paths that mirror the Java package

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -50,8 +50,11 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Invokable expressions** like method or constructor calls are stubbed with
   `/* TODO */` placeholders for the callee and each argument. This includes
   assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
+  Constructor calls retain the `new` keyword as `new /* TODO */()`.
   - Tests: `TranspilerStatementTest.stubsInvokables`,
-    `TranspilerStatementTest.stubsInvokablesInLetStatements`.
+    `TranspilerStatementTest.stubsInvokablesInLetStatements`,
+    `TranspilerStatementTest.stubsConstructorCalls`,
+    `TranspilerStatementTest.stubsConstructorCallsInLetStatements`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -165,6 +165,8 @@ class MethodStubber {
         if (open == -1 || close == -1 || close <= open) {
             return "/* TODO */";
         }
+        String head = stmt.substring(0, open).trim();
+        boolean isNew = head.startsWith("new ");
         String args = stmt.substring(open + 1, close).trim();
         int count = args.isBlank() ? 0 : args.split(",").length;
         java.util.List<String> parts = new java.util.ArrayList<>();
@@ -172,6 +174,7 @@ class MethodStubber {
             parts.add("/* TODO */");
         }
         String joined = String.join(", ", parts);
-        return "/* TODO */(" + joined + ")";
+        String prefix = isNew ? "new " : "";
+        return prefix + "/* TODO */(" + joined + ")";
     }
 }

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -48,6 +48,46 @@ class TranspilerStatementTest {
     }
 
     @Test
+    void stubsConstructorCalls() {
+        String javaSrc = String.join("\n",
+                "public class Foo {",
+                "    void build() {",
+                "        new Bar(1, 2);",
+                "    }",
+                "}");
+
+        String expected = String.join("\n",
+                "export default class Foo {",
+                "    build(): void {",
+                "        new /* TODO */(/* TODO */, /* TODO */);",
+                "    }",
+                "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void stubsConstructorCallsInLetStatements() {
+        String javaSrc = String.join("\n",
+                "public class Foo {",
+                "    void make() {",
+                "        Bar b = new Bar(1);",
+                "    }",
+                "}");
+
+        String expected = String.join("\n",
+                "export default class Foo {",
+                "    make(): void {",
+                "        let b: any = new /* TODO */(/* TODO */);",
+                "    }",
+                "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void leavesValueAssignmentsAsTodo() {
         String javaSrc = String.join("\n",
             "public class Foo {",


### PR DESCRIPTION
## Summary
- handle constructor calls when stubbing invokable expressions
- test that constructor invocations are stubbed in statements and `let` declarations
- document that `new` is preserved for constructor stubs
- update roadmap with new tests

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684480f4a37c8321bc7e3d2ef7cdce76