### PR TITLE
Handle numeric assignments

### DIFF
--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -26,7 +26,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Generics** preserve type parameters, e.g. `List<T>` → `List<T>`.
   - Tests: `TranspilerMethodTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
-  - Return statements with numeric literals are preserved as-is. Other statements become `// TODO` comments.
+  - Numeric literals are preserved in both assignments and return statements. Other statements become `// TODO` comments.
     - `if` and `while` statements output `<keyword> (/* TODO */) {` with a single `// TODO` in the body.
     - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -212,6 +212,9 @@ class MethodStubber {
         if (isMemberAccess(trimmed)) {
             return trimmed;
         }
+        if (isNumeric(trimmed)) {
+            return trimmed;
+        }
         return "/* TODO */";
     }
 


### PR DESCRIPTION
## Summary
- keep numeric literals in MethodStubber's value parser
- update roadmap for numeric literal handling

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68448cae9ba08321a4c06b290dd5234c