### PR TITLE
Implement break and continue statements

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -182,6 +182,13 @@ types are compiled through the same block parser, allowing `return` statements
 to appear anywhere rather than being fixed to a single `return 0;` form. This
 keeps the implementation uniform while still validating basic type correctness.
 
+### Break and Continue
+`break` and `continue` provide early exits and iteration skipping for loops.
+The parser recognizes these statements with small regular expressions so the
+overall block parser stays uncomplicated. Tests ensure they behave as expected
+without extra context tracking, and the compiler simply copies them into the
+generated C code.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -46,8 +46,9 @@ This list summarizes the main modules of the project for quick reference.
     directly. Boolean literals in the condition become `1` or `0` to keep the
     generated C self-contained.
     `while` loops follow the same pattern and may contain any supported
-    statements. Functions with non-`Void` return types may include `return`
-    statements anywhere within their bodies.
+    statements. `break` and `continue` are recognized inside these loops
+    and translate directly to their C equivalents. Functions with non-`Void`
+    return types may include `return` statements anywhere within their bodies.
     Basic comparisons `<`, `<=`, `>`, `>=`, and `==` require both sides to have
     matching types; otherwise compilation fails. Nested `if` statements are
     rejected when the conditions cannot all be true at the same time, preventing

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -64,6 +64,8 @@ class Compiler:
         if_pattern = re.compile(r"if\s*\((.+?)\)\s*{", re.DOTALL)
         while_pattern = re.compile(r"while\s*\((.+?)\)\s*{", re.DOTALL)
         return_pattern = re.compile(r"return(?:\s+(.*?))?\s*;", re.DOTALL)
+        break_pattern = re.compile(r"break\s*;")
+        continue_pattern = re.compile(r"continue\s*;")
         array_type_pattern = re.compile(
             r"\[\s*(Bool|U8|U16|U32|U64|USize|I8|I16|I32|I64)\s*;\s*([0-9]+)\s*\]",
             re.IGNORECASE,
@@ -418,6 +420,18 @@ class Compiler:
                     lines.extend(sub_lines)
                     lines.append(f"{indent_str}}}")
                     pos2 = new_pos
+                    continue
+
+                break_match = break_pattern.match(block, pos2)
+                if break_match:
+                    lines.append(f"{indent_str}break;")
+                    pos2 = break_match.end()
+                    continue
+
+                cont_match = continue_pattern.match(block, pos2)
+                if cont_match:
+                    lines.append(f"{indent_str}continue;")
+                    pos2 = cont_match.end()
                     continue
 
                 let_match = let_pattern.match(block, pos2)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -717,3 +717,31 @@ def test_compile_nested_while_with_return(tmp_path):
         output_file.read_text()
         == "int run() {\n    if (1) {\n        int x = 100;\n        while (1) {\n            int y = 200;\n            return 0;\n        }\n    }\n}\n"
     )
+
+
+def test_compile_break_in_while(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn loop(): Void => { while (true) { break; } }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "void loop() {\n    while (1) {\n        break;\n    }\n}\n"
+    )
+
+
+def test_compile_continue_in_while(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn loop(): Void => { while (true) { continue; } }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "void loop() {\n    while (1) {\n        continue;\n    }\n}\n"
+    )


### PR DESCRIPTION
## Summary
- support `break` and `continue` statements
- document loop control in the design docs and module overview
- test break/continue handling in the compiler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1cfa5c508321b5b88a42761bb03f