### PR TITLE
Support simple function definitions

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,6 +5,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
 - [ ] Set up project scaffolding and initial tests
 - [x] Implement a minimal compiler skeleton
 - [ ] Expand the language grammar
+  - [x] Support `fn name() => {}` to `void name() {}`
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -2,10 +2,14 @@
 
 The compiler currently works with a single input file and a single output file.
 This decision keeps the interface familiar and mirrors traditional compilers,
-which simplifies future command-line integration.  For now, non-empty input is
-simply echoed back with a `compiled:` prefix while the empty-file case generates
-an empty `main` function in C.  This minimal behavior allows tests to drive the
-implementation while leaving room for the real compilation pipeline to evolve.
+which simplifies future command-line integration.  For now, non-empty input was
+initially echoed back with a `compiled:` prefix while the empty-file case
+generated an empty `main` function in C.  This minimal behavior allowed tests to
+drive the implementation while leaving room for the real compilation pipeline to
+evolve.  The first extension to the grammar introduces a simple function form
+`fn name() => {}` that compiles directly to `void name() {}` in C.  Supporting
+this syntax keeps the compiler behavior obvious while providing a stepping stone
+toward a richer language.
 
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -4,6 +4,8 @@ This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
 - `magma.compiler.Compiler` – minimal compiler skeleton. Operates on input and
-  output files; empty input results in `int main() {}` in the output.
+  output files; empty input results in `int main() {}` in the output. It also
+  supports a basic function syntax `fn name() => {}` which becomes
+  `void name() {}` in C.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 class Compiler:
@@ -21,6 +22,12 @@ class Compiler:
 
         if not source.strip():
             Path(output_path).write_text("int main() {}\n")
+            return
+
+        match = re.fullmatch(r"fn\s+(\w+)\s*\(\)\s*=>\s*{}\s*", source.strip())
+        if match:
+            name = match.group(1)
+            Path(output_path).write_text(f"void {name}() {{}}\n")
         else:
             Path(output_path).write_text(f"compiled: {source}")
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -26,3 +26,14 @@ def test_compile_non_empty_returns_placeholder(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "compiled: hello"
+
+
+def test_compile_simple_function(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn foo() => {}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void foo() {}\n"


### PR DESCRIPTION
## Summary
- compile `fn name() => {}` into `void name() {}`
- document design reasoning for new syntax and update module overview
- note grammar expansion progress in roadmap
- add tests for simple function compilation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ad9ae04a0832182284fd02160fa72