### PR TITLE
Handle env scope when calling inner functions

### DIFF
--- a/docs/design/inner_functions.md
+++ b/docs/design/inner_functions.md
@@ -44,3 +44,8 @@ completed.  The compiler now records the need for the struct during parsing and
 emits it only once when processing the outer function.  This keeps the generated
 C concise while preserving room for captured variables.
 
+Invocations of inner functions now implicitly supply the environment struct.
+The outer body simply calls `inner()` and the compiler emits `inner_outer(this)`.
+This lets inner functions read captured values without altering call sites and
+brings the language a step closer to supporting closures.
+

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -1448,7 +1448,12 @@ class Compiler:
                             else:
                                 return None
                     c_name = func_sigs.get(name, {}).get("c_name", name)
-                    lines.append(f"{indent_str}{c_name}({', '.join(c_args)});")
+                    env_name = func_name.split("_")[-1]
+                    if c_name != name and c_name.endswith(f"_{env_name}"):
+                        arg_str = ", ".join(["this"] + c_args)
+                    else:
+                        arg_str = ", ".join(c_args)
+                    lines.append(f"{indent_str}{c_name}({arg_str});")
                     pos2 = call_match.end()
                     continue
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -383,6 +383,22 @@ def test_compile_inner_function_with_declaration(tmp_path):
     )
 
 
+def test_compile_inner_function_call_passes_env(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "fn outer() => { let value: I32 = 1; fn inner() => { } inner(); }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct outer_t {\n    int value;\n};\nvoid inner_outer(struct outer_t this) {\n}\nvoid outer() {\n    struct outer_t this;\n    this.value = 1;\n    inner_outer(this);\n}\n"
+    )
+
+
 def test_compile_inner_function_param_capture(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- ensure calls to inner functions thread their environment struct
- test that invoking an inner function passes the scope struct
- document auto-passing of the environment when calling inner functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c276fe2dc83219e3f3199f9dec258