### PR TITLE
Implement not operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ with `/* TODO */` as the initializer.
 String literals remain intact if they begin and end with double quotes.
 Numeric literals are now preserved as well, so `int n = 7;` becomes
 `let n: number = 7;` and `return 42;` is emitted unchanged.
+The `parseValue` helper also understands the logical not operator, so
+`if (!flag)` is emitted exactly the same in TypeScript.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
 calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -27,8 +27,9 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerMethodTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Numeric literals are preserved in both assignments and return statements. Other statements become `// TODO` comments.
-    - `if` and `while` statements parse their conditions using `parseValue`. Method calls are stubbed as in assignments and unknown expressions become `/* TODO */`.
-    - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
+  - The logical not operator `!` is preserved so conditions like `!flag` remain unchanged.
+  - `if` and `while` statements parse their conditions using `parseValue`. Method calls are stubbed as in assignments and unknown expressions become `/* TODO */`.
+  - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
     - Field initializations are ignored so assignments are dropped.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -206,6 +206,10 @@ class MethodStubber {
 
     static String parseValue(String value) {
         String trimmed = value.trim();
+        if (trimmed.startsWith("!")) {
+            String rest = trimmed.substring(1).trim();
+            return "!" + parseValue(rest);
+        }
         if (trimmed.startsWith("new ") && trimmed.contains(".") && isInvokable(trimmed)) {
             return trimmed;
         }
@@ -229,6 +233,10 @@ class MethodStubber {
 
     private static String parseValueArg(String value) {
         String trimmed = value.trim();
+        if (trimmed.startsWith("!")) {
+            String rest = trimmed.substring(1).trim();
+            return "!" + parseValue(rest);
+        }
         if (isInvokable(trimmed)) {
             return "/* TODO */";
         }

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -430,4 +430,28 @@ class TranspilerStatementTest {
         String result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void parsesNotOperatorInIfCondition() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void check() {",
+            "        if (!isValid(1)) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    check(): void {",
+            "        if (!/* TODO */(1)) {",
+            "            // TODO",
+            "        }",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- support the logical not operator in `parseValue`
- handle `!` prefix in `parseValueArg`
- document new behavior in README and roadmap
- test negation in if-condition

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68448e9841048321a8b7573682eaca66