### PR TITLE
Add lazy object singletons

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,6 +42,7 @@ The roadmap tracks upcoming milestones. Items checked are completed.
   - [x] Permit field access without the `this.` prefix inside methods
   - [x] Allow type parameters in `class fn` declarations
   - [x] Permit `extern fn` declarations for external prototypes
+  - [x] Introduce `object` singletons with lazy initialization
 - [ ] Build a self-hosted version of Magma
 
 - [x] Set up CI/CD pipeline for running tests

--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -84,6 +84,11 @@ This shorthand now supports a single type parameter. Using
 `class fn Wrapper<T>(value: T) => {}` defers code generation until a concrete
 type like `Wrapper<I32>` appears. At that point the compiler emits a specialized
 struct and constructor named `Wrapper_I32`.
+Objects build on this idea for the common case of a parameterless singleton.
+Writing `object Config {}` generates the same struct/constructor pair as
+`class fn Config() => {}` but the constructor caches a single instance using
+static storage. Any statements inside the block run only on the first call so
+initialization is deferred until needed.
 Generic function declarations such as `fn malloc<T>() => {}` follow the same
 approach. They are stored without emitting C code until invoked with a concrete
 type.


### PR DESCRIPTION
## Summary
- introduce `object` declarations as a singleton form of `class fn`
- implement support in the compiler and generate lazy constructors
- add tests for object generation
- document the new feature and update the roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5b2f549083218bfb685b392c324c