### PR TITLE
Add struct enum variant fields

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -98,6 +98,25 @@ Struct enums extend this idea by generating a tagged union. A declaration such
 as `struct enum Option { Some, None }` emits an auxiliary `enum OptionTag` and a
 `struct Option` containing that tag along with a C `union` of the variant
 structures. This keeps the feature a thin layer over plain C constructs.
+Variants may specify parameters inside parentheses. These parameters become
+fields of a struct named after the variant. For example
+`struct enum Option { Some(value: I32), None }` produces:
+
+```c
+struct Some {
+    int value;
+};
+struct Option {
+    enum OptionTag tag;
+    union {
+        struct Some Some;
+        struct None None;
+    } data;
+};
+enum OptionTag { Some, None };
+```
+Only variants with parameters receive an explicit struct definition, keeping the
+output minimal when no data is stored.
 Function and struct bodies are emitted with four-space indentation so the
 generated code is easier to inspect.
 Nested blocks written with `{` and `}` can be placed inside functions and

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -82,3 +82,10 @@ compiler emits a small `enum` for the variant tag and a `struct` holding that
 tag alongside a C `union` of the variant structs. This mirrors how many C
 programs model tagged unions manually and keeps Magma's implementation simple.
 
+To keep parsing simple, variants can accept parameters using the same syntax as
+struct fields. These parameters are moved into standalone structs named after
+each variant. Only variants that declare fields generate a struct definition.
+This design avoids polluting the output when variants carry no data while still
+supporting idiomatic option types such as `struct enum Option { Some(value: I32),
+None }`.
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -213,6 +213,25 @@ def test_compile_struct_enum_simple(tmp_path):
     )
 
 
+def test_compile_struct_enum_variant_fields(tmp_path):
+    output = compile_source(tmp_path, "struct enum Option { Some(value: I32), None }")
+
+    assert (
+        output
+        == "struct Some {\n"
+        "    int value;\n"
+        "};\n"
+        "struct Option {\n"
+        "    enum OptionTag tag;\n"
+        "    union {\n"
+        "        struct Some Some;\n"
+        "        struct None None;\n"
+        "    } data;\n"
+        "};\n"
+        "enum OptionTag { Some, None };\n"
+    )
+
+
 
 def test_compile_extern_function_no_params(tmp_path):
     output = compile_source(tmp_path, "extern fn empty();")


### PR DESCRIPTION
## Summary
- support parameters on struct enum variants
- document enum variant fields
- clarify tagged union rationale in design docs
- test struct enum with variant fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3c197cdc83218adf042ad5f53fc8