### PR TITLE
Add mut assignments

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     `I64` to standard C integers
   - [x] Support simple `let` statements within functions
   - [x] Support array `let` statements like `let nums: [I32; 3] = [1, 2, 3];`
+  - [x] Allow assignment statements with `mut` declarations
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -66,6 +66,13 @@ plain `int` in C. This inference keeps the source terse while retaining the
 simple regular-expression parser. Assignments to the `Void` type are rejected so
 that meaningless variables do not slip through the translation.
 
+Assignment statements build on this by requiring a `mut` keyword on the
+original declaration.  Without `mut` the compiler rejects reassignments so that
+immutable values stay predictable.  The same simple literal checks ensure the
+assigned value matches the variable's type.  Booleans remain translated to
+`int` as `1` or `0`, while numeric variables accept only decimal literals.  This
+keeps the implementation small while establishing a basic form of type safety.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -24,5 +24,8 @@ This list summarizes the main modules of the project for quick reference.
     `int arr[] = {1, 2, 3};`.
     When the type is omitted and the value is a boolean or integer literal, the
     compiler infers the type and still emits `int` in the generated C code.
+    Assignment statements are supported when the variable is declared with
+    `mut` and the new value matches the original type.  Reassignment is written
+    simply as `name = 2;` and translates directly to the equivalent C statement.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -239,3 +239,47 @@ def test_compile_let_void_assignment_invalid(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "compiled: fn bad(): Void => { let nothing: Void = 0; }"
+
+
+def test_compile_assignment_mut_numeric(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn assign(): Void => { let mut x: I32 = 100; x = 200; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void assign() { int x = 100; x = 200; }\n"
+
+
+def test_compile_assignment_mut_bool(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn assign(): Void => { let mut flag: Bool = true; flag = false; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void assign() { int flag = 1; flag = 0; }\n"
+
+
+def test_compile_assignment_without_mut_invalid(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn bad(): Void => { let x: I32 = 100; x = 200; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn bad(): Void => { let x: I32 = 100; x = 200; }"
+
+
+def test_compile_assignment_type_mismatch_invalid(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn bad(): Void => { let mut x: I32 = 100; x = true; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn bad(): Void => { let mut x: I32 = 100; x = true; }"


### PR DESCRIPTION
## Summary
- allow assignment statements when vars are declared with `mut`
- parse assignments and track mutability
- document new design reasoning and module overview
- update roadmap and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af4b231f4832198b83d06b14d1c69