### PR TITLE
Allow function types in parameters

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -35,6 +35,8 @@ produces `void (*myEmpty)();` in the output C code. The pattern now accepts
 parameter lists as well, so `let adder: (I32, I32) => I32;` results in
 `int (*adder)(int, int);`. This keeps the regular expression approach while
 supporting simple higher-order functions.
+Function parameters may use the same syntax, so `fn run(cb: () => Void)`
+becomes `void run(void (*cb)())` in the generated C.
 Assignment statements are supported when the variable is declared with
 `mut` and the new value matches the original type.  Reassignment is written
 simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -16,6 +16,8 @@ Struct fields can hold references to functions using the same arrow syntax as
 variable declarations. This keeps the grammar uniform while enabling callbacks
 without additional keywords. The compiler simply emits a function pointer field
 in C, preserving the lightweight translation strategy.
+The same notation now works for function parameters, keeping the grammar
+consistent across declarations.
 
 ### Struct Literal Field Access
 Struct literals now allow immediate access to a field using syntax like

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -164,6 +164,31 @@ def test_compile_function_pointer_with_params_in_function(tmp_path):
     assert output_file.read_text() == "void foo() {\n    int (*cb)(int, int);\n}\n"
 
 
+def test_compile_function_param_function_type(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn call(cb: () => Void): Void => {}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "void call(void (*cb)()) {\n}\n"
+
+
+def test_compile_class_fn_param_function_type(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("class fn Handler(cb: () => Void) => {}")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Handler {\n    void (*cb)();\n};\nstruct Handler Handler(void (*cb)()) {\n    struct Handler this;\n    this.cb = cb;\n    return this;\n}\n"
+    )
+
+
 def test_compile_struct_init_global(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- support function type syntax in parameter declarations
- use new `parse_func_type` helper
- test function type parameters for normal and `class fn` functions
- document parameter syntax for function types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf0212ef48321b7717fa28687b89e