### PR TITLE
Support field access from class instances

### DIFF
--- a/docs/compiler_features.md
+++ b/docs/compiler_features.md
@@ -180,7 +180,8 @@ Array elements can be accessed with `arr[i]` when `i` is bounded by
 Out-of-range constants are rejected at compile time.
 Struct literals may expose a field directly as `(Wrapper {100}).value`,
 which compiles to the literal value without introducing a temporary
-variable.
+variable. Fields of struct variables can be read using the same dot
+notation: `let value = point.x;` translates to `unsigned int value = point.x;`.
 Expressions may be wrapped in any number of parentheses. The compiler
 removes matching outer pairs before processing so `( (x) )` is treated the
 same as `x`. Parentheses that alter precedence are preserved, so `(3 + 4) * 7`

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -509,6 +509,36 @@ def test_compile_inline_class_instantiation(tmp_path):
     )
 
 
+def test_compile_class_field_access(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text(
+        "class fn Point(x: U32, y: U32) => {}\n"
+        "fn main(): Void => { let p = Point(1, 2); let value = p.x; }"
+    )
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "struct Point {\n"
+        "    unsigned int x;\n"
+        "    unsigned int y;\n"
+        "};\n"
+        "struct Point Point(unsigned int x, unsigned int y) {\n"
+        "    struct Point this;\n"
+        "    this.x = x;\n"
+        "    this.y = y;\n"
+        "    return this;\n"
+        "}\n"
+        "void main() {\n"
+        "    struct Point p = Point(1, 2);\n"
+        "    unsigned int value = p.x;\n"
+        "}\n"
+    )
+
+
 def test_compile_pointer_global(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- allow `var.field` expressions
- ignore enum variant parsing when first token is a known variable
- test reading a class field in a function
- document struct field access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c7cd9e0388321b6da9e7d10e89216