### PR TITLE
Add constructor type parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ with `/* TODO */` as the initializer.
 String literals remain intact if they begin and end with double quotes.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
-calls keep the `new` keyword, producing `new /* TODO */()` when stubbed. This also
+calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also
 applies to variable definitions like `int x = run();`, which become
 `let x: number = /* TODO */();`.
 Member access expressions like `parent.field` are preserved so assignments such as

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -50,7 +50,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Invokable expressions** like method or constructor calls are stubbed with
   `/* TODO */` placeholders for the callee and each argument. This includes
   assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
-  Constructor calls retain the `new` keyword as `new /* TODO */()`.
+  Constructor calls retain the `new` keyword and type name as `new Bar(/* TODO */)`.
   - Tests: `TranspilerStatementTest.stubsInvokables`,
     `TranspilerStatementTest.stubsInvokablesInLetStatements`,
     `TranspilerStatementTest.stubsConstructorCalls`,
@@ -95,5 +95,6 @@ Only the features listed below are supported. Anything not mentioned here is con
    declarations.
 10. Translate `import` statements to relative paths reflecting the package hierarchy.
 11. Preserve member access expressions like `obj.field`.
+12. Parse constructor types so stubs emit `new Type(/* TODO */)`.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -207,6 +207,15 @@ class MethodStubber {
         }
         String head = stmt.substring(0, open).trim();
         boolean isNew = head.startsWith("new ");
+        String callee = "/* TODO */";
+        if (isNew) {
+            String afterNew = head.substring(4).trim();
+            if (!afterNew.isBlank()) {
+                callee = "new " + afterNew;
+            } else {
+                callee = "new /* TODO */";
+            }
+        }
         String args = stmt.substring(open + 1, close).trim();
         int count = args.isBlank() ? 0 : args.split(",").length;
         java.util.List<String> parts = new java.util.ArrayList<>();
@@ -214,7 +223,9 @@ class MethodStubber {
             parts.add("/* TODO */");
         }
         String joined = String.join(", ", parts);
-        String prefix = isNew ? "new " : "";
-        return prefix + "/* TODO */(" + joined + ")";
+        if (!isNew) {
+            callee = "/* TODO */";
+        }
+        return callee + "(" + joined + ")";
     }
 }

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -59,7 +59,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    build(): void {",
-                "        new /* TODO */(/* TODO */, /* TODO */);",
+                "        new Bar(/* TODO */, /* TODO */);",
                 "    }",
                 "}");
 
@@ -79,7 +79,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    make(): void {",
-                "        let b: any = new /* TODO */(/* TODO */);",
+                "        let b: any = new Bar(/* TODO */);",
                 "    }",
                 "}");
 
@@ -202,12 +202,28 @@ class TranspilerStatementTest {
         assertEquals(expected, result);
     }
 
+
     @Test
     void keepsStringValues() {
         String javaSrc = String.join("\n",
             "public class Foo {",
             "    void show() {",
             "        String msg = \"hi\";",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    show(): void {",
+            "        let msg: string = \"hi\";",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void preservesMemberAccessInAssignments() {
         String javaSrc = String.join("\n",
             "public class Foo {",
@@ -218,8 +234,6 @@ class TranspilerStatementTest {
 
         String expected = String.join("\n",
             "export default class Foo {",
-            "    show(): void {",
-            "        let msg: string = \"hi\";",
             "    run(p: any): void {",
             "        let x: number = p.count;",
             "    }",


### PR DESCRIPTION
## Summary
- keep constructor type names when stubbing invokable expressions
- update tests for constructor calls
- document constructor type preservation
- note constructor parsing on the roadmap

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844830e9b6c8321b9fa02329cc7a675