### PR TITLE
Add SetIter and use in Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ never be edited directly.
   `IOException`
 - `magma.path.NioPath` – wraps `java.nio.file.Path` and implements these I/O
   helpers using the JDK
- - `magma.list.ListLike` – minimal list abstraction using a custom `ListIter`
+- `magma.list.ListLike` – minimal list abstraction using a custom `ListIter`
   that now supports `map`, `fold`, and `flatMap` operations. The `flatMap`
   helper accepts an iterator-returning function so callers stay independent of
   concrete list types.
 - `magma.list.JdkList` – default implementation backed by `ArrayList`
+- `magma.list.SetIter` – wraps a `java.util.Set` so callers can reuse iterator helpers
 - `magma.app.MethodStubber` – replaces method bodies with `// TODO` stubs.
   Helpers now use a single scan so functions never contain more than one loop,
   and indentation levels stay at two or fewer. `var` declarations infer a

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -69,6 +69,8 @@ platforms.
     The iterator now exposes `map`, `fold`, and `flatMap` to keep loops out of callers.
     `flatMap` takes a function returning another iterator so nested lists can
     be flattened without revealing the underlying list implementation.
+- `magma.list.SetIter` – converts a `java.util.Set` into an `Iter` so callers can
+  fold or map over sets without manual loops.
 
 The `parseValue` routine incrementally scans characters.  It recognizes
 member access, method calls, literals and the logical not operator.

--- a/docs/java-to-typescript-roadmap.md
+++ b/docs/java-to-typescript-roadmap.md
@@ -142,5 +142,7 @@ Only the features listed below are supported. Anything not mentioned here is con
 20. Fill in generic parameters when constructors use the diamond operator so
     `new Some<>(value)` becomes `new Some<T>(value)` based on the surrounding
     type.
+21. Provide a `SetIter` helper so `java.util.Set` values integrate with the
+    existing `Iter` operations. `Main` now folds over sets without manual loops.
 
 Each feature should begin with a failing test that describes the expected TypeScript output for a Java example.

--- a/src/main/java/magma/Main.java
+++ b/src/main/java/magma/Main.java
@@ -3,6 +3,7 @@ package magma;
 import magma.app.Transpiler;
 import magma.list.JdkList;
 import magma.list.ListLike;
+import magma.list.SetIter;
 import magma.option.None;
 import magma.option.Option;
 import magma.option.Some;
@@ -46,14 +47,13 @@ public class Main {
         if (!paths.isOk()) {
             return new Err<>(paths.error().get());
         }
-        ListLike<PathLike> javaFiles = JdkList.create();
-        var pathIt = paths.value().get().iterator();
-        while (pathIt.hasNext()) {
-            var p = pathIt.next();
-            if (p.toString().endsWith(".java")) {
-                javaFiles.add(p);
-            }
-        }
+        ListLike<PathLike> javaFiles = SetIter.wrap(paths.value().get()).fold(
+            JdkList.<PathLike>create(), (acc, p) -> {
+                if (p.toString().endsWith(".java")) {
+                    acc.add(p);
+                }
+                return acc;
+            });
         return new Ok<>(javaFiles);
     }
 

--- a/src/main/java/magma/list/SetIter.java
+++ b/src/main/java/magma/list/SetIter.java
@@ -1,0 +1,28 @@
+package magma.list;
+
+import java.util.Iterator;
+import java.util.Set;
+
+/** Iterator backed by a java.util.Set. */
+public class SetIter<T> implements Iter<T> {
+    private final Iterator<T> iterator;
+
+    private SetIter(Iterator<T> iterator) {
+        this.iterator = iterator;
+    }
+
+    /** Wrap an existing Set. */
+    public static <T> SetIter<T> wrap(Set<T> set) {
+        return new SetIter<>(set.iterator());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return iterator.next();
+    }
+}

--- a/src/main/node/magma/Main.ts
+++ b/src/main/node/magma/Main.ts
@@ -1,6 +1,7 @@
 import Transpiler from "./app/Transpiler";
 import JdkList from "./list/JdkList";
 import ListLike from "./list/ListLike";
+import SetIter from "./list/SetIter";
 import None from "./option/None";
 import Option from "./option/Option";
 import Some from "./option/Some";
@@ -41,14 +42,13 @@ export default class Main {
         if (!paths.isOk()) {
             return new Err<ListLike<PathLike>>(paths.error().get());
         }
-        let javaFiles : ListLike<PathLike> = JdkList.create();
-        let pathIt : unknown = paths.value().get().iterator();
-        while (pathIt.hasNext()) {
-            let p : unknown = pathIt.next();
-            if (p.toString().endsWith(".java")) {
-                javaFiles.add(p);
-            }
-        }
+        let javaFiles : ListLike<PathLike> = SetIter.wrap(paths.value().get()).fold(;
+            JdkList.<PathLike>create(), (acc, p) => {
+                if (p.toString().endsWith(".java")) {
+                    acc.add(p);
+                }
+                return acc;
+            });
         return new Ok<ListLike<PathLike>>(javaFiles);
     }
 

--- a/src/main/node/magma/list/SetIter.ts
+++ b/src/main/node/magma/list/SetIter.ts
@@ -1,0 +1,25 @@
+import Iterator from "../../java/util/Iterator";
+import Set from "../../java/util/Set";
+/** Iterator backed by a java.util.Set. */
+export default class SetIter<T> implements Iter<T> {
+    private readonly iterator: Iterator<T>;
+
+    SetIter(iterator: Iterator<T>): private {
+        // TODO
+    }
+
+    /** Wrap an existing Set. */
+    wrap(set: Set<T>): SetIter<T> {
+        return new SetIter<T>(set.iterator());
+    }
+
+    @Override
+    hasNext(): boolean {
+        return iterator.hasNext();
+    }
+
+    @Override
+    next(): T {
+        return iterator.next();
+    }
+}

--- a/src/test/java/magma/SetIterTest.java
+++ b/src/test/java/magma/SetIterTest.java
@@ -1,0 +1,26 @@
+package magma;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import magma.list.SetIter;
+import magma.list.Iter;
+import magma.list.JdkList;
+import magma.list.ListLike;
+import org.junit.jupiter.api.Test;
+
+class SetIterTest {
+    @Test
+    void iteratesOverSetValues() {
+        Set<Integer> set = new LinkedHashSet<>();
+        set.add(1);
+        set.add(2);
+        Iter<Integer> iter = SetIter.wrap(set);
+        ListLike<Integer> list = iter.fold(JdkList.create(), (acc, v) -> { acc.add(v); return acc; });
+        assertEquals(2, list.size());
+        assertEquals(1, list.get(0));
+        assertEquals(2, list.get(1));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SetIter` to wrap a `java.util.Set` with our custom `Iter` API
- update `Main.listJavaFiles` to fold over the set of paths using `SetIter`
- document the new helper in README and architecture overview
- extend the roadmap with a `SetIter` bullet
- add regression test for `SetIter`
- regenerate `Main.ts` and add `SetIter.ts`

## Testing
- `./build.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684502bf7d14832195d1d9650ca18495