### PR TITLE
Support chained member access after invokable expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 - Helper classes split the converter into smaller pieces:
   - `ImportHelper` handles packages and imports
   - `MethodStubber` replaces method bodies with stubs and now includes a
-    `parseValue` helper for recursively processing expression values
+    `parseValue` helper for recursively processing expression values,
+    including chains of method calls and fields
   - `FieldTranspiler` rewrites field declarations
   - `ArrowHelper` processes lambda expressions
   - `TypeMapper` maps Java types to TypeScript
@@ -55,7 +56,7 @@ applies to variable definitions like `int x = run();`, which become
 `let x: number = /* TODO */();`.
 Calls on freshly constructed objects such as `new Main().run()` are now preserved intact, so the expression stays `new Main().run()`. This keeps initialization chains visible in the generated code.
 Member access expressions like `parent.field` are preserved so assignments such as
-`int x = parent.field;` become `let x: number = parent.field;`.
+`int x = parent.field;` become `let x: number = parent.field;`. Chains that mix method calls and fields, for example `doStuff().value.next`, keep the property access while each call is stubbed.
 Import statements are rewritten to relative paths that mirror the Java package
 structure.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -97,7 +97,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    Tests ensure calls are stubbed in both standalone statements and in `let`
    declarations.
 10. Translate `import` statements to relative paths reflecting the package hierarchy.
-11. Preserve member access expressions like `obj.field`.
+11. Preserve member access expressions like `obj.field` and allow chaining after
+    method calls such as `doStuff().value`.
 12. Parse constructor types so stubs emit `new Type(/* TODO */)`.
 13. ~~Preserve method calls on newly created instances.~~
    Calls like `new Main().run()` now remain unchanged in the output.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -194,10 +194,19 @@ class MethodStubber {
 
     static String parseValue(String value) {
         String trimmed = value.trim();
+        if (trimmed.startsWith("new ") && trimmed.contains(".") && isInvokable(trimmed)) {
+            return trimmed;
+        }
+        if (trimmed.contains(".") && !trimmed.contains("=")) {
+            return parseMemberChain(trimmed);
+        }
         if (isInvokable(trimmed)) {
             return stubInvokableExpr(trimmed);
         }
-        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed)) {
+        if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+            return trimmed;
+        }
+        if (isMemberAccess(trimmed)) {
             return trimmed;
         }
         return "/* TODO */";
@@ -212,6 +221,37 @@ class MethodStubber {
             return trimmed;
         }
         return "/* TODO */";
+    }
+
+    private static String parseMemberChain(String expr) {
+        java.util.List<String> parts = new java.util.ArrayList<>();
+        int depth = 0;
+        StringBuilder part = new StringBuilder();
+        for (int i = 0; i < expr.length(); i++) {
+            char c = expr.charAt(i);
+            if (c == '.' && depth == 0) {
+                parts.add(part.toString());
+                part.setLength(0);
+                continue;
+            }
+            if (c == '(') depth++;
+            if (c == ')') depth--;
+            part.append(c);
+        }
+        parts.add(part.toString());
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < parts.size(); i++) {
+            if (i > 0) out.append('.');
+            out.append(parseChainSegment(parts.get(i).trim()));
+        }
+        return out.toString();
+    }
+
+    private static String parseChainSegment(String seg) {
+        if (isInvokable(seg)) {
+            return stubInvokableExpr(seg);
+        }
+        return seg;
     }
 
     static String stubInvokableExpr(String stmt) {

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -322,4 +322,44 @@ class TranspilerStatementTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void preservesMemberAccessAfterInvokable() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void run() {",
+            "        int x = doStuff().myField;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = /* TODO */().myField;",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parsesDeepChainedAccess() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void run() {",
+            "        int x = first.second().third.fourth;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = first./* TODO */().third.fourth;",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- expand `parseValue` to handle chains of method calls and fields
- parse member chains recursively to keep property access after invocations
- document new ability in README and roadmap
- test chaining like `doStuff().myField` and deeper chains

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448a6655488321bf7958aa2dc91783