### PR TITLE
Add pointer type support

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -37,6 +37,10 @@ parameter lists as well, so `let adder: (I32, I32) => I32;` results in
 supporting simple higher-order functions.
 Function parameters may use the same syntax, so `fn run(cb: () => Void)`
 becomes `void run(void (*cb)())` in the generated C.
+Basic pointer types follow a similar pattern. A declaration like
+`let reference: *I32 = &value;` results in `int* reference = &value;`.
+Only the address-of operator is supported so far, keeping pointer usage
+explicit and easy to validate.
 Assignment statements are supported when the variable is declared with
 `mut` and the new value matches the original type.  Reassignment is written
 simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -42,6 +42,11 @@ in C, preserving the lightweight translation strategy.
 The same notation now works for function parameters, keeping the grammar
 consistent across declarations.
 
+### Pointers
+Variables may now store raw addresses using a leading `*` in the type.
+Only taking the address of an existing variable is supported. This keeps
+the safety model simple while allowing low-level interactions when needed.
+
 ### Struct Literal Field Access
 Struct literals now allow immediate access to a field using syntax like
 `(Wrapper {100}).value`. When all field values are literals, the compiler

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -418,3 +418,30 @@ def test_compile_empty_class_with_method_global_instance(tmp_path):
         output_file.read_text()
         == "struct Car {\n};\nstruct Car car = Car();\nvoid drive_Car(struct Car this) {\n}\nstruct Car Car() {\n    struct Car this;\n    return this;\n}\n"
     )
+
+
+def test_compile_pointer_global(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("let value: I32 = 5;\nlet reference: *I32 = &value;")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert output_file.read_text() == "int value = 5;\nint* reference = &value;\n"
+
+
+def test_compile_pointer_in_function(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn foo(): Void => { let value: I32 = 5; let reference: *I32 = &value; }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "void foo() {\n    int value = 5;\n    int* reference = &value;\n}\n"
+    )


### PR DESCRIPTION
## Summary
- enable pointer types via `*T` and address-of `&` expressions
- document pointer syntax and design rationale
- test pointer declarations in global and function scope

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfe0a9ddc8321b754855a763b2dc5