### PR TITLE
Keep method names in transpiled calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ with `/* TODO */` as the initializer.
 String literals remain intact if they begin and end with double quotes.
 Numeric literals are now preserved as well, so `int n = 7;` becomes
 `let n: number = 7;` and `return 42;` is emitted unchanged.
-Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
-the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
-calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also
-applies to variable definitions like `int x = run();`, which become
-`let x: number = /* TODO */();`.
+Invokable expressions such as `doThing()` or `new Some<>()` now keep the method
+name intact. Arguments are parsed recursively so unknown values still emit
+`/* TODO */`. Constructor calls keep the `new` keyword and the type name, so
+`new Bar(1)` remains unchanged. Variable assignments like `int x = run();`
+become `let x: number = run();` with the call preserved.
 Calls on freshly constructed objects such as `new Main().run()` are now preserved intact, so the expression stays `new Main().run()`. This keeps initialization chains visible in the generated code.
 Member access expressions like `parent.field` are preserved so assignments such as
-`int x = parent.field;` become `let x: number = parent.field;`. Chains that mix method calls and fields, for example `doStuff().value.next`, keep the property access while each call is stubbed.
+`int x = parent.field;` become `let x: number = parent.field;`. Chains that mix method calls and fields, for example `doStuff().value.next`, keep both the property access and the method names intact.
 Import statements are rewritten to relative paths that mirror the Java package
 structure.
 

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -27,7 +27,7 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerMethodTest.mapsGenericTypes`.
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Numeric literals are preserved in both assignments and return statements. Other statements become `// TODO` comments.
-    - `if` and `while` statements parse their conditions using `parseValue`. Method calls are stubbed as in assignments and unknown expressions become `/* TODO */`.
+    - `if` and `while` statements parse their conditions using `parseValue`. Method calls now keep their names while unknown values become `/* TODO */`.
     - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.
     - `final` fields are emitted with the `readonly` modifier.
@@ -47,11 +47,11 @@ Only the features listed below are supported. Anything not mentioned here is con
     with `/* TODO */` for the assigned value.
   - Tests: `TranspilerStatementTest.stubsOneTodoPerStatement`,
     `TranspilerStatementTest.leavesValueAssignmentsAsTodo`.
-  - **Invokable expressions** like method or constructor calls are stubbed with
-    `/* TODO */` placeholders for the callee and each argument. This includes
-    assignments such as `int x = run();` which become `let x: number = /* TODO */();`.
-    Constructor calls retain the `new` keyword and type name as `new Bar(/* TODO */)`.
-    Calls on freshly created objects such as `new Main().run()` are preserved intact.
+  - **Invokable expressions** like method or constructor calls keep the method
+    name. Arguments are parsed recursively so unknown values emit `/* TODO */`.
+    Assignments such as `int x = run();` become `let x: number = run();`.
+    Constructor calls retain the `new` keyword and type name. Calls on freshly
+    created objects such as `new Main().run()` are preserved intact.
   - Tests: `TranspilerStatementTest.stubsInvokables`,
     `TranspilerStatementTest.stubsInvokablesInLetStatements`,
     `TranspilerStatementTest.stubsConstructorCalls`,
@@ -94,8 +94,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.
 9. ~~Parse invokable expressions and stub out the caller and arguments.~~
-   Tests ensure calls are stubbed in both standalone statements and in `let`
-   declarations.
+   Tests now verify that method names are preserved while arguments fall back to
+   `/* TODO */` when unknown.
 10. Translate `import` statements to relative paths reflecting the package hierarchy.
 11. Preserve member access expressions like `obj.field` and allow chaining after
     method calls such as `doStuff().value`.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -229,9 +229,6 @@ class MethodStubber {
 
     private static String parseValueArg(String value) {
         String trimmed = value.trim();
-        if (isInvokable(trimmed)) {
-            return "/* TODO */";
-        }
         return parseValue(trimmed);
     }
 
@@ -308,29 +305,13 @@ class MethodStubber {
         if (open == -1) {
             return "/* TODO */";
         }
-        String head = stmt.substring(0, open).trim();
-        if (head.startsWith("new ") && head.contains(".")) {
-            return stmt;
-        }
-        boolean isNew = head.startsWith("new ") && !head.contains(".");
-        String callee = "/* TODO */";
-        if (isNew) {
-            String afterNew = head.substring(4).trim();
-            if (!afterNew.isBlank()) {
-                callee = "new " + afterNew;
-            } else {
-                callee = "new /* TODO */";
-            }
-        }
+        String callee = stmt.substring(0, open).trim();
         String args = stmt.substring(open + 1, close).trim();
         java.util.List<String> parts = splitArgs(args);
         for (int i = 0; i < parts.size(); i++) {
             parts.set(i, parseValueArg(parts.get(i)));
         }
         String joined = String.join(", ", parts);
-        if (!isNew) {
-            callee = "/* TODO */";
-        }
         return callee + "(" + joined + ")";
     }
 

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -19,7 +19,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        /* TODO */(/* TODO */, /* TODO */);",
+                "        doThing(/* TODO */, new Some<>(1));",
                 "    }",
                 "}");
 
@@ -39,7 +39,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = /* TODO */(/* TODO */, /* TODO */);",
+                "        let x: number = doThing(/* TODO */, new Some<>(1));",
                 "    }",
                 "}");
 
@@ -335,7 +335,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    run(): void {",
-            "        let x: number = /* TODO */(/* TODO */, /* TODO */);",
+            "        let x: number = doThing(/* TODO */, new Some<>(make(1, 2)));",
             "    }",
             "}");
 
@@ -355,7 +355,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    run(): void {",
-            "        let x: number = /* TODO */().myField;",
+            "        let x: number = doStuff().myField;",
             "    }",
             "}");
 
@@ -375,7 +375,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    run(): void {",
-            "        let x: number = first./* TODO */().third.fourth;",
+            "        let x: number = first.second().third.fourth;",
             "    }",
             "}");
 
@@ -397,7 +397,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    check(): void {",
-            "        if (/* TODO */(/* TODO */)) {",
+            "        if (isValid(run())) {",
             "            // TODO",
             "        }",
             "    }",
@@ -421,7 +421,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    loop(it: any): void {",
-            "        while (it./* TODO */()) {",
+            "        while (it.hasNext()) {",
             "            // TODO",
             "        }",
             "    }",


### PR DESCRIPTION
## Summary
- stop erasing method names when parsing invokable expressions
- allow arguments to be parsed recursively
- update tests for preserved method calls
- document the change in README and roadmap

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448e61bd74832185de866c8e31e73a