### PR TITLE
Fix duplicate struct emission for inner functions

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -272,6 +272,12 @@ now infers boolean or numeric types when an initializer is present, allowing
 environment struct still stores the resolved C type, so the flattening approach
 remains unchanged while user code becomes less cluttered.
 
+Tests later revealed that this flattening step emitted the same `*_t` struct
+twice: once when the inner function was seen and again when the outer function
+completed.  The compiler now records the need for the struct during parsing and
+emits it only once when processing the outer function.  This keeps the generated
+C concise while preserving room for captured variables.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -557,7 +557,6 @@ class Compiler:
                 nested_match = header_pattern.match(block, pos2)
                 if nested_match:
                     if func_name not in func_structs:
-                        structs.append(f"struct {func_name}_t {{\n}};\n")
                         func_structs.add(func_name)
                     inner_name = nested_match.group(1)
                     params_src = nested_match.group(2).strip()


### PR DESCRIPTION
## Summary
- avoid appending environment structs twice when flattening inner functions
- document reasoning behind the change in design docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdc5f37788321a62c97dfb3800a79