### PR TITLE
Style update for TypeScript declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ feature matrix and roadmap of the supported Java constructs can be found
 in [`docs/java-to-typescript-roadmap.md`](docs/java-to-typescript-roadmap.md).
 Coding conventions are summarized in
 [`docs/coding-standards.md`](docs/coding-standards.md).
+Variable declarations in the generated TypeScript include spaces around the
+colon so assignments read `let x : number`.
 
 ## Building and Testing
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -12,3 +12,7 @@ Instead, represent failure or missing values with a `Result` or `Option` object.
 Abstract classes tend to complicate the design and are avoided in this codebase.
 Favor composition of small collaborating objects over inheritance whenever
 possible.
+
+TypeScript output follows a minimal style. Variable declarations keep spaces
+around the colon so `let` statements read `let x : number` rather than
+`let x: number`.

--- a/src/main/java/magma/app/ArrowHelper.java
+++ b/src/main/java/magma/app/ArrowHelper.java
@@ -68,12 +68,13 @@ class ArrowHelper {
         var header = line.substring(0, open + 1);
         var body = line.substring(open + 1, close).trim();
         var out = new StringBuilder();
+        java.util.Map<String, String> vars = new java.util.HashMap<>();
         out.append(header).append(System.lineSeparator());
         for (var part : body.split(";")) {
             var trimmedPart = part.trim();
             if (trimmedPart.isEmpty()) continue;
             if (trimmedPart.contains("=")) {
-                out.append(MethodStubber.parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
+                out.append(MethodStubber.parseAssignment(trimmedPart, indent, vars)).append(System.lineSeparator());
             } else {
                 out.append(indent).append("    // TODO").append(System.lineSeparator());
             }

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -70,7 +70,7 @@ class MethodStubber {
         return stub.toString();
     }
 
-    private static void appendParts(String[] parts, String indent, StringBuilder stub) {
+    private static void appendParts(String[] parts, String indent, StringBuilder stub, java.util.Map<String, String> vars) {
         for (var part : parts) {
             var trimmedPart = part.trim();
             if (trimmedPart.isEmpty()) continue;
@@ -79,7 +79,7 @@ class MethodStubber {
                 continue;
             }
             if (trimmedPart.contains("=")) {
-                stub.append(parseAssignment(trimmedPart, indent)).append(System.lineSeparator());
+                stub.append(parseAssignment(trimmedPart, indent, vars)).append(System.lineSeparator());
                 continue;
             }
             if (isInvokable(trimmedPart)) {
@@ -107,6 +107,7 @@ class MethodStubber {
 
     private static void parseStatements(String[] lines, int start, int end, String indent, StringBuilder stub) {
         var wrote = false;
+        java.util.Map<String, String> vars = new java.util.HashMap<>();
         for (var i = start; i < end; i++) {
             var body = lines[i].trim();
             if (body.isEmpty()) continue;
@@ -128,7 +129,7 @@ class MethodStubber {
                 continue;
             }
 
-            appendParts(body.split(";"), indent, stub);
+            appendParts(body.split(";"), indent, stub, vars);
         }
         if (!wrote) stub.append(indent).append("    // TODO").append(System.lineSeparator());
     }
@@ -201,7 +202,7 @@ class MethodStubber {
         return parseValue(inside);
     }
 
-    static String parseAssignment(String stmt, String indent) {
+    static String parseAssignment(String stmt, String indent, java.util.Map<String, String> vars) {
         var eq = stmt.indexOf('=');
         if (eq == -1) {
             return indent + "    // TODO";
@@ -213,19 +214,16 @@ class MethodStubber {
             var name = tokens[tokens.length - 1];
             var type = tokens[tokens.length - 2];
             var value = parseValue(rhs);
-            var tsType = type.equals("var") ? inferVarType(rhs) : TypeMapper.toTsType(type);
-            var spacing = type.equals("var") && needsSpace(tsType) ? " " : "";
-            return indent + "    let " + name + spacing + ": " + tsType + " = " + value + ";";
+            var tsType = type.equals("var") ? inferVarType(rhs, vars) : TypeMapper.toTsType(type);
+            vars.put(name, tsType);
+            return indent + "    let " + name + " : " + tsType + " = " + value + ";";
         }
         return indent + "    // TODO";
     }
 
-    private static boolean needsSpace(String tsType) {
-        return !(tsType.equals("number") || tsType.equals("string") || tsType.equals("boolean") || tsType.equals("unknown"));
-    }
-
-    private static String inferVarType(String value) {
+    private static String inferVarType(String value, java.util.Map<String, String> vars) {
         var trimmed = value.trim();
+        if (vars.containsKey(trimmed)) return vars.get(trimmed);
         if (trimmed.startsWith("new ")) {
             var rest = trimmed.substring(4).trim();
             var open = rest.indexOf('(');

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -39,7 +39,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = doThing(a, new Some<>(1));",
+                "        let x : number = doThing(a, new Some<>(1));",
                 "    }",
                 "}");
 
@@ -79,7 +79,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    make(): void {",
-                "        let b: Bar = new Bar(1);",
+                "        let b : Bar = new Bar(1);",
                 "    }",
                 "}");
 
@@ -119,7 +119,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let error: Option<string> = new Main().run();",
+                "        let error : Option<string> = new Main().run();",
                 "    }",
                 "}");
 
@@ -162,7 +162,7 @@ class TranspilerStatementTest {
 
         var expected = String.join(System.lineSeparator(),
                 "Runnable r = () => {",
-                "    let x: number = 0;",
+                "    let x : number = 0;",
                 "    // TODO",
                 "};");
 
@@ -194,8 +194,8 @@ class TranspilerStatementTest {
 
         var expected = String.join(System.lineSeparator(),
                 "Runnable r = () => {",
-                "    let x: number = 1;",
-                "    let y: number = 2;",
+                "    let x : number = 1;",
+                "    let y : number = 2;",
                 "};");
 
         var result = new Transpiler().toTypeScript(javaSrc);
@@ -237,7 +237,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    multi(): number {",
-                "        let y: number = 0;",
+                "        let y : number = 0;",
                 "        // TODO",
                 "        return y;",
                 "    }",
@@ -308,7 +308,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    show(): void {",
-                "        let msg: string = \"hi\";",
+                "        let msg : string = \"hi\";",
                 "    }",
                 "}");
 
@@ -328,7 +328,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    show(): void {",
-                "        let num: number = 7;",
+                "        let num : number = 7;",
                 "    }",
                 "}");
 
@@ -350,9 +350,9 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = 100;",
-                "        let y: string = \"hi\";",
-                "        let z: unknown = unknown();",
+                "        let x : number = 100;",
+                "        let y : string = \"hi\";",
+                "        let z : unknown = unknown();",
                 "    }",
                 "}");
 
@@ -372,7 +372,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(p: Parent): void {",
-                "        let x: number = p.count;",
+                "        let x : number = p.count;",
                 "    }",
                 "}");
 
@@ -412,7 +412,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = doThing(a, new Some<>(make(1, 2)));",
+                "        let x : number = doThing(a, new Some<>(make(1, 2)));",
                 "    }",
                 "}");
 
@@ -432,7 +432,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = doStuff().myField;",
+                "        let x : number = doStuff().myField;",
                 "    }",
                 "}");
 
@@ -452,7 +452,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    copy(src: number): void {",
-                "        let x: number = src;",
+                "        let x : number = src;",
                 "    }",
                 "}");
 
@@ -472,7 +472,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = first.second().third.fourth;",
+                "        let x : number = first.second().third.fourth;",
                 "    }",
                 "}");
 
@@ -612,7 +612,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = first().second().third();",
+                "        let x : number = first().second().third();",
                 "    }",
                 "}");
 
@@ -632,7 +632,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = outer(inner(foo.bar()), other()).value;",
+                "        let x : number = outer(inner(foo.bar()), other()).value;",
                 "    }",
                 "}");
 
@@ -652,7 +652,7 @@ class TranspilerStatementTest {
         var expected = String.join(System.lineSeparator(),
                 "export default class Foo {",
                 "    run(): void {",
-                "        let x: number = new Main().run().value;",
+                "        let x : number = new Main().run().value;",
                 "    }",
                 "}");
 


### PR DESCRIPTION
## Summary
- space before colon in generated variable declarations
- track simple variable types so `var y = x` infers `x`'s type
- document the spacing preference
- update expected output in tests

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844eeb44a808321bd95d9f02a885d70