### PR TITLE
Add java.util.function mapping

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,6 +24,7 @@ platforms.
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
 - `TypeMapper` – maps primitive and generic types and leaves unknown
   identifiers unchanged so the output stays close to the source
+  - `java.util.function` interfaces map to arrow function types
 - `magma.Main` – CLI entry point
  - `magma.result.Result` and `magma.option.Option` – lightweight
    replacements for exceptions. `Option` values can convert to a generic

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -77,6 +77,7 @@ Only the features listed below are supported. Anything not mentioned here is con
   - Tests: `TranspilerStatementTest.preservesMemberAccessInAssignments`,
     `TranspilerStatementTest.parsesMemberAccessInWhileCondition`.
 - **Streams** rely on array helpers such as `map`, `filter`, and `reduce`.
+- **java.util.function** interfaces become arrow function types.
 - **Standard library** utilities are replaced with small TypeScript helpers.
 
 ## Further tasks

--- a/src/main/java/magma/app/TypeMapper.java
+++ b/src/main/java/magma/app/TypeMapper.java
@@ -8,8 +8,10 @@ class TypeMapper {
         if (params.isBlank()) {
             return "";
         }
+        ListLike<String> pieces = split(params);
         ListLike<String> out = JdkList.create();
-        for (var p : params.split(",")) {
+        for (var i = 0; i < pieces.size(); i++) {
+            var p = pieces.get(i);
             var parts = p.trim().split("\\s+");
             if (parts.length == 0) continue;
             var name = parts[parts.length - 1];
@@ -28,7 +30,44 @@ class TypeMapper {
         var genericStart = javaType.indexOf('<');
         var genericEnd = javaType.lastIndexOf('>');
         if (genericStart != -1 && genericEnd != -1 && genericEnd > genericStart) {
-            return mapGeneric(javaType, genericStart, genericEnd);
+            var base = javaType.substring(0, genericStart).trim();
+            var name = base.substring(base.lastIndexOf('.') + 1);
+            var params = javaType.substring(genericStart + 1, genericEnd);
+            switch (name) {
+                case "Function" -> {
+                    return mapFunction(params);
+                }
+                case "BiFunction" -> {
+                    return mapBiFunction(params);
+                }
+                case "Supplier" -> {
+                    var ts = mapParams(params, 0);
+                    return "() => " + ts.returnType;
+                }
+                case "Consumer" -> {
+                    var ts = mapParams(params, 1);
+                    return "(" + ts.params + ") => void";
+                }
+                case "BiConsumer" -> {
+                    var ts = mapParams(params, 2);
+                    return "(" + ts.params + ") => void";
+                }
+                case "Predicate" -> {
+                    var ts = mapParams(params, 1);
+                    return "(" + ts.params + ") => boolean";
+                }
+                case "UnaryOperator" -> {
+                    var ts = mapParams(params, 1);
+                    return "(" + ts.params + ") => " + ts.returnType;
+                }
+                case "BinaryOperator" -> {
+                    var ts = mapParams(params, 2);
+                    return "(" + ts.params + ") => " + ts.returnType;
+                }
+                default -> {
+                    return mapGeneric(javaType, genericStart, genericEnd);
+                }
+            }
         }
         if (javaType.endsWith("[]")) {
             var element = javaType.substring(0, javaType.length() - 2);
@@ -47,8 +86,9 @@ class TypeMapper {
         var base = javaType.substring(0, start).trim();
         var params = javaType.substring(start + 1, end);
         ListLike<String> mapped = JdkList.create();
-        for (var p : params.split(",")) {
-            mapped.add(toTsType(p.trim()));
+        var pieces = split(params);
+        for (var i = 0; i < pieces.size(); i++) {
+            mapped.add(toTsType(pieces.get(i).trim()));
         }
         var joined = new StringBuilder();
         for (var i = 0; i < mapped.size(); i++) {
@@ -56,5 +96,50 @@ class TypeMapper {
             joined.append(mapped.get(i));
         }
         return base + "<" + joined + ">";
+    }
+
+    private static ListLike<String> split(String text) {
+        ListLike<String> out = JdkList.create();
+        var depth = 0;
+        var part = new StringBuilder();
+        for (var i = 0; i < text.length(); i++) {
+            var c = text.charAt(i);
+            if (c == '<') depth++; else if (c == '>') depth--;
+            if (c == ',' && depth == 0) {
+                out.add(part.toString());
+                part.setLength(0);
+                continue;
+            }
+            part.append(c);
+        }
+        out.add(part.toString());
+        return out;
+    }
+
+    private static record Params(String params, String returnType) {}
+
+    private static Params mapParams(String params, int paramCount) {
+        ListLike<String> out = JdkList.create();
+        var parts = split(params);
+        for (var i = 0; i < Math.min(paramCount, parts.size()); i++) {
+            out.add("arg" + i + ": " + toTsType(parts.get(i).trim()));
+        }
+        var ret = parts.size() > paramCount ? toTsType(parts.get(parts.size() - 1).trim()) : "void";
+        var joined = new StringBuilder();
+        for (var i = 0; i < out.size(); i++) {
+            if (i > 0) joined.append(", ");
+            joined.append(out.get(i));
+        }
+        return new Params(joined.toString(), ret);
+    }
+
+    private static String mapFunction(String params) {
+        var ts = mapParams(params, 1);
+        return "(" + ts.params + ") => " + ts.returnType;
+    }
+
+    private static String mapBiFunction(String params) {
+        var ts = mapParams(params, 2);
+        return "(" + ts.params + ") => " + ts.returnType;
     }
 }

--- a/src/test/java/magma/TranspilerMethodTest.java
+++ b/src/test/java/magma/TranspilerMethodTest.java
@@ -136,4 +136,24 @@ class TranspilerMethodTest {
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void mapsFunctionInterfaceTypes() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    java.util.function.Function<Integer,String> map(java.util.function.Function<Integer,String> fn) {",
+            "        return fn;",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    map(fn: (arg0: Integer) => string): (arg0: Integer) => string {",
+            "        return fn;",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- map `java.util.function.*` interfaces to arrow function types
- improve type parsing to split parameters with nested generics
- document functional interface mapping in roadmap and architecture docs
- test mapping for `Function<T,R>`

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844d419cdc88321a7c702fa71b59042