### PR TITLE
Support inline class instantiation

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -70,6 +70,9 @@ A literal initializer like `let p = Name {1, 2};` expands to a declaration
 followed by field assignments so the output stays easy to read. Constructors
 may also be invoked at the global level, so `let car: Car = Car();` emits the
 simple line `struct Car car = Car();` before any methods or functions.
+It is even possible to define a class inline and instantiate it immediately:
+`let value : Test = (class fn Test() => {})();`. The compiler registers the
+struct and its constructor before emitting the initialization call.
 The shorthand `class fn Name(x: Type)` defines both the struct and a
 constructor function that assigns each parameter into a temporary `this`
 value and returns it. Methods declared inside the block are flattened

--- a/docs/design/types_structs.md
+++ b/docs/design/types_structs.md
@@ -94,3 +94,10 @@ generates assignments that set the tag and populate any fields of the variant
 struct. Using `Option.Some(5)` therefore yields a `struct Option` with the
 `Some` tag and its `value` field filled with `5`.
 
+### Inline Class Instantiation
+To keep experimentation simple, a class can be defined and constructed in one
+expression. Writing `let value : Test = (class fn Test() => {})();` injects the
+`Test` struct and constructor before assigning the newly created instance. This
+quirk helps verify that the parser remains flexible without complicating the
+runtime model.
+

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -463,6 +463,20 @@ def test_compile_empty_class_with_method_global_instance(tmp_path):
     )
 
 
+def test_compile_inline_class_instantiation(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("let value : Test = (class fn Test() => {})();")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Test {\n};\nstruct Test value = Test();\nstruct Test Test() {\n    struct Test this;\n    return this;\n}\n"
+    )
+
+
 def test_compile_pointer_global(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow `class fn` expressions inside variable initializers
- document inline class instantiation in compiler features
- explain reasoning in design notes
- test immediate class declaration and construction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c41f8e8ec83218c63bf07423c1cb7