### PR TITLE
Improve invocation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ never be edited directly.
 - `magma.app.ArrowHelper` – turns lambda expressions into arrow functions
 - `magma.app.TypeMapper` – maps primitive and generic types and preserves
   unknown identifiers
+- `src/test/java` – growing suite of tests that now covers nested and chained
+  invocations so the parsing logic remains small yet reliable

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -49,6 +49,11 @@ Arguments inside method calls default to `/* TODO */` unless they are
 simple literals or identifiers. Negated method calls keep their callee
 name so boolean checks remain readable.
 
+Recent tests stress nested and chained invocations to ensure this simple
+scanner handles complex expressions without adding another parsing
+framework. Member access after calls now composes with nested argument
+lists so the design stays minimal while covering common Java idioms.
+
 ## Generated Output
 
 The transpiler writes TypeScript files under `src/main/node`. These files are

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -522,4 +522,64 @@ class TranspilerStatementTest {
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void parsesChainedInvocations() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void run() {",
+            "        int x = first().second().third();",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = first().second().third();",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parsesNestedAndChainedInvocations() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void run() {",
+            "        int x = outer(inner(foo.bar()), other()).value;",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = outer(inner(foo.bar()), other()).value;",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parsesChainedCallsAfterNewInstance() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void run() {",
+            "        int x = new Main().run().value;",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = new Main().run().value;",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for complex invocation expressions
- document how chained invocations are parsed
- list the growing test suite in README

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844cd21af048321bb198f3c3d40554f