### PR TITLE
Fix var inference for interface methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ never be edited directly.
   the constructed class name. When assigned to another method in the same class,
   the stub uses that method's return type. Method calls on newly created
   objects also reuse the target method's return type so `var x = new Foo().getValue();`
-  becomes `let x : number = new Foo().getValue();`. More complex expressions still
+  becomes `let x : number = new Foo().getValue();`. Calls on variables typed
+  with known interfaces such as `PathLike` infer their interface return types,
+  so `var files = root.walk();` becomes `let files : Result<Set<PathLike>> = root.walk();`.
+  More complex expressions still
   default to `unknown`.
+  The generated `Main.ts` now demonstrates this, typing `srcRoot.walk()` as
+  `Result<Set<PathLike>>` rather than `unknown`.
 Arrow blocks passed as arguments are detected and their statements are parsed
 so assignments inside the block become stubs before the closing `});`.
 - `magma.app.FieldTranspiler` – converts Java fields into TypeScript

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -27,9 +27,13 @@ platforms.
   the same class reuse those methods' return types so `var x = getValue();`
   becomes `let x : number = getValue();` when `getValue` returns `int`.
   Method calls on freshly created objects follow the same rule, allowing
-  `var x = new Foo().getValue();` to infer `number`.
-- Nested `if` and `while` blocks are parsed recursively so statements
-  inside them are handled just like top-level code.
+  `var x = new Foo().getValue();` to infer `number`. Calls on variables
+  typed with known interfaces such as `PathLike` also use the interface
+  signature so `var paths = root.walk();` infers `Result<Set<PathLike>>`.
+  The generated `Main.ts` shows this inference in practice, typing
+  `srcRoot.walk()` with the same return type.
+  - Nested `if` and `while` blocks are parsed recursively so statements
+    inside them are handled just like top-level code.
 - `FieldTranspiler` – converts Java field definitions
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
   - Lambda arguments inside method calls are preserved so `doThing(() -> 1)`

--- a/src/main/java/magma/app/MethodStubber.java
+++ b/src/main/java/magma/app/MethodStubber.java
@@ -4,6 +4,20 @@ import magma.list.JdkList;
 import magma.list.ListLike;
 
 class MethodStubber {
+    private static final java.util.Map<String, String> KNOWN_RETURNS = buildKnownReturns();
+
+    private static java.util.Map<String, String> buildKnownReturns() {
+        java.util.Map<String, String> map = new java.util.HashMap<>();
+        map.put("PathLike.walk", "Result<Set<PathLike>>");
+        map.put("PathLike.readString", "Result<string>");
+        map.put("PathLike.createDirectories", "Option<string>");
+        map.put("PathLike.writeString", "Option<string>");
+        map.put("PathLike.resolve", "PathLike");
+        map.put("PathLike.relativize", "PathLike");
+        map.put("PathLike.getParent", "PathLike");
+        map.put("PathLike.deleteIfExists", "Option<string>");
+        return map;
+    }
     static String stubMethods(String source) {
         var lines = source.split("\\R");
         var returns = collectReturnTypes(lines);
@@ -93,7 +107,8 @@ class MethodStubber {
             stub.append(": ").append(tsReturn);
         }
         stub.append(" {").append(System.lineSeparator());
-        parseStatements(lines, start, end, indent, stub, tsReturn, returns);
+        var paramVars = paramVars(tsParams);
+        parseStatements(lines, start, end, indent, stub, tsReturn, returns, paramVars);
         stub.append(indent).append("}").append(System.lineSeparator());
         return stub.toString();
     }
@@ -138,20 +153,21 @@ class MethodStubber {
 
     private static void parseStatements(String[] lines, int start, int end, String indent,
                                         StringBuilder stub, String returnType,
-                                        java.util.Map<String, String> returns) {
+                                        java.util.Map<String, String> returns,
+                                        java.util.Map<String, String> vars) {
         var wrote = false;
-        java.util.Map<String, String> vars = new java.util.HashMap<>();
+        if (vars == null) vars = new java.util.HashMap<>();
         for (var i = start; i < end; i++) {
             var body = lines[i].trim();
             if (body.isEmpty()) continue;
             wrote = true;
 
             if (body.contains("->") && body.endsWith("{")) {
-                i = parseArrowBlock(lines, i, stub, returns) - 1;
+                i = parseArrowBlock(lines, i, stub, returns, vars) - 1;
                 continue;
             }
 
-            var next = handleControlBlock(body, lines, i, indent, stub, returns, returnType);
+            var next = handleControlBlock(body, lines, i, indent, stub, returns, returnType, vars);
             if (next != i) {
                 i = next - 1;
                 continue;
@@ -169,23 +185,23 @@ class MethodStubber {
 
     private static int handleControlBlock(String body, String[] lines, int index, String indent,
                                           StringBuilder stub, java.util.Map<String, String> returns,
-                                          String returnType) {
+                                          String returnType, java.util.Map<String, String> vars) {
         if ((body.startsWith("if") || body.startsWith("else if")) && body.endsWith("{")) {
             var keyword = body.startsWith("else if") ? "else if" : "if";
             var cond = parseCondition(body);
             var blockEnd = skipBody(lines, index);
-            appendParsedBlock(stub, indent, keyword, cond, lines, index + 1, blockEnd - 1, returns, returnType);
+            appendParsedBlock(stub, indent, keyword, cond, lines, index + 1, blockEnd - 1, returns, returnType, vars);
             return blockEnd;
         }
         if (body.startsWith("else") && body.endsWith("{")) {
             var blockEnd = skipBody(lines, index);
-            appendParsedBlock(stub, indent, "else", null, lines, index + 1, blockEnd - 1, returns, returnType);
+            appendParsedBlock(stub, indent, "else", null, lines, index + 1, blockEnd - 1, returns, returnType, vars);
             return blockEnd;
         }
         if (body.startsWith("while") && body.endsWith("{")) {
             var cond = parseCondition(body);
             var blockEnd = skipBody(lines, index);
-            appendParsedBlock(stub, indent, "while", cond, lines, index + 1, blockEnd - 1, returns, returnType);
+            appendParsedBlock(stub, indent, "while", cond, lines, index + 1, blockEnd - 1, returns, returnType, vars);
             return blockEnd;
         }
         return index;
@@ -204,12 +220,13 @@ class MethodStubber {
     }
 
     private static int parseArrowBlock(String[] lines, int start, StringBuilder stub,
-                                       java.util.Map<String, String> returns) {
+                                       java.util.Map<String, String> returns,
+                                       java.util.Map<String, String> vars) {
         var indent = lines[start].substring(0, lines[start].indexOf(lines[start].trim()));
         stub.append(lines[start]).append(System.lineSeparator());
         var end = skipBody(lines, start);
         if (end - start > 2) {
-            parseStatements(lines, start + 1, end - 1, indent, stub, null, returns);
+            parseStatements(lines, start + 1, end - 1, indent, stub, null, returns, vars);
         }
         stub.append(lines[end - 1]).append(System.lineSeparator());
         return end;
@@ -217,13 +234,14 @@ class MethodStubber {
 
     static void appendParsedBlock(StringBuilder stub, String indent, String keyword,
                                   String condition, String[] lines, int start, int end,
-                                  java.util.Map<String, String> returns, String returnType) {
+                                  java.util.Map<String, String> returns, String returnType,
+                                  java.util.Map<String, String> vars) {
         stub.append(indent).append("    ").append(keyword);
         if (condition != null) {
             stub.append(" (").append(condition).append(")");
         }
         stub.append(" {").append(System.lineSeparator());
-        parseStatements(lines, start, end, indent + "    ", stub, returnType, returns);
+        parseStatements(lines, start, end, indent + "    ", stub, returnType, returns, vars);
         stub.append(indent).append("    }").append(System.lineSeparator());
     }
 
@@ -267,7 +285,18 @@ class MethodStubber {
             var open = trimmed.lastIndexOf('(');
             var callee = trimmed.substring(0, open).trim();
             var dot = callee.lastIndexOf('.');
-            if (dot != -1) callee = callee.substring(dot + 1).trim();
+            if (dot != -1) {
+                var receiver = callee.substring(0, dot).trim();
+                var name = callee.substring(dot + 1).trim();
+                var type = vars.get(receiver);
+                if (type != null) {
+                    var key = type + "." + name;
+                    if (KNOWN_RETURNS.containsKey(key)) {
+                        return KNOWN_RETURNS.get(key);
+                    }
+                }
+                callee = name;
+            }
             if (returns.containsKey(callee)) return returns.get(callee);
         }
 
@@ -521,6 +550,21 @@ class MethodStubber {
             out.append(parts.get(i));
         }
         return out.toString();
+    }
+
+    private static java.util.Map<String, String> paramVars(String tsParams) {
+        java.util.Map<String, String> map = new java.util.HashMap<>();
+        if (tsParams.isBlank()) return map;
+        var parts = tsParams.split(",");
+        for (var i = 0; i < parts.length; i++) {
+            var p = parts[i].trim();
+            var colon = p.indexOf(':');
+            if (colon == -1) continue;
+            var name = p.substring(0, colon).trim();
+            var type = p.substring(colon + 1).trim();
+            map.put(name, type);
+        }
+        return map;
     }
 
     private static ListLike<String> splitArgs(String args) {

--- a/src/main/node/magma/Main.ts
+++ b/src/main/node/magma/Main.ts
@@ -37,7 +37,7 @@ export default class Main {
     }
 
     listJavaFiles(srcRoot: PathLike): Result<ListLike<PathLike>> {
-        let paths : unknown = srcRoot.walk();
+        let paths : Result<Set<PathLike>> = srcRoot.walk();
         if (!paths.isOk()) {
             return new Err<ListLike<PathLike>>(paths.error().get());
         }
@@ -53,16 +53,16 @@ export default class Main {
     }
 
     transpileFile(srcRoot: PathLike, outRoot: PathLike, javaFile: PathLike): Option<string> {
-        let javaSrcResult : unknown = javaFile.readString();
+        let javaSrcResult : Result<string> = javaFile.readString();
         if (!javaSrcResult.isOk()) {
             return new Some<string>(javaSrcResult.error().get());
         }
         let javaSrc : unknown = javaSrcResult.value().get();
         let ts : Transpiler = new Transpiler().toTypeScript(javaSrc);
-        let rel : unknown = srcRoot.relativize(javaFile);
+        let rel : PathLike = srcRoot.relativize(javaFile);
         let name : unknown = rel.toString();
         let withoutExt : unknown = name.substring(0, name.length());
-        let outFile : unknown = outRoot.resolve(withoutExt + ".ts");
+        let outFile : PathLike = outRoot.resolve(withoutExt + ".ts");
         let err : unknown = outFile.getParent().createDirectories();
         if (err.isSome()) {
             return err;

--- a/src/test/java/magma/TranspilerStatementTest.java
+++ b/src/test/java/magma/TranspilerStatementTest.java
@@ -705,4 +705,24 @@ class TranspilerStatementTest {
         var result = new Transpiler().toTypeScript(javaSrc);
         assertEquals(expected, result);
     }
+
+    @Test
+    void infersTypesFromInterfaceMethod() {
+        var javaSrc = String.join(System.lineSeparator(),
+                "public class Foo {",
+                "    void run(PathLike root) {",
+                "        var paths = root.walk();",
+                "    }",
+                "}");
+
+        var expected = String.join(System.lineSeparator(),
+                "export default class Foo {",
+                "    run(root: PathLike): void {",
+                "        let paths : Result<Set<PathLike>> = root.walk();",
+                "    }",
+                "}");
+
+        var result = new Transpiler().toTypeScript(javaSrc);
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- infer return types for known interface methods like `PathLike.walk`
- test inference from interface method calls
- document interface method inference in README and architecture overview
- regenerate `Main.ts`

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844fd728a608321bcb1372d369eded4