### PR TITLE
Add bounded numeric parameter support

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -115,6 +115,14 @@ literals or previously declared variables, and boolean values are converted to
 compilation to fail, but the callee's signature is not yet validated. This keeps
 the parser small while letting tests drive interaction between functions.
 
+### Bounded Parameter Types
+Function parameters may include numeric bounds such as `I32 > 10`. These
+constraints are checked only when arguments are compile-time literals so the
+implementation stays simple. Calls with literals that violate the bound cause
+compilation to fail, while variables bypass the check since their values are not
+known. This strikes a balance between early feedback and keeping the parser
+lightweight.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -49,6 +49,8 @@ This list summarizes the main modules of the project for quick reference.
     matching types; otherwise compilation fails.
     Function calls written as `foo(1, bar);` are copied directly after
     translating boolean literals to `1` or `0`. Each argument must either be a
-    literal or a previously declared variable; otherwise compilation fails.
+    literal or a previously declared variable; otherwise compilation fails. When
+    function parameters include numeric bounds such as `I32 > 10`, literal
+    arguments are validated against the bound at compile time.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.


### PR DESCRIPTION
## Summary
- allow parameters to specify numeric bounds (e.g. `I32 > 10`)
- validate literal arguments against those bounds
- track function signatures for basic type checking
- document bounded types in design docs and module overview
- cover new feature with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b069bf6c4832197431dd43b71c7f7