### PR TITLE
Add loop and return support

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -174,6 +174,14 @@ to `1` or `0` so the generated C code stays self-contained. Constant folding
 still only happens when an expression reduces to pure numerics, keeping the
 parser small while allowing idioms like `first(200 + second())`.
 
+### While Loops and Returns
+Control flow now includes `while` loops alongside existing `if` statements. The
+loop parser mirrors the conditional logic so arbitrary statements can appear
+within the loop body, including nested blocks. Functions with non-`Void` return
+types are compiled through the same block parser, allowing `return` statements
+to appear anywhere rather than being fixed to a single `return 0;` form. This
+keeps the implementation uniform while still validating basic type correctness.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -45,6 +45,9 @@ This list summarizes the main modules of the project for quick reference.
     Simple `if` statements written as `if (condition) { ... }` are translated
     directly. Boolean literals in the condition become `1` or `0` to keep the
     generated C self-contained.
+    `while` loops follow the same pattern and may contain any supported
+    statements. Functions with non-`Void` return types may include `return`
+    statements anywhere within their bodies.
     Basic comparisons `<`, `<=`, `>`, `>=`, and `==` require both sides to have
     matching types; otherwise compilation fails. Nested `if` statements are
     rejected when the conditions cannot all be true at the same time, preventing

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -701,3 +701,19 @@ def test_compile_call_with_expression_arg(tmp_path):
         output_file.read_text()
         == "int second() {\n    return 0;\n}\nvoid first(int x) {\n}\nvoid caller() {\n    first(200 + second());\n}\n"
     )
+
+
+def test_compile_nested_while_with_return(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn run(): I32 => { if (true) { let x = 100; while (true) { let y = 200; return 0; } } }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "int run() {\n    if (1) {\n        int x = 100;\n        while (1) {\n            int y = 200;\n            return 0;\n        }\n    }\n}\n"
+    )


### PR DESCRIPTION
## Summary
- support `while` loops and nested return statements in the compiler
- document design changes for loops
- mention new capabilities in modules overview
- test nested `while` handling with returns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1b5580e48321846405c12e976569