### PR TITLE
Support mixed expressions in function calls

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -157,6 +157,14 @@ the expression in Python. Parentheses may be used within these expressions to
 control precedence, so `(3 + 4) * 7` remains exactly as written. This keeps the
 implementation compact while enabling common calculations like `1 + 2 * 3 - 4`.
 
+Mixing function calls within these expressions is now supported as long as the
+called functions were parsed earlier in the file. The code uses Python's `ast`
+module to validate that only arithmetic operators, variables, and known
+function calls appear. Boolean literals within such expressions are translated
+to `1` or `0` so the generated C code stays self-contained. Constant folding
+still only happens when an expression reduces to pure numerics, keeping the
+parser small while allowing idioms like `first(200 + second())`.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -64,6 +64,7 @@ This list summarizes the main modules of the project for quick reference.
     remains grouped in the output. Arithmetic expressions involving only numeric
     literals such as `1 + 2 * 3 - 4` are copied directly into the generated C
     code. They are evaluated only when needed for bound checks, keeping the
-    parser minimal.
+    parser minimal. Expressions may include calls to previously defined
+    functions, allowing constructs like `first(200 + second())`.
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -654,3 +654,19 @@ def test_compile_arithmetic_parentheses_precedence(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void calc() {\n    int x = (3 + 4) * 7;\n}\n"
+
+
+def test_compile_call_with_expression_arg(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn second(): I32 => { return 0; }\nfn first(x: I32): Void => {}\nfn caller(): Void => { first(200 + second()); }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "int second() {\n    return 0;\n}\nvoid first(int x) {\n}\nvoid caller() {\n    first(200 + second());\n}\n"
+    )


### PR DESCRIPTION
## Summary
- allow arithmetic expressions with function calls
- document reasoning about nested expressions
- mention function-call expressions in modules overview
- test function call with an expression argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1487b1748321b1d710dd28132b73