### PR TITLE
Add support for string literal assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Field assignments are removed so initial values are not emitted.
 Assignments inside arrow function bodies are replaced with `// TODO` comments.
 Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
+String literals remain intact if they begin and end with double quotes.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 
 the caller and arguments are emitted as `/* TODO */` placeholders. This also

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -139,7 +139,14 @@ class MethodStubber {
         if (tokens.length >= 2) {
             String name = tokens[tokens.length - 1];
             String type = tokens[tokens.length - 2];
-            String value = isInvokable(rhs) ? stubInvokableExpr(rhs) : "/* TODO */";
+            String value;
+            if (isInvokable(rhs)) {
+                value = stubInvokableExpr(rhs);
+            } else if (rhs.length() >= 2 && rhs.startsWith("\"") && rhs.endsWith("\"")) {
+                value = rhs;
+            } else {
+                value = "/* TODO */";
+            }
             return indent + "    let " + name + ": " + TypeMapper.toTsType(type) + " = " + value + ";";
         }
         return indent + "    // TODO";

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -161,4 +161,24 @@ class TranspilerStatementTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void keepsStringValues() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void show() {",
+            "        String msg = \"hi\";",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    show(): void {",
+            "        let msg: string = \"hi\";",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- allow assignments with double-quoted string literals
- record the new behaviour in README
- test string literal handling

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448192b3d48321bfe219018e0721d4