### PR TITLE
Enable function parameters

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Support array `let` statements like `let nums: [I32; 3] = [1, 2, 3];`
   - [x] Allow assignment statements with `mut` declarations
   - [x] Support `struct` declarations like `struct Point {x : I32;}`
+  - [x] Allow function parameters with `fn add(x: I32, y: I32)` syntax
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -80,6 +80,12 @@ support.  Each field is translated directly to its C equivalent, resulting in
 expression, the compiler avoids a full parser while still allowing clear data
 definitions.
 
+Function declarations now accept parameters written as `name: Type` separated
+by commas.  The same regular-expression approach parses these parameters,
+limiting them to boolean and numeric types so the implementation stays small.
+Parameters translate directly to their C equivalents, maintaining the
+incremental strategy of introducing features only as tests require them.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -16,7 +16,9 @@ This list summarizes the main modules of the project for quick reference.
     that the output remains valid without extra headers. Numeric return types
     like `U8` or `I64` translate to plain C integers such as `unsigned char` or
     `long long` with a fixed body `return 0;`. Multiple functions can appear one
-    per line, each translated in the same manner.
+    per line, each translated in the same manner. Functions can also take
+    parameters written as `name: Type` separated by commas, so
+    `fn add(x: I32, y: I32)` yields `int add(int x, int y)` in the generated C.
     Function bodies may also contain simple variable declarations of the form
     `let name: I32 = 1;` which become `int name = 1;` in C. Only literal values
     are accepted so the regular-expression parser remains straightforward.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -315,3 +315,36 @@ def test_compile_struct_invalid_type(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "compiled: struct Bad {x : Unknown}"
+
+
+def test_compile_function_with_numeric_params(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn add(x: I32, y: I32): I32 => { return 0; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int add(int x, int y) { return 0; }\n"
+
+
+def test_compile_function_with_bool_param(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn flag(value: Bool): Bool => { return true; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int flag(int value) { return 1; }\n"
+
+
+def test_compile_function_invalid_param_type(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn bad(x: Unknown): Void => {}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn bad(x: Unknown): Void => {}"


### PR DESCRIPTION
## Summary
- allow function parameters in the compiler
- test functions with parameters
- document parameter support in the modules overview and design reasoning
- record completion on the roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af8a514b88321981321c555247d21