### PR TITLE
Introduce PathLike wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ the full Java standard library. Unknown type identifiers are emitted
 unchanged so the generated TypeScript stays close to the original
 sources.
 
+File paths no longer rely directly on `java.nio.file.Path`. A simple
+`PathLike` wrapper keeps the rest of the code independent of NIO.
+
 Full module descriptions live in
 [`docs/architecture-overview.md`](docs/architecture-overview.md).  A
 feature matrix and roadmap of the supported Java constructs can be found

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -25,6 +25,8 @@ platforms.
 - `magma.Main` – CLI entry point
 - `magma.result.Result` and `magma.option.Option` – lightweight
   replacements for exceptions
+- `magma.path.PathLike` and `magma.path.NioPath` – small wrapper around
+  `java.nio.file.Path` so other classes don't depend on NIO directly
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -110,5 +110,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    mapping exists.
 15. Parse statements inside `if` and `while` blocks so nested code is
     handled the same as top-level statements.
+16. Introduce a `PathLike` interface to wrap `java.nio.file.Path`.
+    Refactor `Main` to use this abstraction so future code can swap out
+    the NIO implementation.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -11,6 +11,8 @@ import magma.result.Result;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import magma.path.NioPath;
+import magma.path.PathLike;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,8 +28,8 @@ public class Main {
     }
 
     private Option<String> run() {
-        var srcRoot = Path.of("src/main/java");
-        var outRoot = Path.of("src/main/node");
+        PathLike srcRoot = NioPath.of("src/main/java");
+        PathLike outRoot = NioPath.of("src/main/node");
 
         var files = listJavaFiles(srcRoot);
         if (!files.isOk()) {
@@ -43,12 +45,12 @@ public class Main {
         return new None<>();
     }
 
-    private Result<List<Path>> listJavaFiles(Path srcRoot) {
-        List<Path> javaFiles = new ArrayList<>();
-        try (var stream = Files.walk(srcRoot)) {
+    private Result<List<PathLike>> listJavaFiles(PathLike srcRoot) {
+        List<PathLike> javaFiles = new ArrayList<>();
+        try (var stream = Files.walk(((NioPath) srcRoot).toNio())) {
             stream.forEach(p -> {
                 if (p.toString().endsWith(".java")) {
-                    javaFiles.add(p);
+                    javaFiles.add(NioPath.wrap(p));
                 }
             });
             return new Ok<>(javaFiles);
@@ -57,16 +59,16 @@ public class Main {
         }
     }
 
-    private Option<String> transpileFile(Path srcRoot, Path outRoot, Path javaFile) {
+    private Option<String> transpileFile(PathLike srcRoot, PathLike outRoot, PathLike javaFile) {
         try {
-            var javaSrc = Files.readString(javaFile);
+            var javaSrc = Files.readString(((NioPath) javaFile).toNio());
             var ts = new Transpiler().toTypeScript(javaSrc);
             var rel = srcRoot.relativize(javaFile);
             var name = rel.toString();
             var withoutExt = name.substring(0, name.length() - 5);
             var outFile = outRoot.resolve(withoutExt + ".ts");
-            Files.createDirectories(outFile.getParent());
-            Files.writeString(outFile, ts + System.lineSeparator());
+            Files.createDirectories(((NioPath) outFile.getParent()).toNio());
+            Files.writeString(((NioPath) outFile).toNio(), ts + System.lineSeparator());
             return new None<>();
         } catch (IOException e) {
             return new Some<>(e.getMessage());

--- a/src/main/java/magma/path/NioPath.java
+++ b/src/main/java/magma/path/NioPath.java
@@ -1,0 +1,50 @@
+package magma.path;
+
+import java.nio.file.Path;
+
+/**
+ * Implementation of {@link PathLike} that delegates to a
+ * {@link java.nio.file.Path} instance.
+ */
+public class NioPath implements PathLike {
+    private final Path path;
+
+    private NioPath(Path path) {
+        this.path = path;
+    }
+
+    /** Create a wrapper from path segments. */
+    public static NioPath of(String first) {
+        return new NioPath(Path.of(first));
+    }
+
+    /** Wrap an existing NIO path. */
+    public static NioPath wrap(Path path) {
+        return new NioPath(path);
+    }
+
+    public Path toNio() {
+        return path;
+    }
+
+    @Override
+    public PathLike resolve(String other) {
+        return new NioPath(path.resolve(other));
+    }
+
+    @Override
+    public PathLike relativize(PathLike other) {
+        return new NioPath(path.relativize(((NioPath) other).path));
+    }
+
+    @Override
+    public PathLike getParent() {
+        Path parent = path.getParent();
+        return parent == null ? null : new NioPath(parent);
+    }
+
+    @Override
+    public String toString() {
+        return path.toString();
+    }
+}

--- a/src/main/java/magma/path/PathLike.java
+++ b/src/main/java/magma/path/PathLike.java
@@ -1,0 +1,12 @@
+package magma.path;
+
+/**
+ * Minimal abstraction over file system paths. This wrapper lets the
+ * rest of the code avoid a hard dependency on {@code java.nio.file.Path}.
+ */
+public interface PathLike {
+    PathLike resolve(String other);
+    PathLike relativize(PathLike other);
+    PathLike getParent();
+    @Override String toString();
+}

--- a/src/test/java/magma/PathLikeTest.java
+++ b/src/test/java/magma/PathLikeTest.java
@@ -1,0 +1,19 @@
+package magma;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import magma.path.NioPath;
+import magma.path.PathLike;
+import org.junit.jupiter.api.Test;
+
+class PathLikeTest {
+    @Test
+    void resolvesAndRelativizesPaths() {
+        PathLike base = NioPath.of("a");
+        PathLike child = base.resolve("b");
+        assertEquals("a/b", child.toString());
+        PathLike rel = base.relativize(child);
+        assertEquals("b", rel.toString());
+        assertEquals("a", child.getParent().toString());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `PathLike` abstraction to wrap `java.nio.file.Path`
- implement `NioPath` that delegates to `Path`
- refactor `Main` to use `PathLike`
- document the new path wrapper and update the roadmap
- add unit test for `PathLike`

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68449a99e4d083219828ddd06b04faab