### PR TITLE
Support generic class constructors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
     functions
   - [x] Allow `this` to be used in method bodies with `return this;`
   - [x] Permit field access without the `this.` prefix inside methods
+  - [x] Allow type parameters in `class fn` declarations
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -69,6 +69,10 @@ into standalone functions like `void method_Name(struct Name this)` so
 they behave just like inner functions with an explicit receiver. Inside these
 methods the `this` value can be used in expressions, allowing `return this;`
 to return the constructed struct.
+This shorthand now supports a single type parameter. Using
+`class fn Wrapper<T>(value: T) => {}` defers code generation until a concrete
+type like `Wrapper<I32>` appears. At that point the compiler emits a specialized
+struct and constructor named `Wrapper_I32`.
 Field names inside these methods may also omit the `this.` prefix. The compiler
 automatically rewrites `value` to `this.value` when it matches a struct field so
 calls like `return value;` remain concise.

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -11,6 +11,25 @@ monomorphized name. This approach sidesteps template expansion at C compile
 time and keeps the generated code explicit. Tests drive the instantiation logic
 so that only valid numeric and boolean substitutions are accepted.
 
+### Generic Classes
+The same monomorphization now applies to the `class fn` shorthand. A
+declaration like `class fn Wrapper<T>(value: T) => {}` is stored without
+emitting C immediately. When a concrete type such as `Wrapper<I32>` appears in
+code, the compiler emits a specialized struct and constructor:
+
+```
+struct Wrapper_I32 {
+    int value;
+};
+struct Wrapper_I32 Wrapper_I32(int value) {
+    struct Wrapper_I32 this;
+    this.value = value;
+    return this;
+}
+```
+Restricting the parameter `T` to numeric or boolean types avoids generating
+complex C code and keeps the feature in line with existing generic structs.
+
 ### Function Fields
 Struct fields can hold references to functions using the same arrow syntax as
 variable declarations. This keeps the grammar uniform while enabling callbacks

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -267,6 +267,22 @@ def test_compile_class_fn_shorthand(tmp_path):
     )
 
 
+def test_compile_generic_class_fn(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "class fn Wrapper<T>(value : T) => {}\n\nlet value : Wrapper<I32>;"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Wrapper_I32 {\n    int value;\n};\nstruct Wrapper_I32 value;\nstruct Wrapper_I32 Wrapper_I32(int value) {\n    struct Wrapper_I32 this;\n    this.value = value;\n    return this;\n}\n"
+    )
+
+
 def test_compile_class_fn_with_method(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow `class fn` declarations with a single type parameter
- create specialized structs and constructors when generic classes are used
- document generic classes in design notes and feature list
- mark roadmap item for class type parameters as complete
- test generic `class fn` monomorphization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf32a88108321998da73fb9fd6383