### PR TITLE
Remove toNio helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ unchanged so the generated TypeScript stays close to the original
 sources.
 
 File paths no longer rely directly on `java.nio.file.Path`. A simple
-`PathLike` wrapper keeps the rest of the code independent of NIO.
+`PathLike` wrapper keeps the rest of the code independent of NIO. The
+`NioPath` implementation now provides small helpers for reading and
+writing files so other classes never touch `java.nio.file.Files`.
 
 Full module descriptions live in
 [`docs/architecture-overview.md`](docs/architecture-overview.md).  A
@@ -44,3 +46,4 @@ java -cp bin magma.Main
 - `magma.Main` – simple CLI for the transpiler
 - `magma.app.Transpiler` – converts Java code to TypeScript
 - `magma.path.PathLike` – abstracts file system operations such as `walk`
+- `magma.path.NioPath` – wraps `java.nio.file.Path` and handles basic I/O

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -26,7 +26,9 @@ platforms.
 - `magma.result.Result` and `magma.option.Option` – lightweight
   replacements for exceptions
 - `magma.path.PathLike` and `magma.path.NioPath` – small wrapper around
-  `java.nio.file.Path` so other classes don't depend on NIO directly
+  `java.nio.file.Path` so other classes don't depend on NIO directly.
+  `NioPath` also provides helpers for reading and writing files so
+  callers never touch `java.nio.file.Files`.
 - `PathLike.walk` – lists files without exposing `Files.walk` or throwing
   `IOException`
 

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -9,7 +9,6 @@ import magma.result.Ok;
 import magma.result.Result;
 
 import java.io.IOException;
-import java.nio.file.Files;
 
 import magma.path.NioPath;
 import magma.path.PathLike;
@@ -61,14 +60,14 @@ public class Main {
 
     private Option<String> transpileFile(PathLike srcRoot, PathLike outRoot, PathLike javaFile) {
         try {
-            var javaSrc = Files.readString(((NioPath) javaFile).toNio());
+            var javaSrc = ((NioPath) javaFile).readString();
             var ts = new Transpiler().toTypeScript(javaSrc);
             var rel = srcRoot.relativize(javaFile);
             var name = rel.toString();
             var withoutExt = name.substring(0, name.length() - 5);
             var outFile = outRoot.resolve(withoutExt + ".ts");
-            Files.createDirectories(((NioPath) outFile.getParent()).toNio());
-            Files.writeString(((NioPath) outFile).toNio(), ts + System.lineSeparator());
+            ((NioPath) outFile.getParent()).createDirectories();
+            ((NioPath) outFile).writeString(ts + System.lineSeparator());
             return new None<>();
         } catch (IOException e) {
             return new Some<>(e.getMessage());

--- a/src/main/java/magma/path/NioPath.java
+++ b/src/main/java/magma/path/NioPath.java
@@ -31,8 +31,25 @@ public class NioPath implements PathLike {
         return new NioPath(path);
     }
 
-    public Path toNio() {
-        return path;
+
+    /** Read the file contents as a string. */
+    public String readString() throws IOException {
+        return Files.readString(path);
+    }
+
+    /** Create this directory and any missing parents. */
+    public void createDirectories() throws IOException {
+        Files.createDirectories(path);
+    }
+
+    /** Write text to this file. */
+    public void writeString(String text) throws IOException {
+        Files.writeString(path, text);
+    }
+
+    /** Delete the file if it exists. */
+    public void deleteIfExists() throws IOException {
+        Files.deleteIfExists(path);
     }
 
     @Override

--- a/src/main/node/magma/Main.ts
+++ b/src/main/node/magma/Main.ts
@@ -55,14 +55,14 @@ export default class Main {
 
     transpileFile(srcRoot: PathLike, outRoot: PathLike, javaFile: PathLike): Option<string> {
         // TODO
-        let javaSrc: var = Files.readString(((NioPath)).toNio());
+        let javaSrc: var = ((NioPath)).readString();
         let ts: var = new Transpiler().toTypeScript(javaSrc);
         let rel: var = srcRoot.relativize(javaFile);
         let name: var = rel.toString();
         let withoutExt: var = name.substring(0, name.length());
         let outFile: var = outRoot.resolve(withoutExt + ".ts");
-        Files.createDirectories(((NioPath).getParent()).toNio());
-        Files.writeString(((NioPath)).toNio(), ts + System.lineSeparator());
+        ((NioPath).getParent()).createDirectories();
+        ((NioPath)).writeString(ts + System.lineSeparator());
         return new None<>();
         } catch(/* TODO */);
         return new Some<>(e.getMessage());

--- a/src/main/node/magma/path/NioPath.ts
+++ b/src/main/node/magma/path/NioPath.ts
@@ -20,8 +20,26 @@ export default class NioPath implements PathLike {
         return new NioPath(path);
     }
 
-    toNio(): Path {
-        return path;
+
+    /** Read the file contents as a string. */
+    readString(): string {
+        // TODO
+        throw new Error("NotImplemented");
+    }
+
+    /** Create this directory and any missing parents. */
+    createDirectories(): void {
+        // TODO
+    }
+
+    /** Write text to this file. */
+    writeString(text: string): void {
+        // TODO
+    }
+
+    /** Delete the file if it exists. */
+    deleteIfExists(): void {
+        // TODO
     }
 
     @Override

--- a/src/test/java/magma/MainTest.java
+++ b/src/test/java/magma/MainTest.java
@@ -41,7 +41,7 @@ class MainTest {
         if (!result.isOk()) return;
         List<PathLike> paths = new ArrayList<>(result.value().get());
         for (var i = paths.size() - 1; i >= 0; i--) {
-            Files.deleteIfExists(((NioPath) paths.get(i)).toNio());
+            ((NioPath) paths.get(i)).deleteIfExists();
         }
     }
 }

--- a/src/test/java/magma/PathLikeTest.java
+++ b/src/test/java/magma/PathLikeTest.java
@@ -38,7 +38,7 @@ class PathLikeTest {
         assertTrue(paths.stream().anyMatch(p -> p.toString().endsWith("A.java")));
 
         for (var i = paths.size() - 1; i >= 0; i--) {
-            Files.deleteIfExists(((NioPath) paths.get(i)).toNio());
+            ((NioPath) paths.get(i)).deleteIfExists();
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove toNio from `NioPath`
- add helpers in `NioPath` for reading, writing, creating, and deleting files
- switch `Main` and tests to use the new helpers
- document updated design in README and architecture overview
- update TypeScript stubs accordingly

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68449efab73c8321986cc3af0eae2264