### PR TITLE
Refactor docs and stub logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,30 @@
 # Java → TypeScript Transpiler Prototype
 
-This repository begins a self‑hosted transpiler from Java to TypeScript. It keeps dependencies to a minimum and follows a test‑driven approach with a simple design. A key goal is to avoid relying on the Java standard library so that it can later be replaced with platform‑specific code.
+This project explores a minimal approach to translating small Java
+programs into TypeScript.  The code is test driven and keeps the design
+as simple as possible so it can eventually self host without relying on
+the full Java standard library.
 
-## Main Classes
-
-- `magma.app.Transpiler` – prototype Java → TypeScript converter
-- `magma.Main` – CLI that converts all sources under `src/main/java`
-  to TypeScript files under `src/main/node`
-- Helper classes split the converter into smaller pieces:
-  - `ImportHelper` handles packages and imports
-  - `MethodStubber` replaces method bodies with stubs. Its
-    `parseValue` helper recursively processes expression values,
-    including chains of method calls and fields. Return statements and
-    variable assignments delegate to this helper so value handling lives
-    in one place.
-  - `FieldTranspiler` rewrites field declarations
-  - `ArrowHelper` processes lambda expressions
-  - `TypeMapper` maps Java types to TypeScript
-- `magma.result.Result` – base interface with `Ok` and `Err` implementations
-- `magma.option.Option` – base interface with `Some` and `None` variants
-- `Main.run` now returns an `Option<String>` with an error message on failure
-- Tests mirror the transpiler (`TranspilerClassTest`, `TranspilerMethodTest`,
-  `TranspilerFieldTest`, `TranspilerStatementTest`) and CLI (`MainTest`).
-
-The `parseValue` routine walks characters one at a time to split
-function arguments and to recognize strings, numbers, member access,
-and method calls. This avoids brittle regular expressions while still
-handling nested parentheses and keeps the parsing logic centralized.
-
-Abstract classes are intentionally avoided. The project prefers composition of
-small classes over inheritance hierarchies. Functions are kept small: each
-method contains at most one loop and braces never nest more than two levels.
-
-The transpiler removes the `package` declaration since TypeScript does
-not use Java-style packages. It also rewrites simple class definitions
-so that Java modifiers like `public` become `export default`. Method
-body text is replaced with stubs in the generated TypeScript while
-preserving each method's name and indentation. Stubs insert one
-`// TODO` comment for every statement in the original method. Return statements
-retain the `return` keyword with `/* TODO */` as a placeholder value. Conditional blocks (`if` and `while`) parse their conditions using `parseValue` so that method calls or member access are stubbed consistently. Other expressions still become `/* TODO */`. Basic parameter and
-return types are converted to their TypeScript equivalents. Array types
-map directly as well, so `int[]` becomes `number[]` and `String[]`
-becomes `string[]`. Future
-tests will drive the full implementation.
-
-Field declarations inside classes are converted to TypeScript property
-syntax with the appropriate type mappings.
-`final` fields become `readonly` properties in the generated TypeScript.
-Field assignments are removed so initial values are not emitted.
-Assignments inside arrow function bodies are replaced with `// TODO` comments.
-Assignments that define new variables inside methods become `let` declarations
-with `/* TODO */` as the initializer.
-String literals remain intact if they begin and end with double quotes.
-Numeric literals are now preserved as well, so `int n = 7;` becomes
-`let n: number = 7;` and `return 42;` is emitted unchanged.
-Variable references also stay intact. Expressions like `return value;`
-or `int x = other;` keep the identifier rather than `/* TODO */`.
-The `parseValue` helper also understands the logical not operator, so
-`if (!flag)` is emitted exactly the same in TypeScript.
-Invokable expressions such as `doThing()` or `new Some<>()` now keep the method
-name intact. Arguments are parsed recursively so unknown values still emit
-`/* TODO */`. Constructor calls keep the `new` keyword and the type name, so
-`new Bar(1)` remains unchanged. Variable assignments like `int x = run();`
-become `let x: number = run();` with the call preserved.
-Calls on freshly constructed objects such as `new Main().run()` are now preserved intact, so the expression stays `new Main().run()`. This keeps initialization chains visible in the generated code.
-Member access expressions like `parent.field` are preserved so assignments such as
-`int x = parent.field;` become `let x: number = parent.field;`. Chains that mix method calls and fields, for example `doStuff().value.next`, keep both the property access and the method names intact.
-Import statements are rewritten to relative paths that mirror the Java package
-structure.
-
-Generic type parameters are preserved, so `List<String>` becomes
-`List<string>` in the transpiled output.
-
-Interface definitions are translated directly, so `public interface Foo`
-becomes `export interface Foo`.
-
-Inheritance via the `extends` keyword and interface implementation with
-`implements` are copied directly to the TypeScript output.
-
-Enum declarations are also converted so that `public enum Foo` becomes
-`export enum Foo` in the resulting TypeScript.
-
-The primitive `boolean` and its wrapper `Boolean` both become TypeScript
-`boolean`, as verified by `TranspilerMethodTest.mapsBooleanTypes`.
-
-Lambda expressions use TypeScript arrow function syntax, so `() -> {}`
-becomes `() => {}`.
-
-Error handling avoids Java exceptions. Do not use `throw`, `try`, or `catch`.
-Instead, functions should return a `Result` or `Option` object.
-`Main` now exposes a `run` method that returns an `Option<String>` so callers
-can inspect errors without relying on exceptions.
-
-Annotations are currently skipped entirely, so no TypeScript decorators are
-generated.
-
-## Documentation
-
-Additional notes and a feature mapping between Java and TypeScript live in
-[`docs/java-to-typescript-roadmap.md`](docs/java-to-typescript-roadmap.md).
-The roadmap now lists the tests that verify each implemented feature.
-Developer guidelines are summarized in
+Full module descriptions live in
+[`docs/architecture-overview.md`](docs/architecture-overview.md).  A
+feature matrix and roadmap of the supported Java constructs can be found
+in [`docs/java-to-typescript-roadmap.md`](docs/java-to-typescript-roadmap.md).
+Coding conventions are summarized in
 [`docs/coding-standards.md`](docs/coding-standards.md).
-Additional guidelines for contributors can be found in [AGENTS.md](AGENTS.md).
 
-### Building and Testing
+## Building and Testing
 
-The project intentionally avoids Maven. Use the provided helper scripts to
-compile and run the JUnit tests. The build script downloads the JUnit Console
-launcher if needed and places compiled classes in a `bin` directory. When the
-compilation step finishes you will see a confirmation message so it is clear the
-build succeeded.
+Use the provided scripts to compile and run the tests.  The build script
+downloads JUnit if necessary and places compiled classes in `bin`.
 
 ```bash
 ./build.sh  # compile sources
 ./test.sh   # execute all tests
 ```
 
-After compiling, you can invoke the transpiler via the CLI. It scans
-`src/main/java` and writes TypeScript files under `src/main/node`:
+After building you can run the transpiler.  It reads Java sources under
+`src/main/java` and writes TypeScript files to `src/main/node`:
 
 ```bash
 java -cp bin magma.Main
 ```
-

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+This transpiler is intentionally small. The code favors plain string
+processing over heavy parsing frameworks so that it can run without the
+full Java standard library.  Each helper focuses on one task and
+contains at most a single loop.  Complex regular expressions are avoided
+in favor of simple scans so the logic stays maintainable.
+
+## Main Modules
+
+- `magma.app.Transpiler` – orchestrates the conversion to TypeScript
+- `ImportHelper` – rewrites package declarations and import lines
+- `MethodStubber` – replaces method bodies with `// TODO` stubs and
+  walks expressions using `parseValue`
+- `FieldTranspiler` – converts Java field definitions
+- `ArrowHelper` – rewrites lambda expressions to arrow functions
+- `TypeMapper` – maps primitive and generic types
+- `magma.Main` – CLI entry point
+- `magma.result.Result` and `magma.option.Option` – lightweight
+  replacements for exceptions
+
+The `parseValue` routine incrementally scans characters.  It recognizes
+member access, method calls, literals and the logical not operator.
+Arguments inside method calls default to `/* TODO */` unless they are
+simple literals.  When a negated expression contains a method call, the
+callee name is replaced with `/* TODO */` so that boolean checks are
+clearly unfinished.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -28,6 +28,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Numeric literals are preserved in both assignments and return statements. Other statements become `// TODO` comments.
   - The logical not operator `!` is preserved so conditions like `!flag` remain unchanged.
+    - When a negated value is a method call, the callee name becomes `/* TODO */` while its arguments are still parsed recursively.
     - `if` and `while` statements parse their conditions using `parseValue`. Method calls now keep their names while unknown values become `/* TODO */`.
   - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.
@@ -70,15 +71,6 @@ Only the features listed below are supported. Anything not mentioned here is con
     `TranspilerStatementTest.stubsOneTodoPerStatement`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
 - **Standard library** utilities are replaced with small TypeScript helpers.
-
-## Key Modules
-- `magma.app.Transpiler` – orchestrates the conversion to TypeScript
-- `ImportHelper` – handles packages and import statements
-- `MethodStubber` – stubs out method bodies
-- `FieldTranspiler` – converts field declarations
-- `ArrowHelper` – rewrites lambda expressions
-- `TypeMapper` – maps Java types to their TypeScript equivalents
-- `magma.Main` – command line driver that runs the transpiler
 
 ## Further tasks
 1. ~~Implement translation of basic class structure and type mappings.~~  

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -208,6 +208,9 @@ class MethodStubber {
         String trimmed = value.trim();
         if (trimmed.startsWith("!")) {
             String rest = trimmed.substring(1).trim();
+            if (isInvokable(rest)) {
+                return "!" + stubInvokableExpr(rest, true);
+            }
             return "!" + parseValue(rest);
         }
         if (trimmed.startsWith("new ") && trimmed.contains(".") && isInvokable(trimmed)) {
@@ -236,6 +239,9 @@ class MethodStubber {
 
     private static String parseValueArg(String value) {
         String trimmed = value.trim();
+        if (isIdentifier(trimmed)) {
+            return "/* TODO */";
+        }
         return parseValue(trimmed);
     }
 
@@ -309,6 +315,10 @@ class MethodStubber {
     }
 
     static String stubInvokableExpr(String stmt) {
+        return stubInvokableExpr(stmt, false);
+    }
+
+    static String stubInvokableExpr(String stmt, boolean stubCallee) {
         int close = stmt.lastIndexOf(')');
         if (close == -1) {
             return "/* TODO */";
@@ -337,6 +347,9 @@ class MethodStubber {
             parts.set(i, parseValueArg(parts.get(i)));
         }
         String joined = String.join(", ", parts);
+        if (stubCallee) {
+            callee = "/* TODO */";
+        }
         return callee + "(" + joined + ")";
     }
 


### PR DESCRIPTION
## Summary
- split architecture details to a new doc
- trim README and reference separate docs
- document negated call stubbing in roadmap
- stub unknown identifier arguments and negated calls in `MethodStubber`

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684491b939f88321b2930b6d8916762f