### PR TITLE
Allow field access without this prefix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Permit methods inside `class fn` declarations flattened like inner
     functions
   - [x] Allow `this` to be used in method bodies with `return this;`
+  - [x] Permit field access without the `this.` prefix inside methods
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -62,6 +62,9 @@ into standalone functions like `void method_Name(struct Name this)` so
 they behave just like inner functions with an explicit receiver. Inside these
 methods the `this` value can be used in expressions, allowing `return this;`
 to return the constructed struct.
+Field names inside these methods may also omit the `this.` prefix. The compiler
+automatically rewrites `value` to `this.value` when it matches a struct field so
+calls like `return value;` remain concise.
 Enumerations are declared with `enum MyEnum { First, Second }` and become
 `enum MyEnum { First, Second };` in the generated C. The member names keep
 their original casing.

--- a/docs/design/control_and_helpers.md
+++ b/docs/design/control_and_helpers.md
@@ -34,3 +34,11 @@ helper now produces these statements with or without a value so that every
 return site follows the same formatting logic. This keeps the output uniform
 and the compiler simpler to maintain.
 
+### Expression Processing Helper
+Repeated parsing logic appeared when handling arithmetic and function call
+expressions across variable declarations, assignments, and returns. A single
+`analyze_expr` helper now validates expressions using Python's `ast` module,
+determines their resulting type, and rewrites field references to include the
+`this.` prefix when omitted. This ensures expressions like `test(1 + 2 + 3)` or
+`return value;` are handled consistently without duplicating parsing code.
+

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -4,7 +4,7 @@ This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
   - `magma.compiler.Compiler` – minimal compiler skeleton
-  - helper functions `c_type_of`, `bool_to_c`, and `emit_return` reduce
-    duplicate type and return statement logic
+  - helper functions `c_type_of`, `bool_to_c`, `emit_return`, and
+    `analyze_expr` reduce duplicate type, expression, and return logic
 
 See [compiler_features.md](compiler_features.md) for details on supported syntax.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -955,6 +955,22 @@ def test_compile_class_fn_method_return_this(tmp_path):
     )
 
 
+def test_compile_class_fn_method_field_no_this(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "class fn Wrapper(value: I32) => { fn getValue() => { return value; } }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Wrapper {\n    int value;\n};\nint getValue_Wrapper(struct Wrapper this) {\n    return this.value;\n}\nstruct Wrapper Wrapper(int value) {\n    struct Wrapper this;\n    this.value = value;\n    return this;\n}\n"
+    )
+
+
 def test_compile_flatten_inner_function(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- support referencing struct fields without `this.` inside class methods
- add expression helper description and modules overview updates
- document field access change in compiler features
- mark roadmap item completed
- test new field access shorthand

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be92e63248321b687b51e5a4c7828