### PR TITLE
Add test for arithmetic parentheses precedence

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -142,17 +142,20 @@ enough for the regular-expression based parser.
 ### Parenthesized Expressions
 The parser now accepts arbitrary balanced parentheses around expressions. Rather
 than building a full expression grammar, the compiler repeatedly strips matching
-outer parentheses before evaluating the expression. This recursive approach keeps
-the implementation small while allowing familiar grouping such as `((value))`.
+outer pairs before evaluating the expression. This recursive approach keeps the
+implementation small while allowing familiar grouping such as `((value))`. When
+parentheses influence precedence&mdash;for example `(3 + 4) * 7`&mdash;the grouping
+is preserved in the generated C so the semantics remain intact.
 
 ### Arithmetic Expressions
 Variable declarations and assignments may now use simple arithmetic made up of
 numeric literals. Instead of introducing a full expression parser, a tiny helper
-checks that the expression only contains digits and the `+`, `-`, `*`, or `/`
-operators. If valid, the expression is copied verbatim into the generated C
-code. Bounds are still enforced when literals appear by evaluating the
-expression in Python. This keeps the implementation compact while enabling
-common calculations like `1 + 2 * 3 - 4`.
+checks that the expression only contains digits, parentheses, and the `+`, `-`,
+`*`, or `/` operators. If valid, the expression is copied verbatim into the
+generated C code. Bounds are still enforced when literals appear by evaluating
+the expression in Python. Parentheses may be used within these expressions to
+control precedence, so `(3 + 4) * 7` remains exactly as written. This keeps the
+implementation compact while enabling common calculations like `1 + 2 * 3 - 4`.
 
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -60,9 +60,10 @@ This list summarizes the main modules of the project for quick reference.
     Out-of-range constants are rejected at compile time.
     Expressions may be wrapped in any number of parentheses. The compiler
     removes matching outer pairs before processing so `( (x) )` is treated the
-    same as `x`.
-    Arithmetic expressions involving only numeric literals such as
-    `1 + 2 * 3 - 4` are copied directly into the generated C code. They are
-    evaluated only when needed for bound checks, keeping the parser minimal.
+    same as `x`. Parentheses that alter precedence are preserved, so `(3 + 4) * 7`
+    remains grouped in the output. Arithmetic expressions involving only numeric
+    literals such as `1 + 2 * 3 - 4` are copied directly into the generated C
+    code. They are evaluated only when needed for bound checks, keeping the
+    parser minimal.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -643,3 +643,14 @@ def test_compile_arithmetic_infer(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void calc() {\n    int x = 1 + 2 * 3 - 4;\n}\n"
+
+
+def test_compile_arithmetic_parentheses_precedence(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn calc(): Void => { let x: I32 = (3 + 4) * 7; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void calc() {\n    int x = (3 + 4) * 7;\n}\n"


### PR DESCRIPTION
## Summary
- document that parentheses affecting precedence are preserved
- note precedence behavior in modules overview
- test arithmetic with parentheses for order of operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b13681c608321b3a96cdce6b6e5f9