### PR TITLE
Support global init via constructors

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -61,7 +61,9 @@ Generic structures like `struct Wrapper<T>` are monomorphized on use. A
 declaration `let w: Wrapper<I32>;` produces a specialized `struct
 Wrapper_I32` so the output remains explicit C.
 A literal initializer like `let p = Name {1, 2};` expands to a declaration
-followed by field assignments so the output stays easy to read.
+followed by field assignments so the output stays easy to read. Constructors
+may also be invoked at the global level, so `let car: Car = Car();` emits the
+simple line `struct Car car = Car();` before any methods or functions.
 The shorthand `class fn Name(x: Type)` defines both the struct and a
 constructor function that assigns each parameter into a temporary `this`
 value and returns it. Methods declared inside the block are flattened

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -391,3 +391,19 @@ def test_compile_class_fn_return_consistency(tmp_path):
         output_file.read_text()
         == "struct Item {\n};\nstruct Factory {\n};\nstruct Item Item() {\n    struct Item this;\n    return this;\n}\nstruct Item create_Factory(struct Factory this) {\n    return Item();\n}\nstruct Factory Factory() {\n    struct Factory this;\n    return this;\n}\n"
     )
+
+
+def test_compile_empty_class_with_method_global_instance(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "class fn Car() => {\n fn drive() => {\n }\n}\n\nlet car : Car = Car();"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Car {\n};\nstruct Car car = Car();\nvoid drive_Car(struct Car this) {\n}\nstruct Car Car() {\n    struct Car this;\n    return this;\n}\n"
+    )


### PR DESCRIPTION
## Summary
- allow global variables to be initialized using class constructors
- test creating a class with a method and global instance
- document global constructor initialization in compiler features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf5144124832186d4f4a75c3d191e