### PR TITLE
Add parentheses handling

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Validate comparison operators `<`, `<=`, `>`, `>=`, and `==` in `if`
     conditions
   - [x] Check array indexing against compile-time bounds
+  - [x] Allow optional parentheses around expressions
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -139,6 +139,12 @@ rejects out-of-range constants or variables without the appropriate constraint.
 This keeps indexing safe without adding a runtime check while remaining simple
 enough for the regular-expression based parser.
 
+### Parenthesized Expressions
+The parser now accepts arbitrary balanced parentheses around expressions. Rather
+than building a full expression grammar, the compiler repeatedly strips matching
+outer parentheses before evaluating the expression. This recursive approach keeps
+the implementation small while allowing familiar grouping such as `((value))`.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -58,5 +58,8 @@ This list summarizes the main modules of the project for quick reference.
     Array elements can be accessed with `arr[i]` when `i` is bounded by
     `arr.length` using a declaration like `let i: USize < arr.length = 0;`.
     Out-of-range constants are rejected at compile time.
+    Expressions may be wrapped in any number of parentheses. The compiler
+    removes matching outer pairs before processing so `( (x) )` is treated the
+    same as `x`.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.


### PR DESCRIPTION
## Summary
- support parentheses around expressions
- document design choice for parentheses support
- note parentheses feature in module overview and roadmap
- expand tests for parenthesized expressions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b10686d0c83219fab690d687f2583