### PR TITLE
Unify value parsing for returns and assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
   to TypeScript files under `src/main/node`
 - Helper classes split the converter into smaller pieces:
   - `ImportHelper` handles packages and imports
-  - `MethodStubber` replaces method bodies with stubs and now includes a
-    `parseValue` helper for recursively processing expression values,
-    including chains of method calls and fields
+  - `MethodStubber` replaces method bodies with stubs. Its
+    `parseValue` helper recursively processes expression values,
+    including chains of method calls and fields. Return statements and
+    variable assignments delegate to this helper so value handling lives
+    in one place.
   - `FieldTranspiler` rewrites field declarations
   - `ArrowHelper` processes lambda expressions
   - `TypeMapper` maps Java types to TypeScript
@@ -21,9 +23,10 @@ This repository begins a self‑hosted transpiler from Java to TypeScript. It ke
 - Tests mirror the transpiler (`TranspilerClassTest`, `TranspilerMethodTest`,
   `TranspilerFieldTest`, `TranspilerStatementTest`) and CLI (`MainTest`).
 
-The new `parseValue` routine walks characters one at a time to split
-function arguments. This avoids brittle regular expressions while still
-handling nested parentheses.
+The `parseValue` routine walks characters one at a time to split
+function arguments and to recognize strings, numbers, member access,
+and method calls. This avoids brittle regular expressions while still
+handling nested parentheses and keeps the parsing logic centralized.
 
 Abstract classes are intentionally avoided. The project prefers composition of
 small classes over inheritance hierarchies. Functions are kept small: each

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -84,15 +84,11 @@ class MethodStubber {
                 }
                 if (expr.isBlank()) {
                     stub.append(indent).append("    return;").append(System.lineSeparator());
-                } else if (isMemberAccess(expr)) {
-                    stub.append(indent).append("    return ").append(expr).append(";")
-                       .append(System.lineSeparator());
-                } else if (isNumeric(expr)) {
-                    stub.append(indent).append("    return ").append(expr).append(";")
-                        .append(System.lineSeparator());
                 } else {
-                    stub.append(indent).append("    return /* TODO */;")
-                       .append(System.lineSeparator());
+                    stub.append(indent).append("    return ")
+                        .append(parseValue(expr))
+                        .append(";")
+                        .append(System.lineSeparator());
                 }
             } else {
                 appendParts(body.split(";"), indent, stub);
@@ -116,11 +112,11 @@ class MethodStubber {
                 }
                 if (expr.isBlank()) {
                     stub.append(indent).append("    return;").append(System.lineSeparator());
-                } else if (isMemberAccess(expr)) {
-                    stub.append(indent).append("    return ").append(expr).append(";")
-                        .append(System.lineSeparator());
                 } else {
-                    stub.append(indent).append("    return /* TODO */;").append(System.lineSeparator());
+                    stub.append(indent).append("    return ")
+                        .append(parseValue(expr))
+                        .append(";")
+                        .append(System.lineSeparator());
                 }
             } else if (trimmedPart.contains("=")) {
                 stub.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
@@ -209,6 +205,9 @@ class MethodStubber {
         if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
             return trimmed;
         }
+        if (isNumeric(trimmed)) {
+            return trimmed;
+        }
         if (isMemberAccess(trimmed)) {
             return trimmed;
         }
@@ -220,10 +219,7 @@ class MethodStubber {
         if (isInvokable(trimmed)) {
             return "/* TODO */";
         }
-        if ((trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) || isMemberAccess(trimmed) || isNumeric(trimmed)) {
-            return trimmed;
-        }
-        return "/* TODO */";
+        return parseValue(trimmed);
     }
 
     private static String parseMemberChain(String expr) {


### PR DESCRIPTION
## Summary
- centralize value handling in `MethodStubber.parseValue`
- update return statement logic to call `parseValue`
- keep numeric parsing and argument handling consistent
- document the change in the README

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448c4803308321890635b22f68e927