### PR TITLE
Fix lambda invocation argument bug

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,6 +24,8 @@ platforms.
   inside them are handled just like top-level code.
 - `FieldTranspiler` – converts Java field definitions
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
+  - Lambda arguments inside method calls are preserved so `doThing(() -> 1)`
+    becomes `doThing(() => 1)`.
   - `TypeMapper` – maps primitive, boxed, and generic types and leaves unknown
     identifiers unchanged so the output stays close to the source
   - `java.util.function` interfaces map to arrow function types

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -96,6 +96,8 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Refactor generated code to return these types.
 5. Implement lambda expressions and stream translations.
    - Convert lambda expressions to arrow functions.
+   - Lambda expressions used as method arguments are preserved rather than being
+     mistaken for invokable calls.
    - Map basic stream operations to array helpers.
 6. Provide minimal replacements for common standard library utilities.
    - Introduce small helpers for `List` and `Map` behavior.

--- a/docs/lambda-notes.md
+++ b/docs/lambda-notes.md
@@ -10,3 +10,8 @@ logic stays simple.
 
 Recent tests exercise lambdas with parameters and multi-line blocks so that
 future refactoring preserves this behaviour.
+
+Lambda expressions can also appear inside method calls. The parser now keeps
+these arguments intact by detecting the `->` token after the closing
+parenthesis and skipping invocation stubbing in that case. This allows
+`doThing(() -> 1)` to remain unchanged aside from the arrow replacement.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -225,7 +225,12 @@ class MethodStubber {
         if (open == -1 || close == -1 || close <= open) {
             return false;
         }
+        var arrow = stmt.indexOf("->");
+        if (arrow != -1 && arrow > close) {
+            return false;
+        }
         var head = stmt.substring(0, open).trim();
+        if (head.isEmpty()) return false;
         return !head.startsWith("if") && !head.startsWith("while") && !head.startsWith("for");
     }
 
@@ -235,6 +240,7 @@ class MethodStubber {
 
     static String parseValue(String value) {
         var trimmed = value.trim();
+        if (trimmed.contains("->")) return trimmed;
         if (trimmed.startsWith("!")) {
             var rest = trimmed.substring(1).trim();
             return "!" + parseValue(rest);

--- a/src/test/java/magma/PathLikeTest.java
+++ b/src/test/java/magma/PathLikeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import magma.path.NioPath;
 import magma.path.PathLike;
+import java.io.File;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -16,7 +17,7 @@ class PathLikeTest {
     void resolvesAndRelativizesPaths() {
         PathLike base = NioPath.of("a");
         var child = base.resolve("b");
-        assertEquals("a\\b", child.toString());
+        assertEquals("a" + File.separator + "b", child.toString());
         var rel = base.relativize(child);
         assertEquals("b", rel.toString());
         assertEquals("a", child.getParent().toString());

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -202,6 +202,26 @@ class TranspilerStatementTest {
         assertEquals(expected, result);
     }
 
+    @Test
+    void keepsLambdaArgumentsInInvokables() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "public class Foo {",
+            "    void run() {",
+            "        doThing(() -> 1);",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "export default class Foo {",
+            "    run(): void {",
+            "        doThing(() => 1);",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
 
     @Test
     void stubsOneTodoPerStatement() {


### PR DESCRIPTION
## Summary
- avoid stubbing lambdas passed as arguments
- test that lambdas in invokable arguments round-trip
- make path tests OS-independent
- document lambda argument handling in architecture notes and roadmap

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844e054fcd88321afd0775ed25a6ccf