### PR TITLE
Add parameterized function pointer types

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -31,9 +31,10 @@ Typed variables may also be declared without an initializer, for example
 `short value;`.
 Variables can also hold references to functions. Declaring
 `let myEmpty: () => Void;` creates an uninitialized function pointer and
-produces `void (*myEmpty)();` in the output C code. Only the parameterless
-`Void`-return form is recognized for now, paving the way for higher-order
-functions without complicating the parser.
+produces `void (*myEmpty)();` in the output C code. The pattern now accepts
+parameter lists as well, so `let adder: (I32, I32) => I32;` results in
+`int (*adder)(int, int);`. This keeps the regular expression approach while
+supporting simple higher-order functions.
 Assignment statements are supported when the variable is declared with
 `mut` and the new value matches the original type.  Reassignment is written
 simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/docs/design/inner_functions.md
+++ b/docs/design/inner_functions.md
@@ -26,10 +26,10 @@ design a step closer to real closures without complicating the parser.
 
 Allowing variables to reference functions continues this incremental
 approach. The parser recognizes `let myEmpty: () => Void;` and emits the
-C declaration `void (*myEmpty)();`. Supporting only the simplest function
-pointer form keeps validation trivial while paving the way for higher-order
-abstractions. Future steps can expand the pattern to handle parameters and
-return types once real use cases emerge.
+C declaration `void (*myEmpty)();`. The same pattern now accepts simple
+parameter lists, so `let adder: (I32, I32) => I32;` becomes
+`int (*adder)(int, int);`. Validation remains lightweight, preserving the
+regex-based implementation while enabling basic higher-order abstractions.
 
 Originally these captured variables required an explicit type annotation. This
 kept the struct generation simple but forced verbose declarations. The compiler

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -142,6 +142,28 @@ def test_compile_function_pointer_in_function(tmp_path):
     assert output_file.read_text() == "void foo() {\n    void (*cb)();\n}\n"
 
 
+def test_compile_function_pointer_with_params_global(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("let adder: (I32, I32) => I32;")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int (*adder)(int, int);\n"
+
+
+def test_compile_function_pointer_with_params_in_function(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn foo(): Void => { let cb: (I32, I32) => I32; }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void foo() {\n    int (*cb)(int, int);\n}\n"
+
+
 def test_compile_struct_init_global(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- support function pointer declarations with parameter types
- test parameterized function pointer declarations
- document new capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bed21730c8321bda8b705f1a94d99