### PR TITLE
Refactor PathLike IO helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ never be edited directly.
 
 - `magma.Main` – simple CLI for the transpiler
 - `magma.app.Transpiler` – converts Java code to TypeScript
-- `magma.path.PathLike` – abstracts file system operations such as `walk`
-- `magma.path.NioPath` – wraps `java.nio.file.Path` and handles basic I/O
+- `magma.path.PathLike` – abstracts file system operations such as `walk`,
+  `readString`, `writeString`, and directory helpers without exposing
+  `IOException`
+- `magma.path.NioPath` – wraps `java.nio.file.Path` and implements these I/O
+  helpers using the JDK
  - `magma.list.ListLike` – minimal list abstraction using a custom `ListIter`
   that now supports `map`, `fold`, and `flatMap` operations. The `flatMap`
   helper accepts an iterator-returning function so callers stay independent of

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -30,6 +30,8 @@ platforms.
   `java.nio.file.Path` so other classes don't depend on NIO directly.
   `NioPath` also provides helpers for reading and writing files so
   callers never touch `java.nio.file.Files`.
+  These helpers now return `Result` or `Option` values rather than
+  throwing `IOException` and are defined on `PathLike`.
 - `PathLike.walk` – lists files without exposing `Files.walk` or throwing
   `IOException`
 - `magma.list.ListLike` and `magma.list.JdkList` – simple list wrapper so

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -117,5 +117,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 16. Introduce a `PathLike` interface to wrap `java.nio.file.Path`.
     Refactor `Main` to use this abstraction so future code can swap out
     the NIO implementation.
+17. Move file I/O helpers onto `PathLike` so `Main` no longer deals with
+    `IOException`. Methods now return `Result` or `Option` objects.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -8,8 +8,6 @@ import magma.result.Err;
 import magma.result.Ok;
 import magma.result.Result;
 
-import java.io.IOException;
-
 import magma.path.NioPath;
 import magma.path.PathLike;
 import magma.list.JdkList;
@@ -63,18 +61,21 @@ public class Main {
     }
 
     private Option<String> transpileFile(PathLike srcRoot, PathLike outRoot, PathLike javaFile) {
-        try {
-            var javaSrc = ((NioPath) javaFile).readString();
-            var ts = new Transpiler().toTypeScript(javaSrc);
-            var rel = srcRoot.relativize(javaFile);
-            var name = rel.toString();
-            var withoutExt = name.substring(0, name.length() - 5);
-            var outFile = outRoot.resolve(withoutExt + ".ts");
-            ((NioPath) outFile.getParent()).createDirectories();
-            ((NioPath) outFile).writeString(ts + System.lineSeparator());
-            return new None<>();
-        } catch (IOException e) {
-            return new Some<>(e.getMessage());
+        var javaSrcResult = javaFile.readString();
+        if (!javaSrcResult.isOk()) {
+            return new Some<>(javaSrcResult.error().get());
         }
+        var javaSrc = javaSrcResult.value().get();
+        var ts = new Transpiler().toTypeScript(javaSrc);
+        var rel = srcRoot.relativize(javaFile);
+        var name = rel.toString();
+        var withoutExt = name.substring(0, name.length() - 5);
+        var outFile = outRoot.resolve(withoutExt + ".ts");
+        var err = outFile.getParent().createDirectories();
+        if (err.isSome()) {
+            return err;
+        }
+        err = outFile.writeString(ts + System.lineSeparator());
+        return err;
     }
 }

--- a/src/main/java/magma/path/NioPath.java
+++ b/src/main/java/magma/path/NioPath.java
@@ -1,6 +1,5 @@
 package magma.path;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
@@ -9,6 +8,9 @@ import java.util.Set;
 import magma.result.Err;
 import magma.result.Ok;
 import magma.result.Result;
+import magma.option.Option;
+import magma.option.Some;
+import magma.option.None;
 
 /**
  * Implementation of {@link PathLike} that delegates to a
@@ -33,23 +35,46 @@ public class NioPath implements PathLike {
 
 
     /** Read the file contents as a string. */
-    public String readString() throws IOException {
-        return Files.readString(path);
+    @Override
+    public Result<String> readString() {
+        try {
+            return new Ok<>(Files.readString(path));
+        } catch (java.io.IOException e) {
+            return new Err<>(e.getMessage());
+        }
     }
 
     /** Create this directory and any missing parents. */
-    public void createDirectories() throws IOException {
-        Files.createDirectories(path);
+    @Override
+    public Option<String> createDirectories() {
+        try {
+            Files.createDirectories(path);
+            return new None<>();
+        } catch (java.io.IOException e) {
+            return new Some<>(e.getMessage());
+        }
     }
 
     /** Write text to this file. */
-    public void writeString(String text) throws IOException {
-        Files.writeString(path, text);
+    @Override
+    public Option<String> writeString(String text) {
+        try {
+            Files.writeString(path, text);
+            return new None<>();
+        } catch (java.io.IOException e) {
+            return new Some<>(e.getMessage());
+        }
     }
 
     /** Delete the file if it exists. */
-    public void deleteIfExists() throws IOException {
-        Files.deleteIfExists(path);
+    @Override
+    public Option<String> deleteIfExists() {
+        try {
+            Files.deleteIfExists(path);
+            return new None<>();
+        } catch (java.io.IOException e) {
+            return new Some<>(e.getMessage());
+        }
     }
 
     @Override
@@ -74,7 +99,7 @@ public class NioPath implements PathLike {
         try (var stream = Files.walk(path)) {
             stream.forEach(p -> out.add(new NioPath(p)));
             return new Ok<>(out);
-        } catch (IOException e) {
+        } catch (java.io.IOException e) {
             return new Err<>(e.getMessage());
         }
     }

--- a/src/main/java/magma/path/PathLike.java
+++ b/src/main/java/magma/path/PathLike.java
@@ -2,6 +2,7 @@ package magma.path;
 
 import java.util.Set;
 import magma.result.Result;
+import magma.option.Option;
 
 /**
  * Minimal abstraction over file system paths. This wrapper lets the
@@ -12,5 +13,9 @@ public interface PathLike {
     PathLike relativize(PathLike other);
     PathLike getParent();
     Result<Set<PathLike>> walk();
+    Result<String> readString();
+    Option<String> createDirectories();
+    Option<String> writeString(String text);
+    Option<String> deleteIfExists();
     @Override String toString();
 }

--- a/src/test/java/magma/MainTest.java
+++ b/src/test/java/magma/MainTest.java
@@ -41,7 +41,7 @@ class MainTest {
         if (!result.isOk()) return;
         List<PathLike> paths = new ArrayList<>(result.value().get());
         for (var i = paths.size() - 1; i >= 0; i--) {
-            ((NioPath) paths.get(i)).deleteIfExists();
+            paths.get(i).deleteIfExists();
         }
     }
 }

--- a/src/test/java/magma/PathLikeTest.java
+++ b/src/test/java/magma/PathLikeTest.java
@@ -1,6 +1,6 @@
 package magma;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import magma.path.NioPath;
 import magma.path.PathLike;
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PathLikeTest {
     @Test
@@ -38,7 +37,27 @@ class PathLikeTest {
         assertTrue(paths.stream().anyMatch(p -> p.toString().endsWith("A.java")));
 
         for (var i = paths.size() - 1; i >= 0; i--) {
-            ((NioPath) paths.get(i)).deleteIfExists();
+            paths.get(i).deleteIfExists();
         }
+    }
+
+    @Test
+    void readsAndWritesFilesWithoutExceptions() throws IOException {
+        Path root = Files.createTempDirectory("rw");
+        Path file = root.resolve("test.txt");
+        PathLike path = NioPath.wrap(file);
+
+        var err = path.getParent().createDirectories();
+        assertFalse(err.isSome());
+
+        err = path.writeString("hi");
+        assertFalse(err.isSome());
+
+        var text = path.readString();
+        assertTrue(text.isOk());
+        assertEquals("hi", text.value().get());
+
+        path.deleteIfExists();
+        NioPath.wrap(root).deleteIfExists();
     }
 }


### PR DESCRIPTION
## Summary
- return `Result` and `Option` from `PathLike` helpers
- hide `IOException` handling inside `NioPath`
- simplify `Main` by using the new helpers
- test file operations without `IOException`
- document `PathLike` changes and update roadmap

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844aa070e1483219cdd79398b1b6661