### PR TITLE
Implement let statements

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     and carriage returns
   - [x] Map numeric return types `U8`, `U16`, `U32`, `U64`, `I8`, `I16`, `I32`,
     `I64` to standard C integers
+  - [x] Support simple `let` statements within functions
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -45,6 +45,14 @@ so newlines and carriage returns are treated like any other whitespace.
 Without this flexibility, casual reformatting would fail the compile step and
 undermine the project's forgiving early-stage design.
 
+The next feature introduces simple variable declarations using `let` inside
+functions.  Each declaration is validated against the declared type so that
+obvious mismatches are caught early without a full type checker.  Booleans are
+again translated to plain `int` values to keep the generated C self-contained
+while numeric types reuse the existing mapping table.  Allowing only literals as
+values keeps the regular-expression parser manageable and continues the theme of
+small incremental steps.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -17,5 +17,8 @@ This list summarizes the main modules of the project for quick reference.
     like `U8` or `I64` translate to plain C integers such as `unsigned char` or
     `long long` with a fixed body `return 0;`. Multiple functions can appear one
     per line, each translated in the same manner.
+    Function bodies may also contain simple variable declarations of the form
+    `let name: I32 = 1;` which become `int name = 1;` in C. Only literal values
+    are accepted so the regular-expression parser remains straightforward.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -152,3 +152,36 @@ def test_compile_numeric_return(tmp_path, magma_type, c_type):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == f"{c_type} num() {{ return 0; }}\n"
+
+
+def test_compile_let_numeric(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn foo(): Void => { let myValue: I32 = 420; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void foo() { int myValue = 420; }\n"
+
+
+def test_compile_let_bool(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn flag(): Void => { let flag: Bool = true; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void flag() { int flag = 1; }\n"
+
+
+def test_compile_let_invalid_value(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn bad(): Void => { let nope: I32 = true; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn bad(): Void => { let nope: I32 = true; }"


### PR DESCRIPTION
## Summary
- allow `let` statements within function bodies
- validate literal values match their declared type
- document variable declarations and update module list
- mark roadmap item for let statement support
- test `let` statements for numeric and boolean types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aef9bf2f48321afd91975a1bb3e1c