### PR TITLE
Remove duplication in compiler init

### DIFF
--- a/docs/design/control_and_helpers.md
+++ b/docs/design/control_and_helpers.md
@@ -57,3 +57,10 @@ originally handled in separate code paths. As their logic converged, a single
 code or records templates. This keeps the main compile loop short and ensures
 every callable form is validated consistently.
 
+### Environment Initialization Helper
+Capturing variables for nested functions used to repeat struct-field setup in
+multiple places. The new `build_env_init` helper gathers these initialization
+lines and records the fields in a shared table. By reusing this helper, the
+compiler avoids copy-pasted loops each time a function needs its environment
+flattened.
+

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -6,6 +6,8 @@ This list summarizes the main modules of the project for quick reference.
   - `magma.compiler.Compiler` – minimal compiler skeleton
   - helper functions `c_type_of`, `bool_to_c`, `emit_return`, and
     `analyze_expr` reduce duplicate type, expression, and return logic
+  - `build_env_init` gathers lines for captured environments to avoid
+    repeating struct setup
   - `process_callable` handles functions, classes, and their generic forms
 - `magma.numbers` – numeric type mapping and range helpers
 - `tests.utils` – helper used by tests for compiling snippet strings


### PR DESCRIPTION
## Summary
- factor out repeated environment setup in `Compiler`
- update design docs with `build_env_init` helper
- list new helper in modules overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c537d555c8321a95c84be5004b6bb