### PR TITLE
Add tests for member access in conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ never be edited directly.
 - `magma.app.MethodStubber` – replaces method bodies with `// TODO` stubs.
   Helpers now use a single scan so functions never contain more than one loop,
   and indentation levels stay at two or fewer.
+- `magma.app.FieldTranspiler` – converts Java fields into TypeScript
+  properties while ignoring initializations
+- `magma.app.ImportHelper` – rewrites package declarations and import lines
+- `magma.app.ArrowHelper` – turns lambda expressions into arrow functions
+- `magma.app.TypeMapper` – maps primitive and generic types and preserves
+  unknown identifiers

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -107,7 +107,8 @@ Only the features listed below are supported. Anything not mentioned here is con
     `ImportHelper` now rewrites import lines so they use relative module paths.
 11. ~~Preserve member access expressions like `obj.field` and allow chaining after
     method calls such as `doStuff().value`.~~
-    Tests cover both `obj.field` assignments and `doStuff().value` chains.
+    Tests cover `obj.field` assignments, returns, chained accesses, and now
+    verify conditions including `if (p.child)` and `if (!p.child)`.
 12. Parse constructor types so stubs emit `new Type(/* TODO */)`.
 13. ~~Preserve method calls on newly created instances.~~
    Calls like `new Main().run()` now remain unchanged in the output.

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -474,4 +474,52 @@ class TranspilerStatementTest {
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void parsesMemberAccessInIfCondition() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void check(Parent p) {",
+            "        if (p.child) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    check(p: Parent): void {",
+            "        if (p.child) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parsesNotOperatorWithMemberAccess() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void check(Parent p) {",
+            "        if (!p.child) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    check(p: Parent): void {",
+            "        if (!p.child) {",
+            "            System.out.println(1);",
+            "        }",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- test member access expressions used in `if` conditions
- test `!` with member access
- document helper modules in the README
- expand roadmap notes on member access tests

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844c79c6578832199d24a6af512c418