### PR TITLE
Support arithmetic expressions in variable declarations

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -145,6 +145,15 @@ than building a full expression grammar, the compiler repeatedly strips matching
 outer parentheses before evaluating the expression. This recursive approach keeps
 the implementation small while allowing familiar grouping such as `((value))`.
 
+### Arithmetic Expressions
+Variable declarations and assignments may now use simple arithmetic made up of
+numeric literals. Instead of introducing a full expression parser, a tiny helper
+checks that the expression only contains digits and the `+`, `-`, `*`, or `/`
+operators. If valid, the expression is copied verbatim into the generated C
+code. Bounds are still enforced when literals appear by evaluating the
+expression in Python. This keeps the implementation compact while enabling
+common calculations like `1 + 2 * 3 - 4`.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -61,5 +61,8 @@ This list summarizes the main modules of the project for quick reference.
     Expressions may be wrapped in any number of parentheses. The compiler
     removes matching outer pairs before processing so `( (x) )` is treated the
     same as `x`.
+    Arithmetic expressions involving only numeric literals such as
+    `1 + 2 * 3 - 4` are copied directly into the generated C code. They are
+    evaluated only when needed for bound checks, keeping the parser minimal.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -621,3 +621,25 @@ def test_compile_parentheses_in_call_arg(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void callee(int x) {\n}\nvoid caller() {\n    int a = 1;\n    callee(a);\n}\n"
+
+
+def test_compile_arithmetic_literal(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn calc(): Void => { let x: I32 = 1 + 2 * 3 - 4; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void calc() {\n    int x = 1 + 2 * 3 - 4;\n}\n"
+
+
+def test_compile_arithmetic_infer(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn calc(): Void => { let x = 1 + 2 * 3 - 4; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void calc() {\n    int x = 1 + 2 * 3 - 4;\n}\n"


### PR DESCRIPTION
## Summary
- allow arithmetic expressions of literals in variable declarations and assignments
- document arithmetic expression support
- add tests for arithmetic expressions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b11dbf784832199ba4e39170d9813