### PR TITLE
Refactor compiler state into instance fields

### DIFF
--- a/docs/design/basics.md
+++ b/docs/design/basics.md
@@ -180,3 +180,7 @@ resolves correctly. This provides a quick way to compile the example file under
 ``working/`` without installing the package first and keeps experimentation
 lightweight.
 
+To simplify maintenance, the compiler now keeps shared tables such as
+function signatures and struct definitions as fields on ``Compiler``.
+This removes lengthy parameter lists from helper functions.
+

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -4,6 +4,8 @@ This list summarizes the main modules of the project for quick reference.
 
 - `magma.compiler` – entry point for compilation
   - `magma.compiler.Compiler` – minimal compiler skeleton
+  - internal tables like `struct_fields` and `func_sigs` now live on the
+    instance so helpers access shared state without long parameter lists
   - helper functions `c_type_of`, `bool_to_c`, `type_info`, `emit_return`,
     `analyze_expr`, `value_info`, `handle_conditional`, and `handle_let` reduce duplicate type,
     expression, and return logic. `handle_conditional` parses both `if` and


### PR DESCRIPTION
## Summary
- refactor Compiler to store dictionaries like `struct_fields` and `func_sigs` on the instance
- update helper logic to use these fields instead of passing them around
- document the change in design notes and module overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf3423eec8321b25d4abc3aacaff6