### PR TITLE
Support capturing outer variables

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -63,7 +63,11 @@ may nest arbitrarily. Each level of braces increases the indentation in the
 generated C code.
 Inner functions are flattened into new top-level declarations such as
 `inner_outer`. When this happens an empty struct `outer_t` is emitted before
-the functions to reserve space for eventual closure data.
+the functions to reserve space for eventual closure data. If the outer
+function contains `let` declarations, those variables become fields of this
+struct and are assigned within the outer function's body. This models a
+simple closure environment without changing how callers invoke the inner
+function.
 Simple `if` statements written as `if (condition) { ... }` are translated
 directly. Boolean literals in the condition become `1` or `0` to keep the
 generated C self-contained.

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -258,6 +258,13 @@ Future iterations may introduce proper closures, but for now flattening
 preserves simplicity and ensures each function remains a standalone unit while
 hinting at potential context storage.
 
+The next increment stores outer-scope declarations inside that generated struct
+when inner functions are present. Moving variables into the `*_t` struct keeps
+their lifetime explicit and prepares for real closures without rewriting call
+sites. Only top-level `let` statements are captured for now, which keeps the
+implementation straightforward while demonstrating how lexical scope might be
+preserved.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -915,6 +915,22 @@ def test_compile_flatten_inner_function(tmp_path):
     )
 
 
+def test_compile_inner_function_with_declaration(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn parent() => { let myValue : I32 = 100; fn child(something : I32) => { } }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct parent_t {\n    int myValue;\n};\nvoid child_parent(struct parent_t this, int something) {\n}\nvoid parent() {\n    struct parent_t this;\n    this.myValue = 100;\n}\n"
+    )
+
+
 def test_compile_implicit_int_return(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- flattening inner functions now collects outer `let` declarations into a closure struct
- record design reasoning and compiler features
- test new behaviour for nested declarations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd895bc14832189f14a0fd3fa8939