### PR TITLE
Support member access expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders. This also
 applies to variable definitions like `int x = run();`, which become
 `let x: number = /* TODO */();`.
+Member access expressions like `parent.field` are preserved so assignments such as
+`int x = parent.field;` become `let x: number = parent.field;`.
 Import statements are rewritten to relative paths that mirror the Java package
 structure.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -52,6 +52,9 @@ Only the features listed below are supported. Anything not mentioned here is con
   assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
   - Tests: `TranspilerStatementTest.stubsInvokables`,
     `TranspilerStatementTest.stubsInvokablesInLetStatements`.
+- **Member access** expressions like `parent.child` are kept intact.
+  - Tests: `TranspilerStatementTest.preservesMemberAccessInAssignments`,
+    `TranspilerStatementTest.preservesMemberAccessInReturns`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 
@@ -88,5 +91,6 @@ Only the features listed below are supported. Anything not mentioned here is con
    Tests ensure calls are stubbed in both standalone statements and in `let`
    declarations.
 10. Translate `import` statements to relative paths reflecting the package hierarchy.
+11. Preserve member access expressions like `obj.field`.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -78,7 +78,19 @@ class MethodStubber {
                 continue;
             }
             if (body.startsWith("return")) {
-                stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                String expr = body.substring(6).trim();
+                if (expr.endsWith(";")) {
+                    expr = expr.substring(0, expr.length() - 1).trim();
+                }
+                if (expr.isBlank()) {
+                    stub.append(indent).append("    return;").append(System.lineSeparator());
+                } else if (isMemberAccess(expr)) {
+                    stub.append(indent).append("    return ").append(expr).append(";")
+                       .append(System.lineSeparator());
+                } else {
+                    stub.append(indent).append("    return /* TODO */;")
+                       .append(System.lineSeparator());
+                }
             } else {
                 appendParts(body.split(";"), indent, stub);
             }
@@ -95,11 +107,24 @@ class MethodStubber {
             String trimmedPart = part.trim();
             if (trimmedPart.isEmpty()) continue;
             if (trimmedPart.startsWith("return")) {
-                stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                String expr = trimmedPart.substring(6).trim();
+                if (expr.endsWith(";")) {
+                    expr = expr.substring(0, expr.length() - 1).trim();
+                }
+                if (expr.isBlank()) {
+                    stub.append(indent).append("    return;").append(System.lineSeparator());
+                } else if (isMemberAccess(expr)) {
+                    stub.append(indent).append("    return ").append(expr).append(";")
+                        .append(System.lineSeparator());
+                } else {
+                    stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                }
             } else if (trimmedPart.contains("=")) {
                 stub.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
             } else if (isInvokable(trimmedPart)) {
                 stub.append(parseInvokable(trimmedPart, indent)).append(System.lineSeparator());
+            } else if (isMemberAccess(trimmedPart)) {
+                stub.append(parseMemberAccess(trimmedPart, indent)).append(System.lineSeparator());
             } else {
                 stub.append(indent).append("    // TODO").append(System.lineSeparator());
             }
@@ -139,10 +164,25 @@ class MethodStubber {
         if (tokens.length >= 2) {
             String name = tokens[tokens.length - 1];
             String type = tokens[tokens.length - 2];
-            String value = isInvokable(rhs) ? stubInvokableExpr(rhs) : "/* TODO */";
+            String value;
+            if (isInvokable(rhs)) {
+                value = stubInvokableExpr(rhs);
+            } else if (isMemberAccess(rhs)) {
+                value = rhs;
+            } else {
+                value = "/* TODO */";
+            }
             return indent + "    let " + name + ": " + TypeMapper.toTsType(type) + " = " + value + ";";
         }
         return indent + "    // TODO";
+    }
+
+    static boolean isMemberAccess(String stmt) {
+        return stmt.contains(".") && !stmt.contains("(") && !stmt.contains("=");
+    }
+
+    static String parseMemberAccess(String stmt, String indent) {
+        return indent + "    " + stmt + ";";
     }
 
     static boolean isInvokable(String stmt) {

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -161,4 +161,44 @@ class TranspilerStatementTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void preservesMemberAccessInAssignments() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void run(Parent p) {",
+            "        int x = p.count;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    run(p: any): void {",
+            "        let x: number = p.count;",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void preservesMemberAccessInReturns() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    int get(Parent p) {",
+            "        return p.count;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    get(p: any): number {",
+            "        return p.count;",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- keep member access expressions like `parent.field`
- add tests for assignments and return statements that use member access
- document member access handling in README and roadmap
- note upcoming task for member access on the roadmap

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68448105a1588321bf6b32ac82e79308