### PR TITLE
Fix script import issue

### DIFF
--- a/docs/design/basics.md
+++ b/docs/design/basics.md
@@ -164,3 +164,10 @@ validated. No code is emitted, and the compiler does not verify that the symbol
 exists. Requiring the `extern` keyword helps avoid accidentally omitting a
 function body.
 
+A small convenience wrapper allows the compiler to be executed directly with
+``python src/magma/__init__.py``. When run in this manner the module detects the
+absence of a package context and adjusts ``sys.path`` so the ``magma`` package
+resolves correctly. This provides a quick way to compile the example file under
+``working/`` without installing the package first and keeps experimentation
+lightweight.
+

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -12,4 +12,8 @@ This list summarizes the main modules of the project for quick reference.
 - `magma.numbers` – numeric type mapping and range helpers
 - `tests.utils` – helper used by tests for compiling snippet strings
 
+Running ``python src/magma/__init__.py`` directly compiles the example under
+``working/``.  The module adjusts ``sys.path`` at runtime so it functions both
+as a package and as a standalone script.
+
 See [compiler_features.md](compiler_features.md) for details on supported syntax.

--- a/src/magma/__init__.py
+++ b/src/magma/__init__.py
@@ -1,16 +1,32 @@
 import ast
+import os
 import re
+import sys
 from pathlib import Path
 
-from .numbers import (
-    NUMERIC_TYPE_MAP,
-    parse_arithmetic,
-    parse_numeric_condition,
-    range_from_op,
-    intersect_range,
-    bound_to_range,
-    is_subset,
-)
+if __package__ in {None, ""}:
+    # Allow running this module directly as a script for quick experiments.
+    # Insert the parent directory so that ``magma`` resolves on import.
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from magma.numbers import (
+        NUMERIC_TYPE_MAP,
+        parse_arithmetic,
+        parse_numeric_condition,
+        range_from_op,
+        intersect_range,
+        bound_to_range,
+        is_subset,
+    )
+else:
+    from .numbers import (
+        NUMERIC_TYPE_MAP,
+        parse_arithmetic,
+        parse_numeric_condition,
+        range_from_op,
+        intersect_range,
+        bound_to_range,
+        is_subset,
+    )
 
 
 class Compiler:
@@ -2277,6 +2293,7 @@ class Compiler:
 
 if __name__ == "__main__":
     compiler = Compiler()
-    input_file = Path("C:/Users/mathm/IdeaProjects/Magma/working/main.mg")
-    output_file = Path("C:/Users/mathm/IdeaProjects/Magma/working/main.c")
+    repo_root = Path(__file__).resolve().parents[2]
+    input_file = repo_root / "working" / "main.mg"
+    output_file = repo_root / "working" / "main.c"
     compiler.compile(input_file, output_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_init_can_run_directly(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    # copy source package and example working directory
+    shutil.copytree(repo_root / "src", tmp_path / "src")
+    shutil.copytree(repo_root / "working", tmp_path / "working")
+    script = tmp_path / "src" / "magma" / "__init__.py"
+    subprocess.check_call([sys.executable, str(script)], cwd=tmp_path)
+    assert (tmp_path / "working" / "main.c").exists()


### PR DESCRIPTION
## Summary
- handle running `magma` directly as a script
- clean up the example driver paths
- note script usage in docs
- test that the package can run as a standalone script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c58f0c6dc8321a1ee391990d8c013