### PR TITLE
Add value expression helper

### DIFF
--- a/docs/design/control_and_helpers.md
+++ b/docs/design/control_and_helpers.md
@@ -39,8 +39,11 @@ Repeated parsing logic appeared when handling arithmetic and function call
 expressions across variable declarations, assignments, and returns. A single
 `analyze_expr` helper now validates expressions using Python's `ast` module,
 determines their resulting type, and rewrites field references to include the
-`this.` prefix when omitted. This ensures expressions like `test(1 + 2 + 3)` or
-`return value;` are handled consistently without duplicating parsing code.
+`this.` prefix when omitted. A lightweight `value_info` wrapper reuses
+`analyze_expr` and simple literal checks so value expressions like
+`doNothing("%s")` can initialize variables without special cases. This ensures
+expressions like `test(1 + 2 + 3)` or `return value;` are handled consistently
+without duplicating parsing code.
 
 ### Parameter Parsing Helper
 Parameter handling for nested functions, class methods, and top-level

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -4,8 +4,9 @@ This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
   - `magma.compiler.Compiler` – minimal compiler skeleton
-  - helper functions `c_type_of`, `bool_to_c`, `emit_return`, and
-    `analyze_expr` reduce duplicate type, expression, and return logic
+  - helper functions `c_type_of`, `bool_to_c`, `emit_return`,
+    `analyze_expr`, and `value_info` reduce duplicate type, expression,
+    and return logic
   - `build_env_init` gathers lines for captured environments to avoid
     repeating struct setup
   - `process_callable` handles functions, classes, and their generic forms

--- a/docs/suggested_enhancements.md
+++ b/docs/suggested_enhancements.md
@@ -7,3 +7,4 @@ This page tracks ideas for improving the Magma compiler. Update this list whenev
 - Command-line flag to output intermediate representations for debugging
 - Nested object declarations compile to standalone singletons
 - String slice `&Str` for passing text values
+- Central `value_info` helper for all value expressions

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -539,6 +539,55 @@ def test_compile_str_return(tmp_path):
     assert output == 'const char* greet() {\n    return "hi";\n}\n'
 
 
+def test_infer_str_from_call(tmp_path):
+    source = (
+        'fn doNothing(value : &Str) => { return value; }\n\n'
+        'let value = doNothing("%s");'
+    )
+    output = compile_source(tmp_path, source)
+    assert (
+        output
+        == 'const char* value = doNothing("%s");\n'
+        'const char* doNothing(const char* value) {\n'
+        '    return value;\n'
+        '}\n'
+    )
+
+
+def test_infer_bool_from_call(tmp_path):
+    source = (
+        'fn id(flag: Bool): Bool => { return flag; }\n'
+        'fn use(): Void => { let x = id(true); }'
+    )
+    output = compile_source(tmp_path, source)
+    assert (
+        output
+        == 'int id(int flag) {\n'
+        '    return flag;\n'
+        '}\n'
+        'void use() {\n'
+        '    int x = id(1);\n'
+        '}\n'
+    )
+
+
+def test_infer_numeric_from_call(tmp_path):
+    source = (
+        'fn id(x: I32): I32 => { return x; }\n'
+        'fn use(): Void => { let y = id(5); }'
+    )
+    output = compile_source(tmp_path, source)
+    assert (
+        output
+        == 'int id(int x) {\n'
+        '    return x;\n'
+        '}\n'
+        'void use() {\n'
+        '    int y = id(5);\n'
+        '}\n'
+    )
+
+
 def test_compile_object_basic(tmp_path):
     output = compile_source(tmp_path, "object Singleton {}")
 


### PR DESCRIPTION
## Summary
- handle value expressions via a new `value_info` helper
- allow functions with `&Str` parameters in expression analysis
- infer variable types from call expressions
- document helper additions and update enhancements
- test inference from function calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c631600a88321bda398287015e8e9