### PR TITLE
Allow identifiers as value expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ with `/* TODO */` as the initializer.
 String literals remain intact if they begin and end with double quotes.
 Numeric literals are now preserved as well, so `int n = 7;` becomes
 `let n: number = 7;` and `return 42;` is emitted unchanged.
+Variable references also stay intact. Expressions like `return value;`
+or `int x = other;` keep the identifier rather than `/* TODO */`.
 Invokable expressions such as `doThing()` or `new Some<>()` are parsed so that
 the caller and arguments are emitted as `/* TODO */` placeholders. Constructor
 calls keep the `new` keyword and the type name, producing `new Bar(/* TODO */)` when stubbed. This also

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -61,6 +61,12 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Member access** expressions like `parent.child` are kept intact.
   - Tests: `TranspilerStatementTest.preservesMemberAccessInAssignments`,
     `TranspilerStatementTest.preservesMemberAccessInReturns`.
+- **Identifier values** remain unchanged in assignments and returns.
+  - Tests: `TranspilerStatementTest.keepsIdentifierValues`,
+    `TranspilerMethodTest.mapsBooleanTypes`,
+    `TranspilerMethodTest.mapsGenericTypes`,
+    `TranspilerMethodTest.mapsCharCharacterAndStringToString`,
+    `TranspilerStatementTest.stubsOneTodoPerStatement`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -221,6 +221,9 @@ class MethodStubber {
         if (isMemberAccess(trimmed) || isNumeric(trimmed)) {
             return trimmed;
         }
+        if (isIdentifier(trimmed)) {
+            return trimmed;
+        }
         if (isNumeric(trimmed)) {
             return trimmed;
         }
@@ -282,6 +285,24 @@ class MethodStubber {
                 continue;
             }
             if (c < '0' || c > '9') return false;
+        }
+        return true;
+    }
+
+    private static boolean isIdentifier(String s) {
+        if (s.isEmpty()) return false;
+        if (s.equals("true") || s.equals("false") || s.equals("null")) return false;
+        char first = s.charAt(0);
+        if (!((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '_')) {
+            return false;
+        }
+        for (int i = 1; i < s.length(); i++) {
+            char c = s.charAt(i);
+            boolean letter = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+            boolean digit = c >= '0' && c <= '9';
+            if (!(letter || digit || c == '_')) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/test/java/magma/TranspilerMethodTest.java
+++ b/src/test/java/magma/TranspilerMethodTest.java
@@ -63,13 +63,13 @@ class TranspilerMethodTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    fromChar(c: string): string {",
-            "        return /* TODO */;",
+            "        return c;",
             "    }",
             "    fromWrapper(c: string): string {",
-            "        return /* TODO */;",
+            "        return c;",
             "    }",
             "    fromString(s: string): string {",
-            "        return /* TODO */;",
+            "        return s;",
             "    }",
             "}");
 
@@ -109,7 +109,7 @@ class TranspilerMethodTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    flag(a: boolean, b: boolean): boolean {",
-            "        return /* TODO */;",
+            "        return a;",
             "    }",
             "}");
 
@@ -129,7 +129,7 @@ class TranspilerMethodTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    names(in: List<string>): List<string> {",
-            "        return /* TODO */;",
+            "        return in;",
             "    }",
             "}");
 

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -19,7 +19,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        /* TODO */(/* TODO */, /* TODO */);",
+                "        /* TODO */(a, /* TODO */);",
                 "    }",
                 "}");
 
@@ -39,7 +39,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = /* TODO */(/* TODO */, /* TODO */);",
+                "        let x: number = /* TODO */(a, /* TODO */);",
                 "    }",
                 "}");
 
@@ -186,7 +186,7 @@ class TranspilerStatementTest {
             "    multi(): number {",
             "        let y: number = 0;",
             "        // TODO",
-            "        return /* TODO */;",
+            "        return y;",
             "    }",
             "}");
 
@@ -335,7 +335,7 @@ class TranspilerStatementTest {
         String expected = String.join("\n",
             "export default class Foo {",
             "    run(): void {",
-            "        let x: number = /* TODO */(/* TODO */, /* TODO */);",
+            "        let x: number = /* TODO */(a, /* TODO */);",
             "    }",
             "}");
 
@@ -356,6 +356,26 @@ class TranspilerStatementTest {
             "export default class Foo {",
             "    run(): void {",
             "        let x: number = /* TODO */().myField;",
+            "    }",
+            "}");
+
+        String result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void keepsIdentifierValues() {
+        String javaSrc = String.join("\n",
+            "public class Foo {",
+            "    void copy(int src) {",
+            "        int x = src;",
+            "    }",
+            "}");
+
+        String expected = String.join("\n",
+            "export default class Foo {",
+            "    copy(src: number): void {",
+            "        let x: number = src;",
             "    }",
             "}");
 


### PR DESCRIPTION
## Summary
- keep identifiers when parsing value expressions
- update docs to describe identifier handling
- expand tests to cover identifier values

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68448e8a4b348321ae8ff92c78680075