### PR TITLE
Fix var type inference for chained calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ never be edited directly.
   and indentation levels stay at two or fewer. `var` declarations infer a
   TypeScript type from simple values, including constructor calls which return
   the constructed class name. When assigned to another method in the same class,
-  the stub uses that method's return type. More complex expressions still
+  the stub uses that method's return type. Method calls on newly created
+  objects also reuse the target method's return type so `var x = new Foo().getValue();`
+  becomes `let x : number = new Foo().getValue();`. More complex expressions still
   default to `unknown`.
   Arrow blocks passed as arguments are detected and copied line for line until
   the closing `});` so multi-line lambdas survive unchanged.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,6 +24,8 @@ platforms.
   expressions still fall back to `unknown`. Calls to other methods defined in
   the same class reuse those methods' return types so `var x = getValue();`
   becomes `let x : number = getValue();` when `getValue` returns `int`.
+  Method calls on freshly created objects follow the same rule, allowing
+  `var x = new Foo().getValue();` to infer `number`.
 - Nested `if` and `while` blocks are parsed recursively so statements
   inside them are handled just like top-level code.
 - `FieldTranspiler` – converts Java field definitions

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -256,8 +256,19 @@ class MethodStubber {
                                        java.util.Map<String, String> returns) {
         var trimmed = value.trim();
         if (vars.containsKey(trimmed)) return vars.get(trimmed);
+
+        if (isInvokable(trimmed)) {
+            var open = trimmed.lastIndexOf('(');
+            var callee = trimmed.substring(0, open).trim();
+            var dot = callee.lastIndexOf('.');
+            if (dot != -1) callee = callee.substring(dot + 1).trim();
+            if (returns.containsKey(callee)) return returns.get(callee);
+        }
+
         if (trimmed.startsWith("new ")) {
             var rest = trimmed.substring(4).trim();
+            var dot = rest.indexOf('.');
+            if (dot != -1) rest = rest.substring(0, dot).trim();
             var open = rest.indexOf('(');
             if (open != -1) {
                 rest = rest.substring(0, open).trim();
@@ -268,16 +279,13 @@ class MethodStubber {
             }
             return rest.isEmpty() ? "unknown" : rest;
         }
+
         if (isNumeric(trimmed)) return "number";
         if (trimmed.equals("true") || trimmed.equals("false")) return "boolean";
         if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
             return "string";
         }
-        if (isInvokable(trimmed)) {
-            var open = trimmed.indexOf('(');
-            var callee = trimmed.substring(0, open).trim();
-            if (returns.containsKey(callee)) return returns.get(callee);
-        }
+
         return "unknown";
     }
 


### PR DESCRIPTION
## Summary
- infer `var` types from method calls made on newly constructed objects
- document new inference behavior in README and architecture overview

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844f31510908321ac3e2c63a84c4872