### PR TITLE
Fix arrow block call emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ never be edited directly.
   `Result<Set<PathLike>>` rather than `unknown`.
 Arrow blocks passed as arguments are detected and their statements are parsed
 so assignments inside the block become stubs before the closing `});`.
+Calls like `fold(` that continue on the next line now keep that opening line
+intact so the arrow block receives the correct arguments.
 - `magma.app.FieldTranspiler` – converts Java fields into TypeScript
   properties while ignoring initializations
 - `magma.app.ImportHelper` – rewrites package declarations and import lines

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -45,6 +45,9 @@ platforms.
   - `StatementParser` detects arrow blocks that span multiple lines and now
       parses the enclosed statements so assignments become TODO stubs before the
       closing `});`.
+  - When an arrow block follows a call on the next line, the parser now keeps
+    the opening line intact so chained helpers like `fold(` retain their
+    arguments without inserting an extra semicolon.
   - Constructor calls that use Java's diamond operator now fill in the
     generic parameter using the surrounding variable or return type so
     `new Some<>(v)` becomes `new Some<T>(v)` in TypeScript.

--- a/src/main/java/magma/app/StatementParser.java
+++ b/src/main/java/magma/app/StatementParser.java
@@ -103,7 +103,29 @@ class StatementParser {
                 continue;
             }
             if (trimmedPart.contains("=")) {
-                stub.append(parseAssignment(trimmedPart, indent, vars, returns)).append(System.lineSeparator());
+                if (trimmedPart.endsWith("(")) {
+                    var eq = trimmedPart.indexOf('=');
+                    var dest = trimmedPart.substring(0, eq).trim();
+                    var rhs = trimmedPart.substring(eq + 1).trim();
+                    var tokens = dest.split("\\s+");
+                    if (tokens.length >= 2) {
+                        var name = tokens[tokens.length - 1];
+                        var type = tokens[tokens.length - 2];
+                        var tsType = type.equals("var") ? inferVarType(rhs, vars, returns)
+                                                       : TypeMapper.toTsType(type);
+                        vars.put(name, tsType);
+                        stub.append(indent).append("    let ")
+                            .append(name).append(" : ")
+                            .append(tsType).append(" = ")
+                            .append(rhs).append(System.lineSeparator());
+                    } else {
+                        stub.append(indent).append("    ")
+                            .append(trimmedPart).append(System.lineSeparator());
+                    }
+                } else {
+                    stub.append(parseAssignment(trimmedPart, indent, vars, returns))
+                        .append(System.lineSeparator());
+                }
                 continue;
             }
             if (ExpressionParser.isInvokable(trimmedPart)) {

--- a/src/main/node/magma/Main.ts
+++ b/src/main/node/magma/Main.ts
@@ -42,7 +42,7 @@ export default class Main {
         if (!paths.isOk()) {
             return new Err<ListLike<PathLike>>(paths.error().get());
         }
-        let javaFiles : ListLike<PathLike> = SetIter.wrap(paths.value().get()).fold(;
+        let javaFiles : ListLike<PathLike> = SetIter.wrap(paths.value().get()).fold(
             JdkList.<PathLike>create(), (acc, p) => {
                 if (p.toString().endsWith(".java")) {
                     acc.add(p);

--- a/src/main/node/magma/app/StatementParser.ts
+++ b/src/main/node/magma/app/StatementParser.ts
@@ -106,7 +106,29 @@ export default class StatementParser {
                 // TODO
             }
             if (trimmedPart.contains("=")) {
-                stub.append(parseAssignment(trimmedPart, indent, vars, returns)).append(System.lineSeparator());
+                if (trimmedPart.endsWith("(/* TODO */)) {
+                    let eq : unknown = trimmedPart.indexOf(/* TODO */);
+                    let dest : unknown = trimmedPart.substring(0, eq).trim();
+                    let rhs : unknown = trimmedPart.substring(/* TODO */).trim();
+                    let tokens : unknown = dest.split("\\s+");
+                    if (/* TODO */) {
+                        let name : unknown = tokens[tokens.length - 1];
+                        let type : unknown = tokens[tokens.length - 2];
+                        let tsType : unknown = type.equals("var") ? inferVarType(rhs, vars, returns);
+                        : TypeMapper.toTsType(type);
+                        vars.put(name, tsType);
+                        stub.append(indent).append("    let ");
+                        .append(name).append(" : ");
+                        // TODO
+                        .append(rhs).append(System.lineSeparator());
+                        // TODO
+                        stub.append(indent).append("    ");
+                        .append(trimmedPart).append(System.lineSeparator());
+                    }
+                    // TODO
+                    stub.append(parseAssignment(trimmedPart, indent, vars, returns));
+                    .append(System.lineSeparator());
+                }
                 // TODO
             }
             if (ExpressionParser.isInvokable(trimmedPart)) {


### PR DESCRIPTION
## Summary
- ensure multi-line arrow call assignments keep their opening line
- document arrow call preservation

## Testing
- `./build.sh`
- `./test.sh`
- `./validate-ts.sh` *(fails: TS18003 No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68450b8dfbc08321b967919e5a5abf2e