### PR TITLE
Fix typed lambda stubbing

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -26,6 +26,8 @@ platforms.
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
   - Lambda arguments inside method calls are preserved so `doThing(() -> 1)`
     becomes `doThing(() => 1)`.
+  - Typed lambda parameters are converted to `name : type` form so `(String v)`
+    becomes `(v : string)`.
   - `MethodStubber` now detects arrow blocks that span multiple lines and copies
     them verbatim until the closing `});` so calls like `fold(x, () -> { });`
     remain intact.

--- a/docs/lambda-notes.md
+++ b/docs/lambda-notes.md
@@ -2,7 +2,9 @@
 
 `ArrowHelper` rewrites Java lambdas using a straight text scan. Each line is
 checked for the `->` token and it becomes `=>` in the output. This keeps the
-conversion in a single pass without another parser.
+conversion in a single pass without another parser. Typed parameters are
+detected inside the parentheses and mapped to `name : type` using the
+`TypeMapper` helper.
 
 When an arrow body sits on one line `ArrowHelper` expands assignments using the
 existing stubbing helpers. Multi-line bodies are left untouched so the overall

--- a/src/main/java/magma/app/ArrowHelper.java
+++ b/src/main/java/magma/app/ArrowHelper.java
@@ -6,12 +6,40 @@ class ArrowHelper {
         var out = new StringBuilder();
         for (var line : lines) {
             if (line.contains("->")) {
-                out.append(line.replace("->", "=>")).append(System.lineSeparator());
+                var replaced = line.replace("->", "=>");
+                out.append(mapTypedParams(replaced)).append(System.lineSeparator());
             } else {
                 out.append(line).append(System.lineSeparator());
             }
         }
         return out.toString().trim();
+    }
+
+    private static String mapTypedParams(String line) {
+        var arrow = line.indexOf("=>");
+        if (arrow == -1) return line;
+        var close = line.lastIndexOf(')', arrow);
+        var open = line.lastIndexOf('(', close);
+        if (open == -1 || close == -1 || close <= open) return line;
+        var inside = line.substring(open + 1, close).trim();
+        if (!inside.contains(" ")) return line;
+        var parts = inside.split(",");
+        var mapped = new StringBuilder();
+        for (var i = 0; i < parts.length; i++) {
+            var p = parts[i].trim();
+            var tokens = p.split("\\s+");
+            if (tokens.length >= 2) {
+                var name = tokens[tokens.length - 1];
+                var type = tokens[tokens.length - 2];
+                mapped.append(name)
+                    .append(" : ")
+                    .append(TypeMapper.toTsType(type));
+            } else {
+                mapped.append(p);
+            }
+            if (i < parts.length - 1) mapped.append(", ");
+        }
+        return line.substring(0, open + 1) + mapped + line.substring(close);
     }
 
     static String stubArrowAssignments(String source) {

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -171,7 +171,8 @@ class MethodStubber {
         var i = start;
         while (i < lines.length) {
             stub.append(lines[i]).append(System.lineSeparator());
-            if (lines[i].trim().equals("});")) {
+            var trimmed = lines[i].trim();
+            if (trimmed.equals("});") || trimmed.equals("};")) {
                 return i + 1;
             }
             i++;

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -182,7 +182,7 @@ class TranspilerStatementTest {
     @Test
     void convertsTypedParameterLambda() {
         var javaSrc = "Runnable r = (int x) -> {};";
-        var expected = "Runnable r = (int x) => {};";
+        var expected = "Runnable r = (x : number) => {};";
 
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);


### PR DESCRIPTION
## Summary
- map typed lambda parameters to `name : type`
- handle arrow blocks that end with `};`
- document lambda parameter mapping in docs
- update failing test expectations

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844e7e7e59c8321b0c99f3fbd9e87cb