### PR TITLE
Add function pointer variable support

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -29,6 +29,11 @@ compiler infers the type and still emits `int` in the generated C code.
 Typed variables may also be declared without an initializer, for example
 `let value: I16;`. The compiler then emits an uninitialized C variable like
 `short value;`.
+Variables can also hold references to functions. Declaring
+`let myEmpty: () => Void;` creates an uninitialized function pointer and
+produces `void (*myEmpty)();` in the output C code. Only the parameterless
+`Void`-return form is recognized for now, paving the way for higher-order
+functions without complicating the parser.
 Assignment statements are supported when the variable is declared with
 `mut` and the new value matches the original type.  Reassignment is written
 simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -265,6 +265,13 @@ sites. Only top-level `let` statements are captured for now, which keeps the
 implementation straightforward while demonstrating how lexical scope might be
 preserved.
 
+Allowing variables to reference functions continues this incremental
+approach. The parser recognizes `let myEmpty: () => Void;` and emits the
+C declaration `void (*myEmpty)();`. Supporting only the simplest function
+pointer form keeps validation trivial while paving the way for higher-order
+abstractions. Future steps can expand the pattern to handle parameters and
+return types once real use cases emerge.
+
 ## Documentation Practice
 When a new feature is introduced, ensure the relevant documentation is updated to capture why the feature exists and how it fits into the design.
 

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -636,6 +636,14 @@ class Compiler:
                     var_type = let_match.group(3)
                     raw_value = let_match.group(4)
                     value = strip_parens(raw_value) if raw_value else None
+                    if (
+                        var_type
+                        and raw_value
+                        and var_type.strip().endswith(")")
+                        and raw_value.strip().startswith(">")
+                    ):
+                        var_type = f"{var_type.strip()} => {raw_value.strip()[1:].strip()}"
+                        value = None
 
                     struct_init = None
                     if value is not None:
@@ -739,6 +747,31 @@ class Compiler:
                     if value is None:
                         if var_type is None:
                             return None
+                        func_match = re.fullmatch(r"\(\s*\)\s*=>\s*(\w+)", var_type)
+                        if func_match:
+                            ret = func_match.group(1)
+                            ret_base = resolve_type(ret) if ret.lower() != "void" else "void"
+                            if ret_base is None:
+                                return None
+                            if ret_base == "bool":
+                                c_ret = "int"
+                            elif ret_base in self.NUMERIC_TYPE_MAP:
+                                c_ret = self.NUMERIC_TYPE_MAP[ret_base]
+                            elif ret_base in struct_names.values():
+                                c_ret = f"struct {ret_base}"
+                            elif ret_base == "void":
+                                c_ret = "void"
+                            else:
+                                return None
+                            lines.append(f"{indent_str}{c_ret} (*{var_name})();")
+                            variables[var_name] = {
+                                "type": f"fn->{ret_base}",
+                                "c_type": f"{c_ret} (*)()",
+                                "mutable": mutable,
+                                "bound": magma_bound,
+                            }
+                            pos2 = let_match.end()
+                            continue
                         array_type = array_type_pattern.fullmatch(var_type)
                         if array_type:
                             elem_type = array_type.group(1)
@@ -1335,10 +1368,39 @@ class Compiler:
                 var_name = let_match.group(2)
                 var_type = let_match.group(3)
                 value = let_match.group(4)
+                if (
+                    var_type
+                    and value
+                    and var_type.strip().endswith(")")
+                    and value.strip().startswith(">")
+                ):
+                    var_type = f"{var_type.strip()} => {value.strip()[1:].strip()}"
+                    value = None
                 if value is None:
                     if not var_type:
                         Path(output_path).write_text(f"compiled: {source}")
                         return
+                    func_match = re.fullmatch(r"\(\s*\)\s*=>\s*(\w+)", var_type.strip())
+                    if func_match:
+                        ret = func_match.group(1)
+                        ret_base = resolve_type(ret) if ret.lower() != "void" else "void"
+                        if ret_base is None:
+                            Path(output_path).write_text(f"compiled: {source}")
+                            return
+                        if ret_base == "bool":
+                            c_ret = "int"
+                        elif ret_base in self.NUMERIC_TYPE_MAP:
+                            c_ret = self.NUMERIC_TYPE_MAP[ret_base]
+                        elif ret_base in struct_names.values():
+                            c_ret = f"struct {ret_base}"
+                        elif ret_base == "void":
+                            c_ret = "void"
+                        else:
+                            Path(output_path).write_text(f"compiled: {source}")
+                            return
+                        globals.append(f"{c_ret} (*{var_name})();\n")
+                        pos = let_match.end()
+                        continue
                     base = resolve_type(var_type.strip())
                     if base not in struct_names.values():
                         Path(output_path).write_text(f"compiled: {source}")

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -823,6 +823,28 @@ def test_compile_struct_variable_unknown_type(tmp_path):
     assert output_file.read_text() == "compiled: fn foo(): Void => { let p: Unknown; }"
 
 
+def test_compile_global_function_pointer(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("let myEmpty: () => Void;")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void (*myEmpty)();\n"
+
+
+def test_compile_function_pointer_in_function(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn foo(): Void => { let cb: () => Void; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void foo() {\n    void (*cb)();\n}\n"
+
+
 def test_compile_struct_init_global(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- handle `let name: () => Void;` declarations
- compile them to C function pointers
- document reasoning and feature
- test global and local function pointer variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdb4dd2dc8321b2a8d49331ff9533