### PR TITLE
Preserve method calls on new instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
 calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also
 applies to variable definitions like `int x = run();`, which become
 `let x: number = /* TODO */();`.
-Calls on freshly constructed objects such as `new Main().run()` are treated the same way, producing `/* TODO */()`.
+Calls on freshly constructed objects such as `new Main().run()` are now preserved intact, so the expression stays `new Main().run()`. This keeps initialization chains visible in the generated code.
 Member access expressions like `parent.field` are preserved so assignments such as
 `int x = parent.field;` become `let x: number = parent.field;`.
 Import statements are rewritten to relative paths that mirror the Java package

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -47,15 +47,17 @@ Only the features listed below are supported. Anything not mentioned here is con
     with `/* TODO */` for the assigned value.
   - Tests: `TranspilerStatementTest.stubsOneTodoPerStatement`,
     `TranspilerStatementTest.leavesValueAssignmentsAsTodo`.
-- **Invokable expressions** like method or constructor calls are stubbed with
-  `/* TODO */` placeholders for the callee and each argument. This includes
-  assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
-  Constructor calls retain the `new` keyword and type name as `new Bar(/* TODO */)`.
+  - **Invokable expressions** like method or constructor calls are stubbed with
+    `/* TODO */` placeholders for the callee and each argument. This includes
+    assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
+    Constructor calls retain the `new` keyword and type name as `new Bar(/* TODO */)`.
+    Calls on freshly created objects such as `new Main().run()` are preserved intact.
   - Tests: `TranspilerStatementTest.stubsInvokables`,
     `TranspilerStatementTest.stubsInvokablesInLetStatements`,
     `TranspilerStatementTest.stubsConstructorCalls`,
     `TranspilerStatementTest.stubsConstructorCallsInLetStatements`,
-    `TranspilerStatementTest.stubsCallsOnNewInstances`.
+    `TranspilerStatementTest.preservesCallsOnNewInstances`,
+    `TranspilerStatementTest.preservesCallsOnNewInstancesInLetStatements`.
 - **Member access** expressions like `parent.child` are kept intact.
   - Tests: `TranspilerStatementTest.preservesMemberAccessInAssignments`,
     `TranspilerStatementTest.preservesMemberAccessInReturns`.
@@ -97,5 +99,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 10. Translate `import` statements to relative paths reflecting the package hierarchy.
 11. Preserve member access expressions like `obj.field`.
 12. Parse constructor types so stubs emit `new Type(/* TODO */)`.
+13. ~~Preserve method calls on newly created instances.~~
+   Calls like `new Main().run()` now remain unchanged in the output.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -222,6 +222,9 @@ class MethodStubber {
             return "/* TODO */";
         }
         String head = stmt.substring(0, open).trim();
+        if (head.startsWith("new ") && head.contains(".")) {
+            return stmt;
+        }
         boolean isNew = head.startsWith("new ") && !head.contains(".");
         String callee = "/* TODO */";
         if (isNew) {

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -88,7 +88,7 @@ class TranspilerStatementTest {
     }
 
     @Test
-    void stubsCallsOnNewInstances() {
+    void preservesCallsOnNewInstances() {
         String javaSrc = String.join("\n",
                 "public class Foo {",
                 "    void run() {",
@@ -99,7 +99,27 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        /* TODO */();",
+                "        new Main().run();",
+                "    }",
+                "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void preservesCallsOnNewInstancesInLetStatements() {
+        String javaSrc = String.join("\n",
+                "public class Foo {",
+                "    void run() {",
+                "        Option<String> error = new Main().run();",
+                "    }",
+                "}");
+
+        String expected = String.join("\n",
+                "export default class Foo {",
+                "    run(): void {",
+                "        let error: Option<string> = new Main().run();",
                 "    }",
                 "}");
 


### PR DESCRIPTION
## Summary
- keep `new ...().method()` calls intact when stubbing
- update unit tests for new behaviour
- document behaviour change in README
- note completed roadmap item

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68448729d98083219f032743d19b7ab1