### PR TITLE
Infer var type in assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ never be edited directly.
 - `magma.list.JdkList` – default implementation backed by `ArrayList`
 - `magma.app.MethodStubber` – replaces method bodies with `// TODO` stubs.
   Helpers now use a single scan so functions never contain more than one loop,
-  and indentation levels stay at two or fewer.
+  and indentation levels stay at two or fewer. `var` declarations infer a
+  TypeScript type from simple values and default to `unknown` otherwise.
 - `magma.app.FieldTranspiler` – converts Java fields into TypeScript
   properties while ignoring initializations
 - `magma.app.ImportHelper` – rewrites package declarations and import lines

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -18,6 +18,8 @@ platforms.
   Each helper scans once so every function contains at most a single loop
   and indentation never exceeds two levels. Expressions are walked using
   `parseValue`.
+  Local variables declared with `var` now infer a TypeScript type from the
+  assigned value and fall back to `unknown` when the value is complex.
 - Nested `if` and `while` blocks are parsed recursively so statements
   inside them are handled just like top-level code.
 - `FieldTranspiler` – converts Java field definitions

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -195,9 +195,20 @@ class MethodStubber {
             var name = tokens[tokens.length - 1];
             var type = tokens[tokens.length - 2];
             var value = parseValue(rhs);
-            return indent + "    let " + name + ": " + TypeMapper.toTsType(type) + " = " + value + ";";
+            var tsType = type.equals("var") ? inferVarType(rhs) : TypeMapper.toTsType(type);
+            return indent + "    let " + name + ": " + tsType + " = " + value + ";";
         }
         return indent + "    // TODO";
+    }
+
+    private static String inferVarType(String value) {
+        var trimmed = value.trim();
+        if (isNumeric(trimmed)) return "number";
+        if (trimmed.equals("true") || trimmed.equals("false")) return "boolean";
+        if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+            return "string";
+        }
+        return "unknown";
     }
 
     static boolean isMemberAccess(String stmt) {

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -317,6 +317,30 @@ class TranspilerStatementTest {
     }
 
     @Test
+    void resolvesVarTypes() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void run() {",
+            "        var x = 100;",
+            "        var y = \"hi\";",
+            "        var z = unknown();",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    run(): void {",
+            "        let x: number = 100;",
+            "        let y: string = \"hi\";",
+            "        let z: unknown = unknown();",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
+    @Test
     void preservesMemberAccessInAssignments() {
         var javaSrc = String.join(System.lineSeparator(),
             "public class Foo {",


### PR DESCRIPTION
## Summary
- infer simple type info for Java `var` assignments
- test new var type inference
- document var inference in MethodStubber

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844dea1f9f88321abacf8c957f921dd