### PR TITLE
Fix inference for captured vars

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -265,6 +265,13 @@ sites. Only top-level `let` statements are captured for now, which keeps the
 implementation straightforward while demonstrating how lexical scope might be
 preserved.
 
+Originally these captured variables required an explicit type annotation. This
+kept the struct generation simple but forced verbose declarations. The compiler
+now infers boolean or numeric types when an initializer is present, allowing
+`let x = 100;` inside an outer function that defines an inner function. The
+environment struct still stores the resolved C type, so the flattening approach
+remains unchanged while user code becomes less cluttered.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -647,8 +647,26 @@ class Compiler:
                         if func_name not in env_init_emitted:
                             lines.append(f"{indent_str}struct {func_name}_t this;")
                             env_init_emitted.add(func_name)
+
                         if var_type is None:
-                            return None
+                            if value is None:
+                                return None
+                            if value.lower() in {"true", "false"}:
+                                base = "bool"
+                                c_type = "int"
+                                c_val = "1" if value.lower() == "true" else "0"
+                            elif re.fullmatch(r"[0-9]+", value):
+                                base = "i32"
+                                c_type = "int"
+                                c_val = value
+                            else:
+                                return None
+                            env_struct_fields.setdefault(func_name, []).append((var_name, c_type))
+                            variables[var_name] = {"type": base, "c_type": c_type, "mutable": mutable, "bound": None}
+                            lines.append(f"{indent_str}this.{var_name} = {c_val};")
+                            pos2 = let_match.end()
+                            continue
+
                         base = resolve_type(var_type)
                         if value is None:
                             if base == "bool":

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -931,6 +931,22 @@ def test_compile_inner_function_with_declaration(tmp_path):
     )
 
 
+def test_compile_inner_function_with_inferred_declaration(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn parent() => { let first = 100; fn child(something : I32) => { } }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct parent_t {\n    int first;\n};\nvoid child_parent(struct parent_t this, int something) {\n}\nvoid parent() {\n    struct parent_t this;\n    this.first = 100;\n}\n"
+    )
+
+
 def test_compile_implicit_int_return(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow outer-scope variables to omit their type when nested functions are present
- test capturing an inferred variable
- document why implicit types now work for captured variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdab3a34883219d6e0f17b5d5f719