### PR TITLE
Generalize import handling

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -128,4 +128,8 @@ code. They are evaluated only when needed for bound checks, keeping the
 parser minimal. Expressions may include calls to previously defined
 functions, allowing constructs like `first(200 + second())`.
 
+- `import foo;` inserts `#include <foo.h>` at the top of the generated
+  C file. Any import name is accepted and simply maps to the
+  corresponding header.
+
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/docs/design/basics.md
+++ b/docs/design/basics.md
@@ -151,3 +151,10 @@ literals or previously declared variables, and boolean values are converted to
 compilation to fail, but the callee's signature is not yet validated. This keeps
 the parser small while letting tests drive interaction between functions.
 
+Imports follow the same lightweight approach. When the source contains a line
+like `import foo;`, the compiler simply emits `#include <foo.h>` in the output.
+There is no verification of the module name; the assumption is that the
+developer provides a valid header. This keeps the implementation minimal while
+allowing the build system or later stages of the compiler to supply the proper
+files.
+

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,12 @@
+import pytest
+from .utils import compile_source
+
+
+def test_import_stdlib(tmp_path):
+    output = compile_source(tmp_path, "import stdlib;")
+    assert output == "#include <stdlib.h>\n"
+
+
+def test_import_arbitrary(tmp_path):
+    output = compile_source(tmp_path, "import foo;")
+    assert output == "#include <foo.h>\n"


### PR DESCRIPTION
## Summary
- support arbitrary `import name;` lines
- document generic import support and design reasoning
- test new `import` behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bf960c5288321b41a2bfd0d4119cc