### PR TITLE
Improve whitespace tolerance in function parsing

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,6 +11,8 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Support boolean return with `fn name(): Bool => { return true; }` or
     `fn name(): Bool => { return false; }` generating
     `int name() { return 1; }` or `int name() { return 0; }` in C
+  - [x] Accept extra whitespace in function declarations, including newlines
+    and carriage returns
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -31,6 +31,15 @@ To keep the generated C portable without additional headers, the compiler emits
 lets the regular-expression approach continue working while hinting at how types
 and function bodies will eventually evolve.
 
+The translation relies on a single regular expression. To keep this simple
+approach viable as code gets reformatted, the regex now tolerates arbitrary
+whitespace in function declarations. Initially this only covered spaces and
+tabs because the compiler split input into lines. This restriction meant each
+function had to occupy a single line. The parser now scans the entire source
+so newlines and carriage returns are treated like any other whitespace.
+Without this flexibility, casual reformatting would fail the compile step and
+undermine the project's forgiving early-stage design.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -6,9 +6,11 @@ This list summarizes the main modules of the project for quick reference.
   - `magma.compiler.Compiler` – minimal compiler skeleton. Operates on input and
     output files; empty input results in `int main() {}` in the output. It also
     supports a basic function syntax `fn name() => {}` which becomes
-    `void name() {}` in C. An optional explicit return type such as
-    `fn name(): Void => {}` is also recognized and produces the same C output.
-    Functions may declare a boolean return with
+    `void name() {}` in C. The pattern tolerates arbitrary whitespace so that
+    formatting differences – including newline and carriage return characters – do
+    not affect compilation. An optional explicit
+    return type such as `fn name(): Void => {}` is also recognized and produces
+    the same C output. Functions may declare a boolean return with
     `fn name(): Bool => { return true; }` or `fn name(): Bool => { return false; }`.
     These yield `int name() { return 1; }` or `int name() { return 0; }` in C so
     that the output remains valid without extra headers. Multiple functions can

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -24,16 +24,15 @@ class Compiler:
             Path(output_path).write_text("int main() {}\n")
             return
 
-        lines = [line.strip() for line in source.strip().splitlines() if line.strip()]
         funcs = []
         pattern = re.compile(
-            r"fn\s+(\w+)\s*\(\)\s*(?::\s*(Void|Bool)\s*)?=>\s*{\s*(.*?)\s*}\s*",
-            re.IGNORECASE,
+            r"fn\s+(\w+)\s*\(\s*\)\s*(?::\s*(Void|Bool)\s*)?=>\s*{\s*(.*?)\s*}\s*",
+            re.IGNORECASE | re.DOTALL,
         )
 
-        for line in lines:
-            match = pattern.fullmatch(line)
-            if not match:
+        pos = 0
+        for match in pattern.finditer(source):
+            if source[pos:match.start()].strip():
                 Path(output_path).write_text(f"compiled: {source}")
                 return
 
@@ -57,6 +56,12 @@ class Compiler:
             else:
                 Path(output_path).write_text(f"compiled: {source}")
                 return
+
+            pos = match.end()
+
+        if source[pos:].strip():
+            Path(output_path).write_text(f"compiled: {source}")
+            return
 
         if funcs:
             Path(output_path).write_text("".join(funcs))

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -82,3 +82,48 @@ def test_compile_bool_false_return(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "int lie() { return 0; }\n"
+
+
+def test_compile_function_with_extra_whitespace(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn   spaced  (  )  :  Void  =>  {   }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void spaced() {}\n"
+
+
+def test_compile_bool_with_whitespace(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn ws(): Bool => {  return true;  }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int ws() { return 1; }\n"
+
+
+def test_compile_function_with_newlines(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn nl\n(\n)\n:\nVoid\n=>\n{\n}\n")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void nl() {}\n"
+
+
+def test_compile_function_with_carriage_returns(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    content = "fn cr\r\n(\r\n)\r\n:\r\nVoid\r\n=>\r\n{\r\n}\r\n"
+    input_file.write_text(content)
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void cr() {}\n"


### PR DESCRIPTION
## Summary
- allow newlines and CRs in function declarations
- explain multiline regex approach
- document whitespace handling improvements
- test compilation of newline and CR delimited functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aebad2dbc832186a5297587bfe56c