### PR TITLE
Fix compile timeout for Windows

### DIFF
--- a/docs/design/practices.md
+++ b/docs/design/practices.md
@@ -9,7 +9,9 @@ As the test suite expanded, repeated setup code cluttered the files. A small
 helper `compile_source` now compiles a Magma snippet to C and returns the
 resulting string. Tests invoke this helper so each case stays short and
 focused. To prevent runaway compiler loops, the helper raises a `CompileTimeout`
-error if compilation exceeds three seconds.
+error if compilation exceeds three seconds. Because the `signal.SIGALRM`
+facility is missing on Windows, the timeout is only installed when that signal
+is available; otherwise compilation proceeds without the limit.
 
 ## Test Maintenance
 Occasional duplication in the test suite obscured the behavior being specified. We removed the redundant cases so each test now expresses a unique expectation. This keeps the suite concise and reinforces the principle of simple design.

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -11,6 +11,7 @@ This list summarizes the main modules of the project for quick reference.
 - `magma.numbers` – numeric type mapping and range helpers
 - `tests.utils` – helper used by tests for compiling snippet strings; its
   `compile_source` function enforces a three-second timeout to catch infinite
-  loops during compilation
+  loops when the platform supports `signal.SIGALRM`. On systems without it the
+  helper simply runs without a timeout
 
 See [compiler_features.md](compiler_features.md) for details on supported syntax.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,12 +23,15 @@ def compile_source(tmp_path, source: str) -> str:
     output_file = tmp_path / "out.c"
     input_file.write_text(source)
 
-    old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
-    signal.alarm(3)
+    has_alarm = hasattr(signal, "SIGALRM")
+    if has_alarm:
+        old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+        signal.alarm(3)
     try:
         compiler.compile(input_file, output_file)
     finally:
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, old_handler)
+        if has_alarm:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old_handler)
 
     return output_file.read_text()


### PR DESCRIPTION
## Summary
- make `compile_source` work on platforms without `SIGALRM`
- document cross-platform behaviour in practices and modules pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c504f183c8321b0ef2b1f07588080