### PR TITLE
Support boolean false return

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,8 +8,9 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Support `fn name() => {}` to `void name() {}`
   - [x] Handle multiple `fn` declarations in a single file
   - [x] Allow optional `Void` return type with `fn name(): Void => {}`
-  - [x] Support boolean return with `fn name(): Bool => { return true; }`
-    generating `int name() { return 1; }` in C
+  - [x] Support boolean return with `fn name(): Bool => { return true; }` or
+    `fn name(): Bool => { return false; }` generating
+    `int name() { return 1; }` or `int name() { return 0; }` in C
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -24,11 +24,12 @@ code but parsing the annotation prepares the ground for richer type handling
 without complicating the current translation scheme.
 
 As another small step, a boolean return can be expressed using
-`fn name(): Bool => { return true; }`. To keep the generated C portable
-without additional headers, the compiler emits `int` and `1` rather than
-`bool` and `true`: `int name() { return 1; }`. Keeping the body fixed lets
-the regular-expression approach continue working while hinting at how
-types and function bodies will eventually evolve.
+`fn name(): Bool => { return true; }` or `fn name(): Bool => { return false; }`.
+To keep the generated C portable without additional headers, the compiler emits
+`int` and `1` or `0` rather than `bool` and `true`/`false`:
+`int name() { return 1; }` or `int name() { return 0; }`. Keeping the body fixed
+lets the regular-expression approach continue working while hinting at how types
+and function bodies will eventually evolve.
 
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -9,9 +9,9 @@ This list summarizes the main modules of the project for quick reference.
     `void name() {}` in C. An optional explicit return type such as
     `fn name(): Void => {}` is also recognized and produces the same C output.
     Functions may declare a boolean return with
-    `fn name(): Bool => { return true; }` which yields
-    `int name() { return 1; }` in C so that the output remains valid without
-    extra headers. Multiple functions can appear one per line, each
-    translated in the same manner.
+    `fn name(): Bool => { return true; }` or `fn name(): Bool => { return false; }`.
+    These yield `int name() { return 1; }` or `int name() { return 0; }` in C so
+    that the output remains valid without extra headers. Multiple functions can
+    appear one per line, each translated in the same manner.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -47,11 +47,13 @@ class Compiler:
                     return
                 funcs.append(f"void {name}() {{}}\n")
             elif ret_type.lower() == "bool":
-                if body != "return true;":
+                lower_body = body.lower()
+                if lower_body not in {"return true;", "return false;"}:
                     Path(output_path).write_text(f"compiled: {source}")
                     return
                 # emit valid C without relying on additional headers
-                funcs.append(f"int {name}() {{ return 1; }}\n")
+                return_value = "1" if lower_body == "return true;" else "0"
+                funcs.append(f"int {name}() {{ return {return_value}; }}\n")
             else:
                 Path(output_path).write_text(f"compiled: {source}")
                 return

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -71,3 +71,14 @@ def test_compile_bool_return(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "int truth() { return 1; }\n"
+
+
+def test_compile_bool_false_return(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn lie(): Bool => { return false; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int lie() { return 0; }\n"


### PR DESCRIPTION
## Summary
- allow boolean functions to return `false` to output `0`
- test compilation of boolean functions returning `false`
- document boolean false support across design docs
- update roadmap bullet about boolean return

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aea03bb4c8321955deeb1466800f9