### PR TITLE
Add this parameter for nested functions

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -250,11 +250,13 @@ Nested function declarations are flattened into top-level functions. When a
 function `inner` appears inside `outer`, the compiler generates a new C
 function named `inner_outer` before emitting `outer` itself. When this happens
 the compiler also declares an empty struct `outer_t` to reserve space for future
-closure environments. This approach keeps the regular-expression driven parser
-viable while sidestepping the complexity of capturing lexical scope. Future
-iterations may introduce proper closures, but for now flattening preserves
-simplicity and ensures each function remains a standalone unit while hinting at
-potential context storage.
+closure environments. The generated inner function receives this struct as a
+`this` parameter so that captured variables could be threaded through later
+without changing call sites. This approach keeps the regular-expression driven
+parser viable while sidestepping the complexity of capturing lexical scope.
+Future iterations may introduce proper closures, but for now flattening
+preserves simplicity and ensures each function remains a standalone unit while
+hinting at potential context storage.
 
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -589,6 +589,8 @@ class Compiler:
                             if bound_op:
                                 bound = (bound_op, int(bound_val))
                             param_info.append({"name": p_name, "type": base, "bound": bound})
+                    this_param = f"struct {func_name}_t this"
+                    c_params = [this_param] + c_params
                     param_list = ", ".join(c_params)
                     ret_resolved = resolve_type(inner_ret) if inner_ret else "void"
                     if inner_ret and ret_resolved is None:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -911,7 +911,7 @@ def test_compile_flatten_inner_function(tmp_path):
 
     assert (
         output_file.read_text()
-        == "struct outer_t {\n};\nvoid inner_outer() {\n}\nvoid outer() {\n}\n"
+        == "struct outer_t {\n};\nvoid inner_outer(struct outer_t this) {\n}\nvoid outer() {\n}\n"
     )
 
 


### PR DESCRIPTION
## Summary
- pass the generated struct as a `this` parameter when flattening inner functions
- update inner function flattening test
- document the reason for the new `this` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd742f9a883218a0d9b0458290fbf