### PR TITLE
Add numeric return type support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,8 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     `int name() { return 1; }` or `int name() { return 0; }` in C
   - [x] Accept extra whitespace in function declarations, including newlines
     and carriage returns
+  - [x] Map numeric return types `U8`, `U16`, `U32`, `U64`, `I8`, `I16`, `I32`,
+    `I64` to standard C integers
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -31,6 +31,11 @@ To keep the generated C portable without additional headers, the compiler emits
 lets the regular-expression approach continue working while hinting at how types
 and function bodies will eventually evolve.
 
+Numeric return types such as `U8` or `I32` map directly to plain C integers like
+`unsigned char` or `int`. The body is limited to `return 0;` so the same regular
+expression can parse these functions without growing more complicated. Using
+standard C types avoids introducing additional headers at this stage.
+
 The translation relies on a single regular expression. To keep this simple
 approach viable as code gets reformatted, the regex now tolerates arbitrary
 whitespace in function declarations. Initially this only covered spaces and

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -13,7 +13,9 @@ This list summarizes the main modules of the project for quick reference.
     the same C output. Functions may declare a boolean return with
     `fn name(): Bool => { return true; }` or `fn name(): Bool => { return false; }`.
     These yield `int name() { return 1; }` or `int name() { return 0; }` in C so
-    that the output remains valid without extra headers. Multiple functions can
-    appear one per line, each translated in the same manner.
+    that the output remains valid without extra headers. Numeric return types
+    like `U8` or `I64` translate to plain C integers such as `unsigned char` or
+    `long long` with a fixed body `return 0;`. Multiple functions can appear one
+    per line, each translated in the same manner.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -10,6 +10,17 @@ class Compiler:
     straightforward.
     """
 
+    NUMERIC_TYPE_MAP = {
+        "u8": "unsigned char",
+        "u16": "unsigned short",
+        "u32": "unsigned int",
+        "u64": "unsigned long long",
+        "i8": "signed char",
+        "i16": "short",
+        "i32": "int",
+        "i64": "long long",
+    }
+
     def compile(self, input_path: Path, output_path: Path) -> None:
         """Compile ``input_path`` to ``output_path``.
 
@@ -26,7 +37,7 @@ class Compiler:
 
         funcs = []
         pattern = re.compile(
-            r"fn\s+(\w+)\s*\(\s*\)\s*(?::\s*(Void|Bool)\s*)?=>\s*{\s*(.*?)\s*}\s*",
+            r"fn\s+(\w+)\s*\(\s*\)\s*(?::\s*(Void|Bool|U8|U16|U32|U64|I8|I16|I32|I64)\s*)?=>\s*{\s*(.*?)\s*}\s*",
             re.IGNORECASE | re.DOTALL,
         )
 
@@ -53,6 +64,12 @@ class Compiler:
                 # emit valid C without relying on additional headers
                 return_value = "1" if lower_body == "return true;" else "0"
                 funcs.append(f"int {name}() {{ return {return_value}; }}\n")
+            elif ret_type.lower() in self.NUMERIC_TYPE_MAP:
+                if body != "return 0;":
+                    Path(output_path).write_text(f"compiled: {source}")
+                    return
+                c_type = self.NUMERIC_TYPE_MAP[ret_type.lower()]
+                funcs.append(f"{c_type} {name}() {{ return 0; }}\n")
             else:
                 Path(output_path).write_text(f"compiled: {source}")
                 return

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
@@ -127,3 +128,27 @@ def test_compile_function_with_carriage_returns(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void cr() {}\n"
+
+
+@pytest.mark.parametrize(
+    "magma_type,c_type",
+    [
+        ("U8", "unsigned char"),
+        ("U16", "unsigned short"),
+        ("U32", "unsigned int"),
+        ("U64", "unsigned long long"),
+        ("I8", "signed char"),
+        ("I16", "short"),
+        ("I32", "int"),
+        ("I64", "long long"),
+    ],
+)
+def test_compile_numeric_return(tmp_path, magma_type, c_type):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(f"fn num(): {magma_type} => {{ return 0; }}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == f"{c_type} num() {{ return 0; }}\n"


### PR DESCRIPTION
## Summary
- support numeric return types U8/U16/U32/U64/I8/I16/I32/I64
- document numeric types in design docs and modules overview
- update roadmap for numeric return types
- test numeric return mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aed3af3c883219d4fa8fd957791a3