### PR TITLE
Fix cross-file references by inferring missing imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ never be edited directly.
 - `magma.app.FieldTranspiler` – converts Java fields into TypeScript
   properties while ignoring initializations
 - `magma.app.ImportHelper` – rewrites package declarations and import lines
+  and now inserts missing imports when classes are referenced without an
+  explicit `import` statement
 - `magma.app.ArrowHelper` – turns lambda expressions into arrow functions
 - Interface method signatures now keep parameter and return types so
   `PathLike resolve(String other);` becomes `resolve(other : string): PathLike`.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -13,7 +13,9 @@ platforms.
 ## Main Modules
 
 - `magma.app.Transpiler` – orchestrates the conversion to TypeScript
-- `ImportHelper` – rewrites package declarations and import lines
+- `ImportHelper` – rewrites package declarations and import lines, and now
+  adds missing imports when classes from the same package are referenced
+  without an explicit `import` statement
 - `MethodStubber` – replaces method bodies with `// TODO` stubs.
   Each helper scans once so every function contains at most a single loop
   and indentation never exceeds two levels. Expressions are walked using

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -135,5 +135,8 @@ Only the features listed below are supported. Anything not mentioned here is con
 18. ~~Infer `var` types from local method calls.~~
     Assignments like `var n = getValue();` now reuse the return type of
     `getValue` so the stub reads `let n : number = getValue();`.
+19. Automatically import classes referenced without explicit `import` lines so
+    files in the same package resolve each other's types.
+    Tested via `TranspilerImportTest.addsImportsForReferencedClasses`.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/app/ImportHelper.java
+++ b/src/main/java/magma/app/ImportHelper.java
@@ -28,21 +28,35 @@ class ImportHelper {
 
     static String translateImports(String source, String currentPkg) {
         var lines = source.split("\\R");
-        var out = new StringBuilder();
+        var imports = new StringBuilder();
+        java.util.Set<String> names = new java.util.HashSet<>();
+        var body = new StringBuilder();
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i];
             var trimmed = line.trim();
             if (trimmed.startsWith("import ") && trimmed.endsWith(";") &&
                     !trimmed.contains("*") && !trimmed.startsWith("import static")) {
                 var imp = trimmed.substring(7, trimmed.length() - 1).trim();
-                out.append("import ").append(buildImport(imp, currentPkg)).append(";")
-                   .append(System.lineSeparator());
+                var cls = imp.substring(imp.lastIndexOf('.') + 1);
+                names.add(cls);
+                imports.append("import ").append(buildImport(imp, currentPkg)).append(";")
+                       .append(System.lineSeparator());
                 i = skipEmptyLines(lines, i + 1);
                 continue;
             }
-            out.append(line).append(System.lineSeparator());
+            body.append(line).append(System.lineSeparator());
         }
-        return out.toString().trim();
+
+        var bodyText = body.toString().trim();
+        var self = extractClassName(bodyText);
+        var refs = inferReferences(bodyText, names, self);
+        var refIt = refs.iterator();
+        while (refIt.hasNext()) {
+            var r = refIt.next();
+            imports.append("import ").append(r).append(" from \"./").append(r)
+                   .append("\";").append(System.lineSeparator());
+        }
+        return imports.toString() + bodyText;
     }
 
     private static int skipEmptyLines(String[] lines, int start) {
@@ -90,5 +104,69 @@ class ImportHelper {
             out.append(parts[i]).append('/');
         }
         return out.toString();
+    }
+
+    private static String extractClassName(String source) {
+        var lines = source.split("\\R");
+        for (var line : lines) {
+            var trimmed = line.trim();
+            var cls = pickName(trimmed, "class ");
+            if (!cls.isBlank()) return cls;
+            cls = pickName(trimmed, "interface ");
+            if (!cls.isBlank()) return cls;
+            cls = pickName(trimmed, "enum ");
+            if (!cls.isBlank()) return cls;
+        }
+        return "";
+    }
+
+    private static String pickName(String line, String keyword) {
+        var idx = line.indexOf(keyword);
+        if (idx == -1) return "";
+        var after = line.substring(idx + keyword.length()).trim();
+        var space = after.indexOf(' ');
+        var brace = after.indexOf('{');
+        var end = after.length();
+        if (space != -1 && space < end) end = space;
+        if (brace != -1 && brace < end) end = brace;
+        return after.substring(0, end).trim();
+    }
+
+    private static java.util.Set<String> inferReferences(String source, java.util.Set<String> imports,
+                                                         String self) {
+        java.util.Set<String> refs = new java.util.HashSet<>();
+        var word = new StringBuilder();
+        var capture = false;
+        for (var i = 0; i < source.length(); i++) {
+            var c = source.charAt(i);
+            if (!capture) {
+                if (Character.isUpperCase(c) && (i == 0 || !Character.isLetterOrDigit(source.charAt(i - 1)) &&
+                        source.charAt(i - 1) != '_')) {
+                    word.setLength(0);
+                    word.append(c);
+                    capture = true;
+                }
+                continue;
+            }
+            if (Character.isLetterOrDigit(c) || c == '_') {
+                word.append(c);
+                continue;
+            }
+            if (c == '.') {
+                var name = word.toString();
+                if (!name.equals(self) && !imports.contains(name) && !isBuiltIn(name)) {
+                    refs.add(name);
+                }
+            }
+            capture = false;
+        }
+        return refs;
+    }
+
+    private static boolean isBuiltIn(String name) {
+        return name.equals("System") || name.equals("String") || name.equals("Integer") ||
+               name.equals("Long") || name.equals("Float") || name.equals("Double") ||
+               name.equals("Short") || name.equals("Byte") || name.equals("Character") ||
+               name.equals("Boolean") || name.equals("Object") || name.equals("Math");
     }
 }

--- a/src/test/java/magma/TranspilerImportTest.java
+++ b/src/test/java/magma/TranspilerImportTest.java
@@ -44,4 +44,27 @@ class TranspilerImportTest {
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void addsImportsForReferencedClasses() {
+        var javaSrc = String.join(System.lineSeparator(),
+            "package com.example;",
+            "",
+            "public class B {",
+            "    void empty() {",
+            "        var v = A.value;",
+            "    }",
+            "}");
+
+        var expected = String.join(System.lineSeparator(),
+            "import A from \"./A\";",
+            "export default class B {",
+            "    empty(): void {",
+            "        let v : unknown = A.value;",
+            "    }",
+            "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- improve ImportHelper to infer missing imports from member access
- add tests for implicit import inference
- document the new helper in the architecture overview, README, and roadmap

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844f70e1f108321844d98896e5a59f2