### PR TITLE
Support pointer dereference

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -39,8 +39,10 @@ Function parameters may use the same syntax, so `fn run(cb: () => Void)`
 becomes `void run(void (*cb)())` in the generated C.
 Basic pointer types follow a similar pattern. A declaration like
 `let reference: *I32 = &value;` results in `int* reference = &value;`.
-Only the address-of operator is supported so far, keeping pointer usage
-explicit and easy to validate.
+Only the address-of operator was supported initially.  Pointers can now be
+dereferenced with `*name`, so `let value: I32 = *reference;` copies the pointed
+integer.  The compiler simply emits `*reference` in the C output and performs no
+additional checks, keeping pointer usage explicit and easy to validate.
 Assignment statements are supported when the variable is declared with
 `mut` and the new value matches the original type.  Reassignment is written
 simply as `name = 2;` and translates directly to the equivalent C statement.

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -44,8 +44,11 @@ consistent across declarations.
 
 ### Pointers
 Variables may now store raw addresses using a leading `*` in the type.
-Only taking the address of an existing variable is supported. This keeps
-the safety model simple while allowing low-level interactions when needed.
+Initially only taking the address of an existing variable was supported.
+Dereferencing with `*name` is now available as well and compiles directly to
+C. The compiler does not attempt safety checks here; keeping the feature small
+avoids complicating the parsing logic while still permitting low-level
+interactions when needed.
 
 ### Struct Literal Field Access
 Struct literals now allow immediate access to a field using syntax like

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -445,3 +445,17 @@ def test_compile_pointer_in_function(tmp_path):
         output_file.read_text()
         == "void foo() {\n    int value = 5;\n    int* reference = &value;\n}\n"
     )
+
+
+def test_compile_dereference_global(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("let reference: *I32;\nlet dereference: I32 = *reference;")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "int* reference;\nint dereference = *reference;\n"
+    )


### PR DESCRIPTION
## Summary
- allow dereference expressions like `*name`
- document pointer dereference support
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c00ef2a9c8321a182da4df7f325fc