### PR TITLE
Fix identifier handling bug

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -16,8 +16,6 @@ platforms.
 - `ImportHelper` – rewrites package declarations and import lines
 - `MethodStubber` – replaces method bodies with `// TODO` stubs and
   walks expressions using `parseValue`
-- `MethodStubber.stubInvokableCallee` – drops the method name when a
-  negated call appears in an `if` or `while` condition
 - `FieldTranspiler` – converts Java field definitions
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
 - `TypeMapper` – maps primitive and generic types
@@ -28,6 +26,5 @@ platforms.
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.
 Arguments inside method calls default to `/* TODO */` unless they are
-simple literals.  When a negated expression contains a method call, the
-callee name is replaced with `/* TODO */` so that boolean checks are
-clearly unfinished.
+simple literals or identifiers. Negated method calls keep their callee
+name so boolean checks remain readable.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -28,7 +28,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 - **Methods** keep their names and basic return types such as `int` or `void` translate to `number` or `void`.
   - Numeric literals are preserved in both assignments and return statements. Other statements become `// TODO` comments.
   - The logical not operator `!` is preserved so conditions like `!flag` remain unchanged.
-    - When a negated value is a method call, the callee name becomes `/* TODO */` while its arguments are still parsed recursively.
+    - When a negated value is a method call, the callee name is preserved and arguments are parsed recursively.
     - `if` and `while` statements parse their conditions using `parseValue`. Method calls now keep their names while unknown values become `/* TODO */`.
   - Tests: `TranspilerMethodTest.stubsMethodBodiesPreservingNames`, `TranspilerMethodTest.stubsVoidReturnTypes`, `TranspilerStatementTest.stubsOneTodoPerStatement`, `TranspilerStatementTest.stubsIfStatements`, `TranspilerStatementTest.stubsWhileStatements`, `TranspilerStatementTest.keepsNumericValues`.
   - **Fields** become class properties.
@@ -50,7 +50,8 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerStatementTest.stubsOneTodoPerStatement`,
     `TranspilerStatementTest.leavesValueAssignmentsAsTodo`.
   - **Invokable expressions** like method or constructor calls keep the method
-    name. Arguments are parsed recursively so unknown values emit `/* TODO */`.
+    name. Arguments are parsed recursively so identifiers and literals are kept
+    while unknown expressions emit `/* TODO */`.
     Assignments such as `int x = run();` become `let x: number = run();`.
     Constructor calls retain the `new` keyword and type name. Calls on freshly
     created objects such as `new Main().run()` are preserved intact.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -211,9 +211,6 @@ class MethodStubber {
         var trimmed = value.trim();
         if (trimmed.startsWith("!")) {
             var rest = trimmed.substring(1).trim();
-            if (isInvokable(rest)) {
-                return "!" + stubInvokableCallee(rest);
-            }
             return "!" + parseValue(rest);
         }
         if (trimmed.startsWith("new ") && trimmed.contains(".") && isInvokable(trimmed)) {
@@ -242,9 +239,6 @@ class MethodStubber {
 
     private static String parseValueArg(String value) {
         var trimmed = value.trim();
-        if (isIdentifier(trimmed)) {
-            return "/* TODO */";
-        }
         return parseValue(trimmed);
     }
 
@@ -345,35 +339,6 @@ class MethodStubber {
         parts.replaceAll(MethodStubber::parseValueArg);
         var joined = String.join(", ", parts);
         return callee + "(" + joined + ")";
-    }
-
-    static String stubInvokableCallee(String stmt) {
-        var close = stmt.lastIndexOf(')');
-        if (close == -1) {
-            return "/* TODO */";
-        }
-        var open = -1;
-        var depth = 0;
-        for (var i = close; i >= 0; i--) {
-            var c = stmt.charAt(i);
-            if (c == ')') {
-                depth++;
-            } else if (c == '(') {
-                depth--;
-                if (depth == 0) {
-                    open = i;
-                    break;
-                }
-            }
-        }
-        if (open == -1) {
-            return "/* TODO */";
-        }
-        var args = stmt.substring(open + 1, close).trim();
-        var parts = splitArgs(args);
-        parts.replaceAll(MethodStubber::parseValueArg);
-        var joined = String.join(", ", parts);
-        return "/* TODO */(" + joined + ")";
     }
 
     private static List<String> splitArgs(String args) {


### PR DESCRIPTION
## Summary
- maintain callee names in negated expressions
- keep identifier arguments instead of replacing with TODO
- update architecture and roadmap docs
- remove unused helper method

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844976619f083219db1da9894427afc