### PR TITLE
Add flatMap method to ListIterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,7 @@ never be edited directly.
 - `magma.path.PathLike` – abstracts file system operations such as `walk`
 - `magma.path.NioPath` – wraps `java.nio.file.Path` and handles basic I/O
 - `magma.list.ListLike` – minimal list abstraction using a custom `ListIterator`
-  that now supports `map` and `fold` operations
+  that now supports `map`, `fold`, and `flatMap` operations. The `flatMap`
+  helper accepts an iterator-returning function so callers stay independent of
+  concrete list types.
 - `magma.list.JdkList` – default implementation backed by `ArrayList`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -34,7 +34,9 @@ platforms.
 - `magma.list.ListLike` and `magma.list.JdkList` – simple list wrapper so
     code avoids a hard dependency on `java.util.List`. Iteration uses a
     lightweight `ListIterator` interface instead of `java.lang.Iterable`.
-    The iterator now exposes `map` and `fold` to keep loops out of callers.
+    The iterator now exposes `map`, `fold`, and `flatMap` to keep loops out of callers.
+    `flatMap` takes a function returning another iterator so nested lists can
+    be flattened without revealing the underlying list implementation.
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -93,7 +93,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Map basic stream operations to array helpers.
 6. Provide minimal replacements for common standard library utilities.
    - Introduce small helpers for `List` and `Map` behavior.
-     `ListLike` now wraps `java.util.List` and exposes a custom `ListIterator`.
+    `ListLike` now wraps `java.util.List` and exposes a custom `ListIterator` with `map`, `fold`, and `flatMap` methods. `flatMap` accepts a function returning
+    another iterator so callers can compose nested lists without direct references to concrete collection types.
      A `Map` wrapper is still pending.
 7. Explore concurrency patterns for future features.
    - Investigate Web Workers or async/await translation strategies.

--- a/src/main/java/magma/list/ListIterator.java
+++ b/src/main/java/magma/list/ListIterator.java
@@ -18,6 +18,16 @@ public interface ListIterator<T> {
         return result;
     }
 
+    default <R> ListLike<R> flatMap(Function<T, ListIterator<R>> fn) {
+        return fold(JdkList.create(), (acc, value) -> {
+            fn.apply(value).fold(acc, (a, r) -> {
+                a.add(r);
+                return a;
+            });
+            return acc;
+        });
+    }
+
     default <R> R fold(R init, BiFunction<R, T, R> fn) {
         var acc = init;
         while (hasNext()) {

--- a/src/test/java/magma/ListLikeTest.java
+++ b/src/test/java/magma/ListLikeTest.java
@@ -21,4 +21,24 @@ class ListLikeTest {
         assertEquals("1", mapped.get(0));
         assertEquals("2", mapped.get(1));
     }
+
+    @Test
+    void flatMapsNestedLists() {
+        ListLike<Integer> list = JdkList.create();
+        list.add(1);
+        list.add(2);
+
+        var result = list.iterator().flatMap(v -> {
+            ListLike<String> inner = JdkList.create();
+            inner.add(v + "a");
+            inner.add(v + "b");
+            return inner.iterator();
+        });
+
+        assertEquals(4, result.size());
+        assertEquals("1a", result.get(0));
+        assertEquals("1b", result.get(1));
+        assertEquals("2a", result.get(2));
+        assertEquals("2b", result.get(3));
+    }
 }


### PR DESCRIPTION
## Summary
- let ListIterator.flatMap accept a function returning another iterator
- adjust ListLikeTest for the new flatMap signature
- clarify flatMap behavior in the docs and README

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844a5328fa08321a29ad90d51cb6778