### PR TITLE
Handle conditional expressions with parseValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ so that Java modifiers like `public` become `export default`. Method
 body text is replaced with stubs in the generated TypeScript while
 preserving each method's name and indentation. Stubs insert one
 `// TODO` comment for every statement in the original method. Return statements
-retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks and `while` loops are rewritten as skeletons where the condition becomes `/* TODO */` and the body contains a single `// TODO` comment. Basic parameter and
+retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks (`if` and `while`) parse their conditions using `parseValue` so that method calls or member access are stubbed consistently. Other expressions still become `/* TODO */`. Basic parameter and
 return types are converted to their TypeScript equivalents. Array types
 map directly as well, so `int[]` becomes `number[]` and `String[]`
 becomes `string[]`. Future

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -27,8 +27,8 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerMethodTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Return statements with numeric literals are preserved as-is. Other statements become `// TODO` comments.
-    - `if` and `while` statements output `<keyword> (/* TODO */) {` with a single `// TODO` in the body.
-    - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
+    - `if` and `while` statements parse their conditions using `parseValue`. Method calls are stubbed as in assignments and unknown expressions become `/* TODO */`.
+    - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`, `TranspilerStatementTest.parsesInvokableInIfCondition`, `TranspilerStatementTest.parsesMemberAccessInWhileCondition`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -63,17 +63,20 @@ class MethodStubber {
             }
             wrote = true;
             if ((body.startsWith("if") || body.startsWith("else if")) && body.endsWith("{")) {
-                appendBlockStub(stub, indent, "if", true);
+                String keyword = body.startsWith("else if") ? "else if" : "if";
+                String cond = parseCondition(body);
+                appendBlockStub(stub, indent, keyword, cond);
                 i = skipBody(lines, i) - 1;
                 continue;
             }
             if (body.startsWith("else") && body.endsWith("{")) {
-                appendBlockStub(stub, indent, "else", false);
+                appendBlockStub(stub, indent, "else", null);
                 i = skipBody(lines, i) - 1;
                 continue;
             }
             if (body.startsWith("while") && body.endsWith("{")) {
-                appendBlockStub(stub, indent, "while", true);
+                String cond = parseCondition(body);
+                appendBlockStub(stub, indent, "while", cond);
                 i = skipBody(lines, i) - 1;
                 continue;
             }
@@ -146,14 +149,24 @@ class MethodStubber {
         return i;
     }
 
-    static void appendBlockStub(StringBuilder stub, String indent, String keyword, boolean withCondition) {
+    static void appendBlockStub(StringBuilder stub, String indent, String keyword, String condition) {
         stub.append(indent).append("    ").append(keyword);
-        if (withCondition) {
-            stub.append(" (/* TODO */)");
+        if (condition != null) {
+            stub.append(" (").append(condition).append(")");
         }
         stub.append(" {").append(System.lineSeparator());
         stub.append(indent).append("        // TODO").append(System.lineSeparator());
         stub.append(indent).append("    }").append(System.lineSeparator());
+    }
+
+    private static String parseCondition(String stmt) {
+        int open = stmt.indexOf('(');
+        int close = stmt.lastIndexOf(')');
+        if (open == -1 || close == -1 || close <= open) {
+            return "/* TODO */";
+        }
+        String inside = stmt.substring(open + 1, close).trim();
+        return parseValue(inside);
     }
 
     static String parseAssignment(String stmt, String indent) {
@@ -209,7 +222,7 @@ class MethodStubber {
         if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
             return trimmed;
         }
-        if (isMemberAccess(trimmed)) {
+        if (isMemberAccess(trimmed) || isNumeric(trimmed)) {
             return trimmed;
         }
         return "/* TODO */";

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -382,4 +382,52 @@ class TranspilerStatementTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void parsesInvokableInIfCondition() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void check() {",
+            "        if (isValid(run())) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    check(): void {",
+            "        if (/* TODO */(/* TODO */)) {",
+            "            // TODO",
+            "        }",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parsesMemberAccessInWhileCondition() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void loop(Iter it) {",
+            "        while (it.hasNext()) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    loop(it: any): void {",
+            "        while (it./* TODO */()) {",
+            "            // TODO",
+            "        }",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- parse conditional expressions in `if` and `while` blocks using `parseValue`
- treat numeric literals in `parseValue`
- document updated behaviour in README and roadmap
- cover new cases for conditions in tests

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448c616e048321b47c093c4f77730a