### PR TITLE
Allow optional Void return type

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
 - [ ] Expand the language grammar
   - [x] Support `fn name() => {}` to `void name() {}`
   - [x] Handle multiple `fn` declarations in a single file
+  - [x] Allow optional `Void` return type with `fn name(): Void => {}`
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -18,6 +18,11 @@ translated; anything else falls back to the placeholder behavior. This keeps the
 compiler's implementation straightforward and allows the tests to drive future
 grammar additions.
 
+The grammar now accepts an explicit `Void` return type written as
+`fn name(): Void => {}`.  The compiler still emits `void` in the generated C
+code but parsing the annotation prepares the ground for richer type handling
+without complicating the current translation scheme.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -6,7 +6,9 @@ This list summarizes the main modules of the project for quick reference.
   - `magma.compiler.Compiler` – minimal compiler skeleton. Operates on input and
     output files; empty input results in `int main() {}` in the output. It also
     supports a basic function syntax `fn name() => {}` which becomes
-    `void name() {}` in C. Multiple functions can appear one per line, each
-    translated in the same manner.
+    `void name() {}` in C. An optional explicit return type such as
+    `fn name(): Void => {}` is also recognized and produces the same C output.
+    Multiple functions can appear one per line, each translated in the same
+    manner.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -27,7 +27,7 @@ class Compiler:
         lines = [line.strip() for line in source.strip().splitlines() if line.strip()]
         funcs = []
         for line in lines:
-            match = re.fullmatch(r"fn\s+(\w+)\s*\(\)\s*=>\s*{}\s*", line)
+            match = re.fullmatch(r"fn\s+(\w+)\s*\(\)\s*(?::\s*\w+\s*)?=>\s*{}\s*", line, re.IGNORECASE)
             if not match:
                 Path(output_path).write_text(f"compiled: {source}")
                 return

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -49,3 +49,14 @@ def test_compile_multiple_functions(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void foo() {}\nvoid bar() {}\n"
+
+
+def test_compile_explicit_void_return(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn empty(): Void => {}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void empty() {}\n"


### PR DESCRIPTION
## Summary
- parse `fn name(): Void => {}` and compile it to `void name() {}`
- describe the new grammar addition in docs
- note it on the project roadmap
- test the optional return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae3537a4c83219b950387dfaa82ba