### PR TITLE
Introduce custom ListIterator abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ java -cp bin magma.Main
 - `magma.app.Transpiler` – converts Java code to TypeScript
 - `magma.path.PathLike` – abstracts file system operations such as `walk`
 - `magma.path.NioPath` – wraps `java.nio.file.Path` and handles basic I/O
-- `magma.list.ListLike` – minimal list abstraction
+- `magma.list.ListLike` – minimal list abstraction using a custom `ListIterator`
 - `magma.list.JdkList` – default implementation backed by `ArrayList`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -32,7 +32,8 @@ platforms.
 - `PathLike.walk` – lists files without exposing `Files.walk` or throwing
   `IOException`
 - `magma.list.ListLike` and `magma.list.JdkList` – simple list wrapper so
-  code avoids a hard dependency on `java.util.List`
+    code avoids a hard dependency on `java.util.List`. Iteration uses a
+    lightweight `ListIterator` interface instead of `java.lang.Iterable`.
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -93,7 +93,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Map basic stream operations to array helpers.
 6. Provide minimal replacements for common standard library utilities.
    - Introduce small helpers for `List` and `Map` behavior.
-     `ListLike` now wraps `java.util.List`; a `Map` wrapper is still pending.
+     `ListLike` now wraps `java.util.List` and exposes a custom `ListIterator`.
+     A `Map` wrapper is still pending.
 7. Explore concurrency patterns for future features.
    - Investigate Web Workers or async/await translation strategies.
 8. Keep the list of tests up to date as new features are covered.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -35,7 +35,9 @@ public class Main {
             return new Some<>(files.error().get());
         }
 
-        for (var file : files.value().get()) {
+        var fileIt = files.value().get().iterator();
+        while (fileIt.hasNext()) {
+            var file = fileIt.next();
             var err = transpileFile(srcRoot, outRoot, file);
             if (err.isSome()) {
                 return err;
@@ -50,7 +52,9 @@ public class Main {
             return new Err<>(paths.error().get());
         }
         ListLike<PathLike> javaFiles = JdkList.create();
-        for (var p : paths.value().get()) {
+        var pathIt = paths.value().get().iterator();
+        while (pathIt.hasNext()) {
+            var p = pathIt.next();
             if (p.toString().endsWith(".java")) {
                 javaFiles.add(p);
             }

--- a/src/main/java/magma/list/JdkList.java
+++ b/src/main/java/magma/list/JdkList.java
@@ -1,7 +1,6 @@
 package magma.list;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /** Default ListLike backed by java.util.ArrayList. */
@@ -43,7 +42,18 @@ public class JdkList<T> implements ListLike<T> {
     }
 
     @Override
-    public Iterator<T> iterator() {
-        return list.iterator();
+    public ListIterator<T> iterator() {
+        java.util.Iterator<T> it = list.iterator();
+        return new ListIterator<T>() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return it.next();
+            }
+        };
     }
 }

--- a/src/main/java/magma/list/ListIterator.java
+++ b/src/main/java/magma/list/ListIterator.java
@@ -1,0 +1,7 @@
+package magma.list;
+
+/** Minimal iterator abstraction independent of java.util.Iterator. */
+public interface ListIterator<T> {
+    boolean hasNext();
+    T next();
+}

--- a/src/main/java/magma/list/ListLike.java
+++ b/src/main/java/magma/list/ListLike.java
@@ -1,9 +1,10 @@
 package magma.list;
 
-/** Minimal list abstraction mirroring java.util.List. */
-public interface ListLike<T> extends Iterable<T> {
+/** Minimal list abstraction mirroring java.util.List but without Iterable. */
+public interface ListLike<T> {
     void add(T value);
     T get(int index);
     void set(int index, T value);
     int size();
+    ListIterator<T> iterator();
 }

--- a/src/test/java/magma/ListLikeTest.java
+++ b/src/test/java/magma/ListLikeTest.java
@@ -15,8 +15,9 @@ class ListLikeTest {
         assertEquals(2, list.size());
         assertEquals(1, list.get(0));
         int sum = 0;
-        for (var n : list) {
-            sum += n;
+        var it = list.iterator();
+        while (it.hasNext()) {
+            sum += it.next();
         }
         assertEquals(3, sum);
     }


### PR DESCRIPTION
## Summary
- add `ListIterator` abstraction and stop extending `Iterable`
- adapt `JdkList` and `ListLike` to use the new iterator
- refactor `Main` and `ListLikeTest` to iterate explicitly
- document custom iterator in README and architecture docs
- update roadmap with iterator details

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a1f282e083219d4503167c03d0ab