### PR TITLE
Improve cross-platform build tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ Coding conventions are summarized in
 
 Use the provided scripts to compile and run the tests.  The build script
 downloads JUnit if necessary and places compiled classes in `bin`.
+On Windows, invoke the scripts through `bash` so the same commands work
+across operating systems.
 
 ```bash
-./build.sh  # compile sources
-./test.sh   # execute all tests
+./build.sh          # compile sources
+./test.sh           # execute all tests
+# Windows users
+bash build.sh       # compile sources
+bash test.sh        # execute all tests
 ```
 
 After building you can run the transpiler.  It reads Java sources under

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -6,6 +6,10 @@ full Java standard library.  Each helper focuses on one task and
 contains at most a single loop.  Complex regular expressions are avoided
 in favor of simple scans so the logic stays maintainable.
 
+The build and test scripts are kept as short shell wrappers. They can be
+invoked through `bash` on Windows so the same commands work on both
+platforms.
+
 ## Main Modules
 
 - `magma.app.Transpiler` – orchestrates the conversion to TypeScript

--- a/src/test/java/magma/BuildScriptTest.java
+++ b/src/test/java/magma/BuildScriptTest.java
@@ -12,7 +12,12 @@ import org.junit.jupiter.api.Test;
 class BuildScriptTest {
     @Test
     void printsSuccessMessage() throws Exception {
-        var process = new ProcessBuilder("./build.sh")
+        String os = System.getProperty("os.name").toLowerCase();
+        String[] cmd = os.contains("windows")
+                ? new String[]{"bash", "build.sh"}
+                : new String[]{"./build.sh"};
+
+        var process = new ProcessBuilder(cmd)
                 .directory(new File("."))
                 .redirectErrorStream(true)
                 .start();

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -19,7 +19,7 @@ class TranspilerStatementTest {
         var expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        doThing(/* TODO */, new Some<>(1));",
+                "        doThing(a, new Some<>(1));",
                 "    }",
                 "}");
 
@@ -39,7 +39,7 @@ class TranspilerStatementTest {
         var expected = String.join("\n",
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = doThing(/* TODO */, new Some<>(1));",
+                "        let x: number = doThing(a, new Some<>(1));",
                 "    }",
                 "}");
 
@@ -335,7 +335,7 @@ class TranspilerStatementTest {
         var expected = String.join("\n",
             "export default class Foo {",
             "    run(): void {",
-            "        let x: number = doThing(/* TODO */, new Some<>(make(1, 2)));",
+            "        let x: number = doThing(a, new Some<>(make(1, 2)));",
             "    }",
             "}");
 
@@ -465,7 +465,7 @@ class TranspilerStatementTest {
         var expected = String.join("\n",
             "export default class Foo {",
             "    check(): void {",
-            "        if (!/* TODO */(1)) {",
+            "        if (!isValid(1)) {",
             "            // TODO",
             "        }",
             "    }",


### PR DESCRIPTION
## Summary
- make BuildScriptTest detect Windows and call `bash`
- update statement tests to match new transpiler behavior
- note Windows `bash` usage in documentation

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68449554b1508321a7d287c1226562e1