### PR TITLE
Refactor numeric parsing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ intact so the arrow block receives the correct arguments.
   and now inserts missing imports when classes are referenced without an
   explicit `import` statement
 - `magma.app.ArrowHelper` – turns lambda expressions into arrow functions
+- `magma.app.ParseHelper` – shared utilities such as numeric checks to
+  keep parsing helpers small
 - `magma.Actual` – marker annotation recognized by the transpiler to
   omit placeholder classes from the generated code
 - Interface method signatures now keep parameter and return types so

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -42,6 +42,8 @@ platforms.
     simple value assignments still emit `// TODO`.
 - `FieldTranspiler` – converts Java field definitions
 - `ArrowHelper` – rewrites lambda expressions to arrow functions
+- `ParseHelper` – small shared helpers like numeric detection so other
+  classes avoid duplicating these checks
   - Lambda arguments inside method calls are preserved so `doThing(() -> 1)`
     becomes `doThing(() => 1)`.
   - Typed lambda parameters are converted to `name : type` form so `(String v)`

--- a/src/main/java/magma/app/ExpressionParser.java
+++ b/src/main/java/magma/app/ExpressionParser.java
@@ -53,13 +53,13 @@ class ExpressionParser {
         if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
             return trimmed;
         }
-        if (isMemberAccess(trimmed) || isNumeric(trimmed)) {
+        if (isMemberAccess(trimmed) || ParseHelper.isNumeric(trimmed)) {
             return trimmed;
         }
         if (isIdentifier(trimmed)) {
             return trimmed;
         }
-        if (isNumeric(trimmed)) {
+        if (ParseHelper.isNumeric(trimmed)) {
             return trimmed;
         }
         return "/* TODO */";
@@ -133,26 +133,6 @@ class ExpressionParser {
             return stubInvokableExpr(seg);
         }
         return seg;
-    }
-
-    private static boolean isNumeric(String s) {
-        if (s.isEmpty()) return false;
-        var i = 0;
-        if (s.charAt(0) == '-') {
-            if (s.length() == 1) return false;
-            i = 1;
-        }
-        var dot = false;
-        for (; i < s.length(); i++) {
-            var c = s.charAt(i);
-            if (c == '.') {
-                if (dot) return false;
-                dot = true;
-                continue;
-            }
-            if (c < '0' || c > '9') return false;
-        }
-        return true;
     }
 
     private static boolean isIdentifier(String s) {

--- a/src/main/java/magma/app/ParseHelper.java
+++ b/src/main/java/magma/app/ParseHelper.java
@@ -1,0 +1,23 @@
+package magma.app;
+
+class ParseHelper {
+    static boolean isNumeric(String s) {
+        if (s.isEmpty()) return false;
+        var i = 0;
+        if (s.charAt(0) == '-') {
+            if (s.length() == 1) return false;
+            i = 1;
+        }
+        var dot = false;
+        for (; i < s.length(); i++) {
+            var c = s.charAt(i);
+            if (c == '.') {
+                if (dot) return false;
+                dot = true;
+                continue;
+            }
+            if (c < '0' || c > '9') return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/magma/app/StatementParser.java
+++ b/src/main/java/magma/app/StatementParser.java
@@ -226,33 +226,13 @@ class StatementParser {
             return rest.isEmpty() ? "unknown" : rest;
         }
 
-        if (isNumeric(trimmed)) return "number";
+        if (ParseHelper.isNumeric(trimmed)) return "number";
         if (trimmed.equals("true") || trimmed.equals("false")) return "boolean";
         if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
             return "string";
         }
 
         return "unknown";
-    }
-
-    private static boolean isNumeric(String s) {
-        if (s.isEmpty()) return false;
-        var i = 0;
-        if (s.charAt(0) == '-') {
-            if (s.length() == 1) return false;
-            i = 1;
-        }
-        var dot = false;
-        for (; i < s.length(); i++) {
-            var c = s.charAt(i);
-            if (c == '.') {
-                if (dot) return false;
-                dot = true;
-                continue;
-            }
-            if (c < '0' || c > '9') return false;
-        }
-        return true;
     }
 
     static java.util.Map<String, String> paramVars(String tsParams) {


### PR DESCRIPTION
## Summary
- factor out duplicate numeric check into ParseHelper
- call ParseHelper from ExpressionParser and StatementParser
- document ParseHelper in README and architecture overview

## Testing
- `./build.sh`
- `./test.sh`
- `./validate-ts.sh` *(fails: no TypeScript inputs in tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6845948f05848321b07a4a7f77e6d309