### PR TITLE
Extend conditional helper to handle while loops

### DIFF
--- a/docs/design/control_and_helpers.md
+++ b/docs/design/control_and_helpers.md
@@ -28,10 +28,13 @@ literals to `1` or `0`. A small helper now converts these conditions into C
 syntax. This keeps the block parser shallow and avoids repeating nested
 expressions.
 
-### If Statement Helper
-`if` blocks used a sizeable chunk of code within the main block parser.
-Extracting this logic into a dedicated `handle_if` helper shortened
-`compile_block` and kept the conditional range updates in one place.
+### Conditional Block Helper
+`if` blocks originally consumed a sizeable chunk of code within the main block
+parser. Extracting this logic into a dedicated helper shortened
+`compile_block` and kept the conditional range updates in one place. The helper
+has since been expanded to also parse `while` loops because the structure is the
+same: a condition followed by a braced block. Sharing this logic keeps the
+parser small and ensures both constructs honor the same condition checks.
 
 ### Type Conversion Helpers
 As the compiler grew, repeated checks converted Magma types to C types and

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -5,8 +5,9 @@ This list summarizes the main modules of the project for quick reference.
 - `magma.compiler` – entry point for compilation
   - `magma.compiler.Compiler` – minimal compiler skeleton
   - helper functions `c_type_of`, `bool_to_c`, `type_info`, `emit_return`,
-    `analyze_expr`, `value_info`, and `handle_if` reduce duplicate type,
-    expression, and return logic
+    `analyze_expr`, `value_info`, and `handle_conditional` reduce duplicate type,
+    expression, and return logic. `handle_conditional` parses both `if` and
+    `while` blocks so the main loop stays compact
   - `build_env_init` gathers lines for captured environments to avoid
     repeating struct setup
   - `process_callable` handles functions, classes, and their generic forms

--- a/docs/suggested_enhancements.md
+++ b/docs/suggested_enhancements.md
@@ -13,4 +13,4 @@ This page tracks ideas for improving the Magma compiler. Update this list whenev
 - Allow `Any` parameters on extern functions for simplified FFI hooks
 - Extern functions may use generics with variadic or fixed-size arrays
 - Range-based `for` loops over arrays and slices
-- Extract `if` block handling into a helper
+ - Shared helper for `if` and `while` blocks to reduce duplication

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -67,6 +67,20 @@ def test_compile_continue_in_while(tmp_path):
     )
 
 
+def test_compile_while_numeric_condition(tmp_path):
+    compiler = Compiler()
+    input_file = tmp_path / "input.mg"
+    input_file.write_text("fn loop(x: I32): Void => { while (x < 3) { let y: I32 = 1; } }")
+    output_file = tmp_path / "out.c"
+
+    compiler.compile(input_file, output_file)
+
+    assert (
+        output_file.read_text()
+        == "void loop(int x) {\n    while (x < 3) {\n        int y = 1;\n    }\n}\n"
+    )
+
+
 def test_compile_for_loop_basic(tmp_path):
     compiler = Compiler()
     input_file = tmp_path / "input.mg"


### PR DESCRIPTION
## Summary
- generalize `handle_if` into `handle_conditional` so `while` blocks reuse the same logic
- adjust `compile_block` to delegate both `if` and `while` statements to this helper
- document the new helper and update modules overview
- revise suggested enhancements
- add test for numeric conditions in while loops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8508ba9c832189d0b92ce32e0696