### PR TITLE
Support this variable resolution

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,6 +38,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Capture outer parameters when flattening inner functions
   - [x] Permit methods inside `class fn` declarations flattened like inner
     functions
+  - [x] Allow `this` to be used in method bodies with `return this;`
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -59,7 +59,9 @@ The shorthand `class fn Name(x: Type)` defines both the struct and a
 constructor function that assigns each parameter into a temporary `this`
 value and returns it. Methods declared inside the block are flattened
 into standalone functions like `void method_Name(struct Name this)` so
-they behave just like inner functions with an explicit receiver.
+they behave just like inner functions with an explicit receiver. Inside these
+methods the `this` value can be used in expressions, allowing `return this;`
+to return the constructed struct.
 Enumerations are declared with `enum MyEnum { First, Second }` and become
 `enum MyEnum { First, Second };` in the generated C. The member names keep
 their original casing.

--- a/docs/design_reasoning.md
+++ b/docs/design_reasoning.md
@@ -106,7 +106,9 @@ the regex-driven parser.
 Methods placed inside this `class fn` block are flattened into separate
 functions that take the struct as their first parameter. This mirrors the
 existing approach for inner functions so the implementation stays uniform
-while enabling a basic method syntax without real member lookups.
+while enabling a basic method syntax without real member lookups. The
+receiver is exposed as a regular variable named `this`, making it possible to
+return or pass the value directly with statements like `return this;`.
 
 Function declarations now accept parameters written as `name: Type` separated
 by commas.  The same regular-expression approach parses these parameters,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -939,6 +939,22 @@ def test_compile_class_fn_with_method(tmp_path):
     )
 
 
+def test_compile_class_fn_method_return_this(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "class fn Point(x: U32, y: U32) => { fn empty() => { return this; } }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Point {\n    unsigned int x;\n    unsigned int y;\n};\nstruct Point empty_Point(struct Point this) {\n    return this;\n}\nstruct Point Point(unsigned int x, unsigned int y) {\n    struct Point this;\n    this.x = x;\n    this.y = y;\n    return this;\n}\n"
+    )
+
+
 def test_compile_flatten_inner_function(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow `this` to be treated as a variable in methods and inner functions
- generalize return statement handling for all types
- test returning `this` from a `class fn` method
- document the new capability and roadmap item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be340f8ec83219ee6dbfc3c7c3bf7