### PR TITLE
Handle numeric literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Assignments inside arrow function bodies are replaced with `// TODO` comments.
 Assignments that define new variables inside methods become `let` declarations
 with `/* TODO */` as the initializer.
 String literals remain intact if they begin and end with double quotes.
+Numeric literals are now preserved as well, so `int n = 7;` becomes
+`let n: number = 7;` and `return 42;` is emitted unchanged.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
 calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -26,9 +26,9 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Generics** preserve type parameters, e.g. `List<T>` → `List<T>`.
   - Tests: `TranspilerMethodTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
-  - Return statements are emitted as `return /* TODO */;` while other statements become `// TODO` comments.
+  - Return statements with numeric literals are preserved as-is. Other statements become `// TODO` comments.
     - `if` and `while` statements output `<keyword> (/* TODO */) {` with a single `// TODO` in the body.
-      - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`.
+    - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -87,6 +87,9 @@ class MethodStubber {
                 } else if (isMemberAccess(expr)) {
                     stub.append(indent).append("    return ").append(expr).append(";")
                        .append(System.lineSeparator());
+                } else if (isNumeric(expr)) {
+                    stub.append(indent).append("    return ").append(expr).append(";")
+                        .append(System.lineSeparator());
                 } else {
                     stub.append(indent).append("    return /* TODO */;")
                        .append(System.lineSeparator());
@@ -197,7 +200,7 @@ class MethodStubber {
         if (isInvokable(trimmed)) {
             return stubInvokableExpr(trimmed);
         }
-        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed)) {
+        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed) || isNumeric(trimmed)) {
             return trimmed;
         }
         return "/* TODO */";
@@ -208,10 +211,30 @@ class MethodStubber {
         if (isInvokable(trimmed)) {
             return "/* TODO */";
         }
-        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed)) {
+        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed) || isNumeric(trimmed)) {
             return trimmed;
         }
         return "/* TODO */";
+    }
+
+    private static boolean isNumeric(String s) {
+        if (s.isEmpty()) return false;
+        int i = 0;
+        if (s.charAt(0) == '-') {
+            if (s.length() == 1) return false;
+            i = 1;
+        }
+        boolean dot = false;
+        for (; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '.') {
+                if (dot) return false;
+                dot = true;
+                continue;
+            }
+            if (c < '0' || c > '9') return false;
+        }
+        return true;
     }
 
     static String stubInvokableExpr(String stmt) {

--- a/src/test/java/magma/TranspilerMethodTest.java
+++ b/src/test/java/magma/TranspilerMethodTest.java
@@ -18,7 +18,7 @@ class TranspilerMethodTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    bar(x: number): number {",
-            "        return /* TODO */;",
+            "        return 42;",
             "    }",
             "}");
 

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -59,7 +59,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    build(): void {",
-                "        new Bar(/* TODO */, /* TODO */);",
+                "        new Bar(1, 2);",
                 "    }",
                 "}");
 
@@ -79,7 +79,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    make(): void {",
-                "        let b: any = new Bar(/* TODO */);",
+                "        let b: any = new Bar(1);",
                 "    }",
                 "}");
 
@@ -162,7 +162,7 @@ class TranspilerStatementTest {
 
         String expected = String.join("\n",
             "Runnable r = () => {",
-            "    let x: number = /* TODO */;",
+            "    let x: number = 0;",
             "    // TODO",
             "};");
 
@@ -184,7 +184,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    multi(): number {",
-            "        let y: number = /* TODO */;",
+            "        let y: number = 0;",
             "        // TODO",
             "        return /* TODO */;",
             "    }",
@@ -256,6 +256,26 @@ class TranspilerStatementTest {
             "export default class Foo {",
             "    show(): void {",
             "        let msg: string = \"hi\";",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void keepsNumericValues() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void show() {",
+            "        int num = 7;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    show(): void {",
+            "        let num: number = 7;",
             "    }",
             "}");
 


### PR DESCRIPTION
## Summary
- keep numeric literals in method stubs and assignments
- document numeric literal handling in README and roadmap
- add tests for numeric literals

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68448a3de6108321aab193aef854b558