### PR TITLE
Add function invocation support

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -109,6 +109,12 @@ operands share the same type. This conservative check prevents accidental mixes
 of boolean and numeric values while keeping the parser straightforward.  When a
 mismatch occurs, compilation fails rather than producing questionable C code.
 
+Function calls are now recognized as stand-alone statements. Arguments may be
+literals or previously declared variables, and boolean values are converted to
+`1` or `0` so the generated C remains header-free. Unknown variables cause
+compilation to fail, but the callee's signature is not yet validated. This keeps
+the parser small while letting tests drive interaction between functions.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -47,5 +47,8 @@ This list summarizes the main modules of the project for quick reference.
     generated C self-contained.
     Basic comparisons `<`, `<=`, `>`, `>=`, and `==` require both sides to have
     matching types; otherwise compilation fails.
+    Function calls written as `foo(1, bar);` are copied directly after
+    translating boolean literals to `1` or `0`. Each argument must either be a
+    literal or a previously declared variable; otherwise compilation fails.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.


### PR DESCRIPTION
## Summary
- support C-style function call statements in Magma
- document why calls are implemented simply
- list function call capability in modules overview
- test calling functions with literals and variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b047735e08321b958ca9c216f27b5