### PR TITLE
Implement file-based compile skeleton

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 The roadmap tracks upcoming milestones. Items checked are completed.
 
 - [ ] Set up project scaffolding and initial tests
-- [ ] Implement a minimal compiler skeleton
+- [x] Implement a minimal compiler skeleton
 - [ ] Expand the language grammar
 - [ ] Build a self-hosted version of Magma
 

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -1,0 +1,8 @@
+# Design Reasoning
+
+The compiler currently works with a single input file and a single output file.
+This decision keeps the interface familiar and mirrors traditional compilers,
+which simplifies future command-line integration.  For now, non-empty input is
+simply echoed back with a `compiled:` prefix while the empty-file case generates
+an empty `main` function in C.  This minimal behavior allows tests to drive the
+implementation while leaving room for the real compilation pipeline to evolve.

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -3,5 +3,6 @@
 This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
-- `magma.compiler.Compiler` – minimal compiler skeleton
+- `magma.compiler.Compiler` – minimal compiler skeleton. Operates on input and
+  output files; empty input results in `int main() {}` in the output.
 

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -1,7 +1,26 @@
-class Compiler:
-    """Minimal compiler skeleton."""
+from pathlib import Path
 
-    def compile(self, source: str) -> str:
-        """Return a placeholder compilation result."""
-        return f"compiled: {source}"
+
+class Compiler:
+    """Minimal compiler skeleton.
+
+    The compiler operates on files to keep the interface simple for now.  This
+    mirrors how traditional compilers work and makes future CLI integration
+    straightforward.
+    """
+
+    def compile(self, input_path: Path, output_path: Path) -> None:
+        """Compile ``input_path`` to ``output_path``.
+
+        An empty input file results in a minimal C program with an empty
+        ``main`` function.  Non-empty input is currently passed through as a
+        placeholder to keep the initial skeleton trivial.
+        """
+
+        source = Path(input_path).read_text()
+
+        if not source.strip():
+            Path(output_path).write_text("int main() {}\n")
+        else:
+            Path(output_path).write_text(f"compiled: {source}")
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -6,8 +6,23 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 from magma import Compiler
 
 
-def test_compile_returns_placeholder():
+def test_compile_empty_input_creates_empty_main(tmp_path):
     compiler = Compiler()
-    result = compiler.compile("hello")
-    assert result == "compiled: hello"
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("")
+    output_file = tmp_path / "out.c"
 
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int main() {}\n"
+
+
+def test_compile_non_empty_returns_placeholder(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("hello")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: hello"


### PR DESCRIPTION
## Summary
- implement a file-based `Compiler.compile` method
- generate an empty `main` function when the input file is empty
- update roadmap to mark compiler skeleton complete
- document design reasoning
- note module overview changes
- update tests for new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad4c9fef48321bd2c3cde0fdb7d28