### PR TITLE
Permit declarations without initializers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,8 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     `I64` to standard C integers
   - [x] Support simple `let` statements within functions
   - [x] Support array `let` statements like `let nums: [I32; 3] = [1, 2, 3];`
+  - [x] Permit variable declarations without initial values using syntax like
+    `let value: I16;`
   - [x] Allow assignment statements with `mut` declarations
   - [x] Support `struct` declarations like `struct Point {x : I32;}`
   - [x] Allow function parameters with `fn add(x: I32, y: I32)` syntax

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -66,6 +66,11 @@ plain `int` in C. This inference keeps the source terse while retaining the
 simple regular-expression parser. Assignments to the `Void` type are rejected so
 that meaningless variables do not slip through the translation.
 
+Typed declarations may now omit an initializer entirely. Providing the type is
+enough information for the compiler to emit an uninitialized C variable, so
+`let value: I16;` becomes `short value;`. This keeps the parser simple because no
+additional expression analysis is required.
+
 Assignment statements build on this by requiring a `mut` keyword on the
 original declaration.  Without `mut` the compiler rejects reassignments so that
 immutable values stay predictable.  The same simple literal checks ensure the

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -26,6 +26,9 @@ This list summarizes the main modules of the project for quick reference.
     `int arr[] = {1, 2, 3};`.
     When the type is omitted and the value is a boolean or integer literal, the
     compiler infers the type and still emits `int` in the generated C code.
+    Typed variables may also be declared without an initializer, for example
+    `let value: I16;`. The compiler then emits an uninitialized C variable like
+    `short value;`.
     Assignment statements are supported when the variable is declared with
     `mut` and the new value matches the original type.  Reassignment is written
     simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -230,6 +230,17 @@ def test_compile_let_infer_numeric(tmp_path):
     assert output_file.read_text() == "void infer() {\n    int myInt = 100;\n}\n"
 
 
+def test_compile_let_declaration_no_value(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn decl(): Void => { let value: I16; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void decl() {\n    short value;\n}\n"
+
+
 def test_compile_let_void_assignment_invalid(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow `let` statements to omit the initializer
- document uninitialized declarations in the design docs
- record the feature in the roadmap
- describe the new syntax in the module overview
- test uninitialized variable declarations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b21c7a3708321b05489c4d1e31ba5