### PR TITLE
Switch placeholders to explicit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Magma Self-Hosted Compiler
+
+This repository contains a single monolithic file `src/magma/Main.java`. The program is intentionally self-contained and compiles itself from Java to C. The design keeps all logic in one place so the generated C code mirrors the original source.
+
+## Error Handling
+
+Earlier versions inserted placeholder comments whenever the compiler encountered unsupported syntax. Placeholders have been removed in favor of explicit errors. The compiler now throws `CompilationError` when it cannot handle an input fragment.
+
+## Key Components
+
+- **Option** and **List** – lightweight collection abstractions.
+- **Result** – represents success or `IOError` from file operations.
+- **JavaType**, **Node**, **CDefinition** – models of the generated C code.
+

--- a/src/magma/Main.java
+++ b/src/magma/Main.java
@@ -493,6 +493,12 @@ public class Main {
         }
     }
 
+    private static class CompilationError extends RuntimeException {
+        public CompilationError(String message) {
+            super(message);
+        }
+    }
+
     @Actual
     private record JavaIOError(IOException exception) implements IOError {
         @Override
@@ -1524,9 +1530,7 @@ public class Main {
     }
 
     private static String generatePlaceholder(String input) {
-        return "/*" + input
-                .replace("/*", "start")
-                .replace("*/", "end") + "*/";
+        throw new CompilationError("Unsupported input: " + input);
     }
 
     private static <T extends Node> String generateValueNodes(List<T> nodes) {


### PR DESCRIPTION
## Summary
- throw `CompilationError` when encountering unsupported input
- document new error handling in README

## Testing
- `javac src/magma/Main.java`

------
https://chatgpt.com/codex/tasks/task_e_6848511d32bc8321977779274e1c0b1e