### PR TITLE
Introduce ListLike abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ java -cp bin magma.Main
 - `magma.app.Transpiler` – converts Java code to TypeScript
 - `magma.path.PathLike` – abstracts file system operations such as `walk`
 - `magma.path.NioPath` – wraps `java.nio.file.Path` and handles basic I/O
+- `magma.list.ListLike` – minimal list abstraction
+- `magma.list.JdkList` – default implementation backed by `ArrayList`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -31,6 +31,8 @@ platforms.
   callers never touch `java.nio.file.Files`.
 - `PathLike.walk` – lists files without exposing `Files.walk` or throwing
   `IOException`
+- `magma.list.ListLike` and `magma.list.JdkList` – simple list wrapper so
+  code avoids a hard dependency on `java.util.List`
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -93,6 +93,7 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Map basic stream operations to array helpers.
 6. Provide minimal replacements for common standard library utilities.
    - Introduce small helpers for `List` and `Map` behavior.
+     `ListLike` now wraps `java.util.List`; a `Map` wrapper is still pending.
 7. Explore concurrency patterns for future features.
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -12,8 +12,8 @@ import java.io.IOException;
 
 import magma.path.NioPath;
 import magma.path.PathLike;
-import java.util.ArrayList;
-import java.util.List;
+import magma.list.JdkList;
+import magma.list.ListLike;
 
 /**
  * Simple command line interface for the Transpiler.
@@ -44,12 +44,12 @@ public class Main {
         return new None<>();
     }
 
-    private Result<List<PathLike>> listJavaFiles(PathLike srcRoot) {
+    private Result<ListLike<PathLike>> listJavaFiles(PathLike srcRoot) {
         var paths = srcRoot.walk();
         if (!paths.isOk()) {
             return new Err<>(paths.error().get());
         }
-        List<PathLike> javaFiles = new ArrayList<>();
+        ListLike<PathLike> javaFiles = JdkList.create();
         for (var p : paths.value().get()) {
             if (p.toString().endsWith(".java")) {
                 javaFiles.add(p);

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -1,7 +1,7 @@
 package magma.app;
 
-import java.util.ArrayList;
-import java.util.List;
+import magma.list.JdkList;
+import magma.list.ListLike;
 
 class MethodStubber {
     static String stubMethods(String source) {
@@ -249,7 +249,7 @@ class MethodStubber {
     }
 
     private static String parseMemberChain(String expr) {
-        List<String> parts = new ArrayList<>();
+        ListLike<String> parts = JdkList.create();
         var depth = 0;
         var part = new StringBuilder();
         for (var i = 0; i < expr.length(); i++) {
@@ -342,13 +342,19 @@ class MethodStubber {
         var callee = stmt.substring(0, open).trim();
         var args = stmt.substring(open + 1, close).trim();
         var parts = splitArgs(args);
-        parts.replaceAll(MethodStubber::parseValueArg);
-        var joined = String.join(", ", parts);
+        for (var i = 0; i < parts.size(); i++) {
+            parts.set(i, parseValueArg(parts.get(i)));
+        }
+        var joined = new StringBuilder();
+        for (var i = 0; i < parts.size(); i++) {
+            if (i > 0) joined.append(", ");
+            joined.append(parts.get(i));
+        }
         return callee + "(" + joined + ")";
     }
 
-    private static List<String> splitArgs(String args) {
-        List<String> out = new ArrayList<>();
+    private static ListLike<String> splitArgs(String args) {
+        ListLike<String> out = JdkList.create();
         if (args.isBlank()) return out;
         var depth = 0;
         var part = new StringBuilder();

--- a/src/main/java/magma/app/TypeMapper.java
+++ b/src/main/java/magma/app/TypeMapper.java
@@ -1,14 +1,14 @@
 package magma.app;
 
-import java.util.ArrayList;
-import java.util.List;
+import magma.list.JdkList;
+import magma.list.ListLike;
 
 class TypeMapper {
     static String toTsParams(String params) {
         if (params.isBlank()) {
             return "";
         }
-        List<String> out = new ArrayList<>();
+        ListLike<String> out = JdkList.create();
         for (var p : params.split(",")) {
             var parts = p.trim().split("\\s+");
             if (parts.length == 0) continue;
@@ -16,7 +16,12 @@ class TypeMapper {
             var type = parts.length > 1 ? parts[parts.length - 2] : "any";
             out.add(name + ": " + toTsType(type));
         }
-        return String.join(", ", out);
+        var result = new StringBuilder();
+        for (var i = 0; i < out.size(); i++) {
+            if (i > 0) result.append(", ");
+            result.append(out.get(i));
+        }
+        return result.toString();
     }
 
     static String toTsType(String javaType) {
@@ -41,10 +46,15 @@ class TypeMapper {
     private static String mapGeneric(String javaType, int start, int end) {
         var base = javaType.substring(0, start).trim();
         var params = javaType.substring(start + 1, end);
-        List<String> mapped = new ArrayList<>();
+        ListLike<String> mapped = JdkList.create();
         for (var p : params.split(",")) {
             mapped.add(toTsType(p.trim()));
         }
-        return base + "<" + String.join(", ", mapped) + ">";
+        var joined = new StringBuilder();
+        for (var i = 0; i < mapped.size(); i++) {
+            if (i > 0) joined.append(", ");
+            joined.append(mapped.get(i));
+        }
+        return base + "<" + joined + ">";
     }
 }

--- a/src/main/java/magma/list/JdkList.java
+++ b/src/main/java/magma/list/JdkList.java
@@ -1,0 +1,49 @@
+package magma.list;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** Default ListLike backed by java.util.ArrayList. */
+public class JdkList<T> implements ListLike<T> {
+    private final List<T> list;
+
+    private JdkList(List<T> list) {
+        this.list = list;
+    }
+
+    /** Create an empty list. */
+    public static <T> JdkList<T> create() {
+        return new JdkList<>(new ArrayList<>());
+    }
+
+    /** Wrap an existing java.util.List. */
+    public static <T> JdkList<T> wrap(List<T> list) {
+        return new JdkList<>(list);
+    }
+
+    @Override
+    public void add(T value) {
+        list.add(value);
+    }
+
+    @Override
+    public T get(int index) {
+        return list.get(index);
+    }
+
+    @Override
+    public void set(int index, T value) {
+        list.set(index, value);
+    }
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return list.iterator();
+    }
+}

--- a/src/main/java/magma/list/ListLike.java
+++ b/src/main/java/magma/list/ListLike.java
@@ -1,0 +1,9 @@
+package magma.list;
+
+/** Minimal list abstraction mirroring java.util.List. */
+public interface ListLike<T> extends Iterable<T> {
+    void add(T value);
+    T get(int index);
+    void set(int index, T value);
+    int size();
+}

--- a/src/test/java/magma/ListLikeTest.java
+++ b/src/test/java/magma/ListLikeTest.java
@@ -1,0 +1,23 @@
+package magma;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import magma.list.JdkList;
+import magma.list.ListLike;
+import org.junit.jupiter.api.Test;
+
+class ListLikeTest {
+    @Test
+    void addsAndRetrievesValues() {
+        ListLike<Integer> list = JdkList.create();
+        list.add(1);
+        list.add(2);
+        assertEquals(2, list.size());
+        assertEquals(1, list.get(0));
+        int sum = 0;
+        for (var n : list) {
+            sum += n;
+        }
+        assertEquals(3, sum);
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal `ListLike` interface with a `JdkList` implementation
- refactor core classes to depend on `ListLike` instead of `java.util.List`
- document list wrapper usage
- update roadmap to note progress
- cover new list helper with unit tests

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a06817d08321aec1e449ae393738