### PR TITLE
Document src/main/node as generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ After building you can run the transpiler.  It reads Java sources under
 java -cp bin magma.Main
 ```
 
+The files under `src/main/node` are generated output. They are tracked in
+version control so we can review the transpiler's progress, but they should
+never be edited directly.
+
 ## Key Classes
 
 - `magma.Main` – simple CLI for the transpiler

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -39,3 +39,9 @@ member access, method calls, literals and the logical not operator.
 Arguments inside method calls default to `/* TODO */` unless they are
 simple literals or identifiers. Negated method calls keep their callee
 name so boolean checks remain readable.
+
+## Generated Output
+
+The transpiler writes TypeScript files under `src/main/node`. These files are
+checked into version control so we can observe how the generated code evolves.
+They should never be edited directly.


### PR DESCRIPTION
## Summary
- clarify that the TypeScript files under `src/main/node` are generated
- note this in the architecture overview

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a2c34e188321898812bdf8a11f4a