### PR TITLE
Enable extern generics

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -201,6 +201,8 @@ functions, allowing constructs like `first(200 + second())`.
   permitted elsewhere.
 - Extern functions may use a generic parameter with a variadic array, for
   example `extern fn printf<Length: USize>(format : &Str, ...array : [Any; Length]);`.
+- Extern functions may also use generics for fixed-size arrays such as
+  `extern fn printf<Length: USize>(first : &Str, second : [Any; Length]);`.
 
 
 - `.github/workflows/ci.yml` – GitHub Actions workflow that installs dependencies and runs `pytest`.

--- a/docs/suggested_enhancements.md
+++ b/docs/suggested_enhancements.md
@@ -11,4 +11,4 @@ This page tracks ideas for improving the Magma compiler. Update this list whenev
 - Central `value_info` helper for all value expressions
 - `type_info` helper centralizes parsing for pointers and arrays
 - Allow `Any` parameters on extern functions for simplified FFI hooks
-- Extern functions may use generics with variadic arrays
+- Extern functions may use generics with variadic or fixed-size arrays

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -290,6 +290,28 @@ def test_extern_variadic_generic_extern(tmp_path):
     assert output == ""
 
 
+def test_extern_generic_array_param(tmp_path):
+    output = compile_source(
+        tmp_path,
+        "extern fn printf<Length: USize>(first : &Str, second : [Any; Length]);",
+    )
+    assert output == ""
+
+
+def test_extern_generic_function_call(tmp_path):
+    output = compile_source(
+        tmp_path,
+        (
+            "extern fn printf<Length: USize>(first : &Str, second : [Any; Length]);\n"
+            "fn main() => { printf(\"%s\", \"Hello World!\"); }"
+        ),
+    )
+    assert (
+        output
+        == 'void main() {\n    printf("%s", "Hello World!");\n}\n'
+    )
+
+
 def test_any_param_in_non_extern_fails(tmp_path):
     output = compile_source(tmp_path, "fn bad(x: Any): Void => {}")
     assert output == "compiled: fn bad(x: Any): Void => {}"


### PR DESCRIPTION
## Summary
- allow array parameters to use names instead of only digits
- support extern generic function declarations and calls
- document extern generics for arrays
- list extern array generics in the enhancement notes
- test extern generics with and without calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c73118f2083218fcb884767011a2d