### PR TITLE
Add let statement type inference

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -60,6 +60,12 @@ regular-expression approach can verify the element count and type without a full
 type checker. Keeping the transformation straightforward preserves the project's
 focus on small, test-driven increments.
 
+Variable declarations may now omit the type when assigned a boolean or numeric
+literal. In these cases the compiler infers `Bool` or `I32` and still emits a
+plain `int` in C. This inference keeps the source terse while retaining the
+simple regular-expression parser. Assignments to the `Void` type are rejected so
+that meaningless variables do not slip through the translation.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -22,5 +22,7 @@ This list summarizes the main modules of the project for quick reference.
     are accepted so the regular-expression parser remains straightforward.
     Arrays can be declared with `let arr: [I32; 3] = [1, 2, 3];` resulting in
     `int arr[] = {1, 2, 3};`.
+    When the type is omitted and the value is a boolean or integer literal, the
+    compiler infers the type and still emits `int` in the generated C code.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -206,3 +206,36 @@ def test_compile_let_array_invalid_size(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "compiled: fn badarr(): Void => { let arr: [I32; 2] = [1, 2, 3]; }"
+
+
+def test_compile_let_infer_bool(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn infer(): Void => { let value = false; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void infer() { int value = 0; }\n"
+
+
+def test_compile_let_infer_numeric(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn infer(): Void => { let myInt = 100; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void infer() { int myInt = 100; }\n"
+
+
+def test_compile_let_void_assignment_invalid(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn bad(): Void => { let nothing: Void = 0; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn bad(): Void => { let nothing: Void = 0; }"


### PR DESCRIPTION
## Summary
- infer variable type from value for boolean and numeric literals
- disallow variables typed as `Void`
- test inferred let statements and invalid Void usage
- document the inference rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af36a6b908321aaf0bc0d59a1fd6a