### PR TITLE
Add struct variable declarations

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     `let value: I16;`
   - [x] Allow assignment statements with `mut` declarations
   - [x] Support `struct` declarations like `struct Point {x : I32;}`
+  - [x] Permit variables of struct types with `let p: Point;`
   - [x] Allow function parameters with `fn add(x: I32, y: I32)` syntax
   - [x] Handle nested braces within function bodies
   - [x] Support `if` statements written as `if (condition) { ... }`

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -83,7 +83,9 @@ Only boolean and numeric field types are accepted, mirroring the existing scalar
 support.  Each field is translated directly to its C equivalent, resulting in
 `struct Point {int x; int y;};`.  By parsing structures with another regular
 expression, the compiler avoids a full parser while still allowing clear data
-definitions.
+definitions.  Variables may now use these structures as types. A declaration
+like `let p: Point;` expands to `struct Point p;` in C, keeping the layout
+explicit without introducing a new type system.
 
 Function declarations now accept parameters written as `name: Type` separated
 by commas.  The same regular-expression approach parses these parameters,

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -43,6 +43,8 @@ This list summarizes the main modules of the project for quick reference.
         int x;
     };
     ```
+    Variables may use these structures directly. `let p: Name;` becomes
+    `struct Name p;` in the generated C code.
     Function and struct bodies are emitted with four-space indentation so the
     generated code is easier to inspect.
     Nested blocks written with `{` and `}` can be placed inside functions and

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -767,3 +767,46 @@ def test_compile_type_alias_variable(tmp_path):
     compiler.compile(input_file, output_file)
 
     assert output_file.read_text() == "void foo() {\n    short value = 100;\n}\n"
+
+
+def test_compile_global_struct_variable(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "struct Point {x : I32; y : I32;}\n\nlet myPoint: Point;"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Point {\n    int x;\n    int y;\n};\nstruct Point myPoint;\n"
+    )
+
+
+def test_compile_struct_variable_inside_function(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "struct Point {x : I32; y : I32;}\nfn foo(): Void => { let p: Point; }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Point {\n    int x;\n    int y;\n};\nvoid foo() {\n    struct Point p;\n}\n"
+    )
+
+
+def test_compile_struct_variable_unknown_type(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn foo(): Void => { let p: Unknown; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "compiled: fn foo(): Void => { let p: Unknown; }"


### PR DESCRIPTION
## Summary
- enable variables with struct types at global scope and inside functions
- track defined structs so declarations can reference them
- document new capability and update roadmap
- add tests covering global and local struct variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b23e318348321bbacf40ad5c38503