### PR TITLE
Improve lambda parsing with block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ never be edited directly.
   objects also reuse the target method's return type so `var x = new Foo().getValue();`
   becomes `let x : number = new Foo().getValue();`. More complex expressions still
   default to `unknown`.
-  Arrow blocks passed as arguments are detected and copied line for line until
-  the closing `});` so multi-line lambdas survive unchanged.
+Arrow blocks passed as arguments are detected and their statements are parsed
+so assignments inside the block become stubs before the closing `});`.
 - `magma.app.FieldTranspiler` – converts Java fields into TypeScript
   properties while ignoring initializations
 - `magma.app.ImportHelper` – rewrites package declarations and import lines

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -36,9 +36,9 @@ platforms.
     becomes `doThing(() => 1)`.
   - Typed lambda parameters are converted to `name : type` form so `(String v)`
     becomes `(v : string)`.
-  - `MethodStubber` now detects arrow blocks that span multiple lines and copies
-    them verbatim until the closing `});` so calls like `fold(x, () -> { });`
-    remain intact.
+    - `MethodStubber` detects arrow blocks that span multiple lines and now
+      parses the enclosed statements so assignments become TODO stubs before the
+      closing `});`.
   - Interface methods are translated so parameter and return types carry over,
     using spaces around the colon for parameters.
   - `TypeMapper` – maps primitive, boxed, and generic types and leaves unknown

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -100,6 +100,7 @@ Only the features listed below are supported. Anything not mentioned here is con
    - Convert lambda expressions to arrow functions.
    - Lambda expressions used as method arguments are preserved rather than being
      mistaken for invokable calls.
+   - Parse statements inside lambda blocks so assignments become TODO stubs.
    - Map basic stream operations to array helpers.
 6. Provide minimal replacements for common standard library utilities.
    - Introduce small helpers for `List` and `Map` behavior.

--- a/docs/lambda-notes.md
+++ b/docs/lambda-notes.md
@@ -7,8 +7,8 @@ detected inside the parentheses and mapped to `name : type` using the
 `TypeMapper` helper.
 
 When an arrow body sits on one line `ArrowHelper` expands assignments using the
-existing stubbing helpers. Multi-line bodies are left untouched so the overall
-logic stays simple.
+existing stubbing helpers. Multi-line bodies are also parsed so assignments
+become stubs rather than being copied verbatim.
 
 Recent tests exercise lambdas with parameters and multi-line blocks so that
 future refactoring preserves this behaviour.
@@ -17,5 +17,5 @@ Lambda expressions can also appear inside method calls. The parser now keeps
 these arguments intact by detecting the `->` token after the closing
 parenthesis and skipping invocation stubbing in that case. This allows
 `doThing(() -> 1)` to remain unchanged aside from the arrow replacement.
-When the lambda spans multiple lines the stubber copies each line until the
-closing `});` so calls like `fold(x, () -> {\n});` are preserved verbatim.
+When the lambda spans multiple lines the stubber now parses each statement and
+rewrites assignments so blocks like `fold(x, () -> {\n});` gain stubbed bodies.

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -146,7 +146,7 @@ class MethodStubber {
             wrote = true;
 
             if (body.contains("->") && body.endsWith("{")) {
-                i = copyArrowBlock(lines, i, stub) - 1;
+                i = parseArrowBlock(lines, i, stub, returns) - 1;
                 continue;
             }
 
@@ -201,17 +201,16 @@ class MethodStubber {
         return i;
     }
 
-    private static int copyArrowBlock(String[] lines, int start, StringBuilder stub) {
-        var i = start;
-        while (i < lines.length) {
-            stub.append(lines[i]).append(System.lineSeparator());
-            var trimmed = lines[i].trim();
-            if (trimmed.equals("});") || trimmed.equals("};")) {
-                return i + 1;
-            }
-            i++;
+    private static int parseArrowBlock(String[] lines, int start, StringBuilder stub,
+                                       java.util.Map<String, String> returns) {
+        var indent = lines[start].substring(0, lines[start].indexOf(lines[start].trim()));
+        stub.append(lines[start]).append(System.lineSeparator());
+        var end = skipBody(lines, start);
+        if (end - start > 2) {
+            parseStatements(lines, start + 1, end - 1, indent, stub, returns);
         }
-        return i;
+        stub.append(lines[end - 1]).append(System.lineSeparator());
+        return end;
     }
 
     static void appendParsedBlock(StringBuilder stub, String indent, String keyword,

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -222,6 +222,32 @@ class TranspilerStatementTest {
         assertEquals(expected, result);
     }
 
+    @Test
+    void parsesLambdaBlocks() {
+        var javaSrc = String.join(System.lineSeparator(),
+                "public class Foo {",
+                "    void run() {",
+                "        doThing(() -> {",
+                "            int x = 0;",
+                "            x++;",
+                "        });",
+                "    }",
+                "}");
+
+        var expected = String.join(System.lineSeparator(),
+                "export default class Foo {",
+                "    run(): void {",
+                "        doThing(() => {",
+                "            let x : number = 0;",
+                "            // TODO",
+                "        });",
+                "    }",
+                "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
+
 
     @Test
     void stubsOneTodoPerStatement() {


### PR DESCRIPTION
## Summary
- parse statements in lambda blocks with braces
- add tests for lambda blocks
- document lambda block parsing in architecture and notes
- update roadmap for lambda block stubbing
- clarify README notes about lambda blocks

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844f96288c883218eeef7618ccda99c