### PR TITLE
Centralize compiler type mapping logic

### DIFF
--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -224,6 +224,13 @@ literals to `1` or `0`. A small helper now converts these conditions into C
 syntax. This keeps the block parser shallow and avoids repeating nested
 expressions.
 
+### Type Conversion Helpers
+As the compiler grew, repeated checks converted Magma types to C types and
+translated booleans to `1` or `0`. The new `c_type_of` and `bool_to_c`
+helpers centralize these conversions so all parts of the compiler share the
+same implementation. This reduces duplication and makes further changes
+easier to reason about.
+
 ### Type Aliases
 Type aliases allow new names for existing primitive types using syntax like
 `type MyAlias = I16;`. Aliases are resolved during compilation so they do not

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -4,5 +4,6 @@ This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
   - `magma.compiler.Compiler` – minimal compiler skeleton
+  - helper functions `c_type_of` and `bool_to_c` reduce duplicate type logic
 
 See [compiler_features.md](compiler_features.md) for details on supported syntax.


### PR DESCRIPTION
## Summary
- introduce `c_type_of` and `bool_to_c` helpers to map Magma types and booleans
- refactor compiler implementation to remove duplicated conversions
- document new helper functions and update module overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be05121e48321bdd6160bd909e5df