### PR TITLE
Introduce PathLike.walk abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ After building you can run the transpiler.  It reads Java sources under
 ```bash
 java -cp bin magma.Main
 ```
+
+## Key Classes
+
+- `magma.Main` – simple CLI for the transpiler
+- `magma.app.Transpiler` – converts Java code to TypeScript
+- `magma.path.PathLike` – abstracts file system operations such as `walk`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -27,6 +27,8 @@ platforms.
   replacements for exceptions
 - `magma.path.PathLike` and `magma.path.NioPath` – small wrapper around
   `java.nio.file.Path` so other classes don't depend on NIO directly
+- `PathLike.walk` – lists files without exposing `Files.walk` or throwing
+  `IOException`
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -46,17 +46,17 @@ public class Main {
     }
 
     private Result<List<PathLike>> listJavaFiles(PathLike srcRoot) {
-        List<PathLike> javaFiles = new ArrayList<>();
-        try (var stream = Files.walk(((NioPath) srcRoot).toNio())) {
-            stream.forEach(p -> {
-                if (p.toString().endsWith(".java")) {
-                    javaFiles.add(NioPath.wrap(p));
-                }
-            });
-            return new Ok<>(javaFiles);
-        } catch (IOException e) {
-            return new Err<>(e.getMessage());
+        var paths = srcRoot.walk();
+        if (!paths.isOk()) {
+            return new Err<>(paths.error().get());
         }
+        List<PathLike> javaFiles = new ArrayList<>();
+        for (var p : paths.value().get()) {
+            if (p.toString().endsWith(".java")) {
+                javaFiles.add(p);
+            }
+        }
+        return new Ok<>(javaFiles);
     }
 
     private Option<String> transpileFile(PathLike srcRoot, PathLike outRoot, PathLike javaFile) {

--- a/src/main/java/magma/path/NioPath.java
+++ b/src/main/java/magma/path/NioPath.java
@@ -1,6 +1,14 @@
 package magma.path;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import magma.result.Err;
+import magma.result.Ok;
+import magma.result.Result;
 
 /**
  * Implementation of {@link PathLike} that delegates to a
@@ -41,6 +49,17 @@ public class NioPath implements PathLike {
     public PathLike getParent() {
         var parent = path.getParent();
         return parent == null ? null : new NioPath(parent);
+    }
+
+    @Override
+    public Result<Set<PathLike>> walk() {
+        Set<PathLike> out = new LinkedHashSet<>();
+        try (var stream = Files.walk(path)) {
+            stream.forEach(p -> out.add(new NioPath(p)));
+            return new Ok<>(out);
+        } catch (IOException e) {
+            return new Err<>(e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/magma/path/PathLike.java
+++ b/src/main/java/magma/path/PathLike.java
@@ -1,5 +1,8 @@
 package magma.path;
 
+import java.util.Set;
+import magma.result.Result;
+
 /**
  * Minimal abstraction over file system paths. This wrapper lets the
  * rest of the code avoid a hard dependency on {@code java.nio.file.Path}.
@@ -8,5 +11,6 @@ public interface PathLike {
     PathLike resolve(String other);
     PathLike relativize(PathLike other);
     PathLike getParent();
+    Result<Set<PathLike>> walk();
     @Override String toString();
 }

--- a/src/test/java/magma/MainTest.java
+++ b/src/test/java/magma/MainTest.java
@@ -9,6 +9,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import magma.path.NioPath;
+import magma.path.PathLike;
+
 import magma.Main;
 import org.junit.jupiter.api.Test;
 
@@ -33,15 +36,12 @@ class MainTest {
     }
 
     private static void deleteTree(Path root) throws IOException {
-        if (!Files.exists(root)) {
-            return;
-        }
-        List<Path> paths = new ArrayList<>();
-        try (var stream = Files.walk(root)) {
-            stream.forEach(paths::add);
-        }
+        var start = NioPath.wrap(root);
+        var result = start.walk();
+        if (!result.isOk()) return;
+        List<PathLike> paths = new ArrayList<>(result.value().get());
         for (var i = paths.size() - 1; i >= 0; i--) {
-            Files.deleteIfExists(paths.get(i));
+            Files.deleteIfExists(((NioPath) paths.get(i)).toNio());
         }
     }
 }

--- a/src/test/java/magma/PathLikeTest.java
+++ b/src/test/java/magma/PathLikeTest.java
@@ -5,6 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import magma.path.NioPath;
 import magma.path.PathLike;
 import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PathLikeTest {
     @Test
@@ -15,5 +21,24 @@ class PathLikeTest {
         var rel = base.relativize(child);
         assertEquals("b", rel.toString());
         assertEquals("a", child.getParent().toString());
+    }
+
+    @Test
+    void walksDirectories() throws IOException {
+        Path root = Files.createTempDirectory("walks");
+        Path sub = root.resolve("sub");
+        Files.createDirectories(sub);
+        Path file = sub.resolve("A.java");
+        Files.writeString(file, "class A {}");
+
+        PathLike start = NioPath.wrap(root);
+        var result = start.walk();
+        assertTrue(result.isOk());
+        List<PathLike> paths = new ArrayList<>(result.value().get());
+        assertTrue(paths.stream().anyMatch(p -> p.toString().endsWith("A.java")));
+
+        for (var i = paths.size() - 1; i >= 0; i--) {
+            Files.deleteIfExists(((NioPath) paths.get(i)).toNio());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- abstract directory traversal behind `PathLike.walk`
- implement `walk` in `NioPath`
- update `Main` to use new method
- adjust tests and add coverage for walking
- document the new capability and list key classes

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68449c9890fc8321b2f9efe7f6d74dc9