### PR TITLE
feat: add function that always throws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/alwaysThrow.js
+++ b/alwaysThrow.js
@@ -1,0 +1,8 @@
+function alwaysThrow(message) {
+  if (message === undefined || message === '') {
+    return '';
+  }
+  throw new Error(message);
+}
+
+module.exports = { alwaysThrow };

--- a/alwaysThrow.test.js
+++ b/alwaysThrow.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { alwaysThrow } = require('./alwaysThrow');
+
+const MESSAGE = 'This will always fail';
+
+test('alwaysThrow returns empty string when given empty input', () => {
+  assert.strictEqual(alwaysThrow(''), '');
+});
+
+test('alwaysThrow returns empty string when message is undefined', () => {
+  assert.strictEqual(alwaysThrow(), '');
+});
+
+test('alwaysThrow throws provided message', () => {
+  assert.throws(() => alwaysThrow(MESSAGE), new RegExp(MESSAGE));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "magma",
+  "version": "1.0.0",
+  "description": "",
+  "main": "alwaysThrow.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- handle empty or undefined string by returning empty string instead of throwing
- cover empty and undefined cases in tests while removing duplicate message strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ee563cb083219f3c56a1f2fc1180